### PR TITLE
ROE-16 start.sh needs a command between if - else to fix startup prob…

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -6,7 +6,7 @@ APP_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 if [[ -z "${MESOS_SLAVE_PID}" ]]; then
 
-    # No mesos slave PID - Only on docker, not vagrant
+    echo "No mesos slave PID - Only configured for docker in development, not vagrant"
 
 else
 


### PR DESCRIPTION
…lem in toro1
The start.sh had a syntax error
./start.sh: line 11: syntax error near unexpected token `else'
./start.sh: line 11: `else' 
due to there only being a comment between the if - else,  so changing it to an echo
(same was done in confirmation-statement-web)