### PR TITLE
fix: Updating tests with ioredis mock so tests won't forceExit

### DIFF
--- a/test/controllers/authentication.spec.ts
+++ b/test/controllers/authentication.spec.ts
@@ -1,3 +1,5 @@
+jest.mock("ioredis");
+
 import { describe, expect, test, jest, beforeEach } from '@jest/globals';
 import { Request, Response } from 'express';
 import request from "supertest";

--- a/test/controllers/error.controller.spec.ts
+++ b/test/controllers/error.controller.spec.ts
@@ -1,3 +1,4 @@
+jest.mock("ioredis");
 jest.mock("../../src/utils/logger");
 jest.mock("../../src/controllers/landing.controller");
 

--- a/test/controllers/landing.controller.spec.ts
+++ b/test/controllers/landing.controller.spec.ts
@@ -1,3 +1,5 @@
+jest.mock("ioredis");
+
 import { describe, expect, test } from '@jest/globals';
 import request from "supertest";
 

--- a/test/middleware/service.availability.middleware.spec.ts
+++ b/test/middleware/service.availability.middleware.spec.ts
@@ -1,3 +1,4 @@
+jest.mock("ioredis");
 jest.mock("../../src/utils/feature.flag" );
 
 import { describe, expect, test, beforeEach } from '@jest/globals';


### PR DESCRIPTION
Not related to a Jira story

Some tests require to be forced to exit using the --forceExit flag due to ioredis creating connections to Redis.
I've updated the tests in question with a mock for ioredis so they won't need to be forced to exit.



### Work checklist

- [x] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
