### PR TITLE
ROE-38 Make beneficial owner type page store data in session

### DIFF
--- a/src/controllers/beneficial.owner.type.controller.ts
+++ b/src/controllers/beneficial.owner.type.controller.ts
@@ -1,14 +1,35 @@
-import { Request, Response } from "express";
+import { NextFunction, Request, Response } from "express";
+import { getApplicationData, prepareData, setApplicationData } from "../utils/application.data";
+import { ApplicationData, ApplicationDataType, beneficialOwnerTypeType } from "../model";
 import { logger } from "../utils/logger";
 import * as config from "../config";
 
+export const get = (req: Request, res: Response, next: NextFunction) => {
+  try {
+    logger.debug(`GET ${config.BENEFICIAL_OWNER_TYPE_PAGE}`);
 
-export const get = (req: Request, res: Response) => {
-  logger.debug(`GET ${config.BENEFICIAL_OWNER_TYPE_PAGE}`);
-  return res.render(config.BENEFICIAL_OWNER_TYPE_PAGE, { backLinkUrl: config.ENTITY_URL });
+    const appData: ApplicationData = getApplicationData(req.session);
+
+    return res.render(config.BENEFICIAL_OWNER_TYPE_PAGE, {
+      backLinkUrl: config.ENTITY_URL,
+      ...appData.beneficialOwnerType
+    });
+  } catch (error) {
+    logger.errorRequest(req, error);
+    next(error);
+  }
 };
 
-export const post = (req: Request, res: Response) => {
-  logger.debug(`POST ${config.BENEFICIAL_OWNER_TYPE_PAGE}`);
-  return res.redirect("/next-page");
+export const post = (req: Request, res: Response, next: NextFunction) => {
+  try {
+    logger.debug(`POST ${config.BENEFICIAL_OWNER_TYPE_PAGE}`);
+
+    const data: ApplicationDataType = prepareData(req.body, beneficialOwnerTypeType.BeneficialOwnerTypeKeys);
+    setApplicationData(req.session, data, beneficialOwnerTypeType.BeneficialOwnerTypeKey);
+
+    return res.redirect("/next-page");
+  } catch (error) {
+    logger.errorRequest(req, error);
+    next(error);
+  }
 };

--- a/src/model/application.model.ts
+++ b/src/model/application.model.ts
@@ -1,10 +1,11 @@
-import { entityType, presenterType, dataType } from "./index";
+import { entityType, presenterType, dataType, beneficialOwnerTypeType } from "./index";
 
 export const APPLICATION_DATA_KEY = 'roe';
 
 export interface ApplicationData {
     presenter?: presenterType.Presenter;
     entity?: entityType.Entity;
+    beneficialOwnerType?: beneficialOwnerTypeType.BeneficialOwnerType;
 }
 
-export type ApplicationDataType = presenterType.Presenter | entityType.Entity | dataType.Address;
+export type ApplicationDataType = presenterType.Presenter | entityType.Entity | dataType.Address | beneficialOwnerTypeType.BeneficialOwnerType;

--- a/src/model/beneficial.owner.type.model.ts
+++ b/src/model/beneficial.owner.type.model.ts
@@ -1,0 +1,13 @@
+import { BeneficialOwnerTypeChoice } from "./data.types.model";
+
+/*
+  The BeneficialOwnerType fields will have to match the name field on the HTML file to
+  be able to do the mapping correctly
+*/
+export const BeneficialOwnerTypeKey = "beneficialOwnerType";
+export const BeneficialOwnerTypeKeys: string[] = [ "beneficialOwnerType" ];
+
+
+export interface BeneficialOwnerType {
+  beneficialOwnerType?: BeneficialOwnerTypeChoice[];
+}

--- a/src/model/data.types.model.ts
+++ b/src/model/data.types.model.ts
@@ -9,4 +9,10 @@ export interface Address {
 export enum yesNoResponse {
     No = 0,
     Yes = 1
-  }
+}
+
+export enum BeneficialOwnerTypeChoice {
+    individual = "individual",
+    otherLegal = "otherLegal",
+    none = "none"
+}

--- a/src/model/index.ts
+++ b/src/model/index.ts
@@ -1,4 +1,5 @@
 export { ApplicationData, APPLICATION_DATA_KEY, ApplicationDataType } from "./application.model";
 export * as presenterType from "./presenter.model";
 export * as entityType from "./entity.model";
+export * as beneficialOwnerTypeType from "./beneficial.owner.type.model";
 export * as dataType from "./data.types.model";

--- a/test/__mocks__/session.mock.ts
+++ b/test/__mocks__/session.mock.ts
@@ -3,7 +3,8 @@ import { SessionKey } from "@companieshouse/node-session-handler/lib/session/key
 import { SignInInfoKeys } from "@companieshouse/node-session-handler/lib/session/keys/SignInInfoKeys";
 import { UserProfileKeys } from "@companieshouse/node-session-handler/lib/session/keys/UserProfileKeys";
 import { ISignInInfo } from "@companieshouse/node-session-handler/lib/session/model/SessionInterfaces";
-import { ApplicationData, APPLICATION_DATA_KEY, entityType, presenterType } from "../../src/model";
+import { ApplicationData, APPLICATION_DATA_KEY, beneficialOwnerTypeType, entityType, presenterType } from "../../src/model";
+import { BeneficialOwnerTypeChoice } from "../../src/model/data.types.model";
 
 export const userMail = "userWithPermission@ch.gov.uk";
 
@@ -45,6 +46,10 @@ export const ENTITY_OBJECT_MOCK: entityType.Entity = {
   governedLaw: "governedLaw",
   publicRegister: "publicRegister",
   registrationNumber: 123
+};
+
+export const BENEFICIAL_OWNER_TYPE_OBJECT_MOCK: beneficialOwnerTypeType.BeneficialOwnerType = {
+  beneficialOwnerType: [ BeneficialOwnerTypeChoice.individual, BeneficialOwnerTypeChoice.otherLegal ]
 };
 
 export const APPLICATION_DATA_MOCK: ApplicationData = {

--- a/test/__mocks__/text.mock.ts
+++ b/test/__mocks__/text.mock.ts
@@ -2,6 +2,7 @@ export const INDEX_PAGE_TITLE = "Register an overseas entity and tell us about i
 export const SERVICE_UNAVAILABLE = "Sorry, the service is unavailable";
 export const ENTITY_PAGE_TITLE = "Tell us about the overseas entity";
 export const BENEFICIAL_OWNER_TYPE_PAGE_REDIRECT = "Found. Redirecting to /register-an-overseas-entity/beneficial-owner-type";
+export const BENEFICIAL_OWNER_TYPE_PAGE_HEADING = "Who is a beneficial owner of the overseas entity?";
 export const EXPECTED_TEXT = "Page not found - Register an overseas entity and tell us about its beneficial owners";
 export const INCORRECT_URL = "/register-an-overseas-entity/company-numberr";
 export const MESSAGE_ERROR = "Can't connect";

--- a/test/controllers/beneficial.owner.type.controller.spec.ts
+++ b/test/controllers/beneficial.owner.type.controller.spec.ts
@@ -1,5 +1,6 @@
 jest.mock("ioredis");
 jest.mock('../../src/controllers/authentication.controller');
+jest.mock('../../src/utils/application.data');
 
 import { describe, expect, test } from '@jest/globals';
 import { NextFunction, Request, Response } from "express";
@@ -7,30 +8,67 @@ import request from "supertest";
 import app from "../../src/app";
 import { authentication } from "../../src/controllers";
 import { BENEFICIAL_OWNER_TYPE_URL, ENTITY_URL } from "../../src/config";
+import { getApplicationData, prepareData, setApplicationData } from '../../src/utils/application.data';
+import { ANY_MESSAGE_ERROR, BENEFICIAL_OWNER_TYPE_PAGE_HEADING, SERVICE_UNAVAILABLE } from '../__mocks__/text.mock';
+import { APPLICATION_DATA_MOCK, BENEFICIAL_OWNER_TYPE_OBJECT_MOCK } from '../__mocks__/session.mock';
+import { beneficialOwnerTypeType } from '../../src/model';
 
 const mockAuthenticationMiddleware = authentication as jest.Mock;
 mockAuthenticationMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => next() );
 
-const PAGE_HEADING = "Who is a beneficial owner of the overseas entity?";
+const mockGetApplicationData = getApplicationData as jest.Mock;
+const mockSetApplicationData = setApplicationData as jest.Mock;
+const mockPrepareData = prepareData as jest.Mock;
 
 describe("BENEFICIAL OWNER TYPE controller", () => {
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   describe("GET tests", () => {
     test("renders the beneficial owner type page", async () => {
+      mockGetApplicationData.mockReturnValueOnce(APPLICATION_DATA_MOCK);
       const resp = await request(app).get(BENEFICIAL_OWNER_TYPE_URL);
 
       expect(resp.status).toEqual(200);
-      expect(resp.text).toContain(PAGE_HEADING);
+      expect(resp.text).toContain(BENEFICIAL_OWNER_TYPE_PAGE_HEADING);
       expect(resp.text).toContain(ENTITY_URL);
+    });
+
+    test("catch error when rendering the page", async () => {
+      mockGetApplicationData.mockImplementationOnce( () => { throw new Error(ANY_MESSAGE_ERROR); });
+      const resp = await request(app).get(BENEFICIAL_OWNER_TYPE_URL);
+
+      expect(resp.status).toEqual(500);
+      expect(resp.text).toContain(SERVICE_UNAVAILABLE);
     });
   });
 
   describe("POST tests", () => {
     test("redirects to the next page", async () => {
-      const resp = await request(app).post(BENEFICIAL_OWNER_TYPE_URL).send({});
+      const resp = await request(app).post(BENEFICIAL_OWNER_TYPE_URL);
 
       expect(resp.status).toEqual(302);
       expect(resp.header.location).toEqual("/next-page");
     });
-  });
 
+    test("adds data to the session", async () => {
+      mockPrepareData.mockImplementationOnce( () => BENEFICIAL_OWNER_TYPE_OBJECT_MOCK );
+      const resp = await request(app).post(BENEFICIAL_OWNER_TYPE_URL);
+
+      expect(mockSetApplicationData.mock.calls[0][1]).toEqual(BENEFICIAL_OWNER_TYPE_OBJECT_MOCK);
+      expect(mockSetApplicationData.mock.calls[0][2]).toEqual(beneficialOwnerTypeType.BeneficialOwnerTypeKey);
+      expect(resp.status).toEqual(302);
+      expect(resp.header.location).toEqual("/next-page");
+    });
+
+    test("catch error when posting data", async () => {
+      mockSetApplicationData.mockImplementationOnce( () => { throw new Error(ANY_MESSAGE_ERROR); });
+      const resp = await request(app).post(BENEFICIAL_OWNER_TYPE_URL);
+
+      expect(resp.status).toEqual(500);
+      expect(resp.text).toContain(SERVICE_UNAVAILABLE);
+    });
+  });
 });

--- a/test/controllers/entity.controller.spec.ts
+++ b/test/controllers/entity.controller.spec.ts
@@ -47,7 +47,7 @@ describe("ENTITY controller", () => {
     expect(resp.text).toContain(SERVICE_UNAVAILABLE);
   });
 
-  test("catch error when post data from ENTIRY page", async () => {
+  test("catch error when post data from ENTITY page", async () => {
     mockSetApplicationData.mockImplementation( () => { throw new Error(ANY_MESSAGE_ERROR); });
     const resp = await request(app).post(ENTITY_URL);
 

--- a/views/beneficial-owner-type.html
+++ b/views/beneficial-owner-type.html
@@ -25,7 +25,7 @@
 
         {{ govukCheckboxes({
           idPrefix: "beneficial-owner-type",
-          name: "beneficial-owner-type",
+          name: "beneficialOwnerType",
           fieldset: {
             legend: {
               text: "Who is a beneficial owner of the overseas entity?",
@@ -39,11 +39,13 @@
           items: [
             {
               value: "individual",
-              text: "An individual beneficial owner"
+              text: "An individual beneficial owner",
+              checked: beneficialOwnerType and 'individual' in beneficialOwnerType
             },
             {
-              value: "other-legal",
-              text: "A public authority, or other legal entity"
+              value: "otherLegal",
+              text: "A public authority, or other legal entity",
+              checked: beneficialOwnerType and 'otherLegal' in beneficialOwnerType
             },
             {
               divider: "or"
@@ -51,7 +53,8 @@
             {
               value: "none",
               text: "There is no beneficial owner",
-              behaviour: "exclusive"
+              behaviour: "exclusive",
+              checked: beneficialOwnerType and 'none' in beneficialOwnerType
             }
           ]
         }) }}


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/ROE-38


### Change description
* Storing the beneficial owner type data in the session
* Populate template with session data

### Work checklist

- [x] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
