### PR TITLE
ROE-32 fixing missing back link and adding phase banner

### DIFF
--- a/views/layout.html
+++ b/views/layout.html
@@ -30,6 +30,16 @@
 
 {% endblock %}
 
+{% block beforeContent %}
+  {{ govukPhaseBanner({
+    tag: {
+    text: "alpha"
+    }
+  }) }}
+  {% block backLink %}
+  {% endblock %}
+{% endblock %}
+
 {% block header %}
   {{ govukHeader({
     homepageUrl: "https://www.gov.uk",

--- a/views/presenter.html
+++ b/views/presenter.html
@@ -1,7 +1,7 @@
 {% extends "layout.html" %}
 
 {% block pageTitle %}
-  Who is registering – Register an overseas entity – Companies House
+  Who is registering - Register an overseas entity - Companies House
 {% endblock %}
 
 {% block backLink %}


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/ROE-32

Addressed issue with my initial PR where the back link wasn't displaying on the presenter page as it wasn't on the layout to be overridden. Also took the opportunity to add the alpha govuk phase banner. The "–" characters in the pageTitle were also being flagged so replaced with "-' 

### Work checklist

- [x] Tests added where applicable
- [x] UI changes meet accessibility criteria
