### PR TITLE
ROE-111 Adding navigation from beneficial owner type page

### DIFF
--- a/src/controllers/beneficial.owner.type.controller.ts
+++ b/src/controllers/beneficial.owner.type.controller.ts
@@ -3,6 +3,8 @@ import { getApplicationData, prepareData, setApplicationData } from "../utils/ap
 import { ApplicationData, ApplicationDataType, beneficialOwnerTypeType } from "../model";
 import { logger } from "../utils/logger";
 import * as config from "../config";
+import { BeneficialOwnerType } from "../model/beneficial.owner.type.model";
+import { BeneficialOwnerTypeChoice } from "../model/data.types.model";
 
 export const get = (req: Request, res: Response, next: NextFunction) => {
   try {
@@ -27,9 +29,24 @@ export const post = (req: Request, res: Response, next: NextFunction) => {
     const data: ApplicationDataType = prepareData(req.body, beneficialOwnerTypeType.BeneficialOwnerTypeKeys);
     setApplicationData(req.session, data, beneficialOwnerTypeType.BeneficialOwnerTypeKey);
 
-    return res.redirect("/next-page");
+    const beneficialOwnerTypeData: BeneficialOwnerType = data as BeneficialOwnerType;
+    const nextPage: string = getNextPage(beneficialOwnerTypeData.beneficialOwnerType);
+    return res.redirect(nextPage);
   } catch (error) {
     logger.errorRequest(req, error);
     next(error);
   }
+};
+
+const getNextPage = (beneficialOwnerTypeChoices?: BeneficialOwnerTypeChoice[]): string => {
+  if (beneficialOwnerTypeChoices?.includes(BeneficialOwnerTypeChoice.individual)) {
+    return config.BENEFICIAL_OWNER_INDIVIDUAL_URL;
+  }
+  if (beneficialOwnerTypeChoices?.includes(BeneficialOwnerTypeChoice.otherLegal)) {
+    return config.BENEFICIAL_OWNER_OTHER_URL;
+  }
+  if (beneficialOwnerTypeChoices?.includes(BeneficialOwnerTypeChoice.none)) {
+    return config.MANAGING_OFFICER_URL;
+  }
+  return config.BENEFICIAL_OWNER_TYPE_URL;
 };

--- a/test/controllers/beneficial.owner.type.controller.spec.ts
+++ b/test/controllers/beneficial.owner.type.controller.spec.ts
@@ -7,11 +7,12 @@ import { NextFunction, Request, Response } from "express";
 import request from "supertest";
 import app from "../../src/app";
 import { authentication } from "../../src/controllers";
-import { BENEFICIAL_OWNER_TYPE_URL, ENTITY_URL } from "../../src/config";
+import * as config from "../../src/config";
 import { getApplicationData, prepareData, setApplicationData } from '../../src/utils/application.data';
 import { ANY_MESSAGE_ERROR, BENEFICIAL_OWNER_TYPE_PAGE_HEADING, SERVICE_UNAVAILABLE } from '../__mocks__/text.mock';
 import { APPLICATION_DATA_MOCK, BENEFICIAL_OWNER_TYPE_OBJECT_MOCK } from '../__mocks__/session.mock';
 import { beneficialOwnerTypeType } from '../../src/model';
+import { BeneficialOwnerTypeChoice } from '../../src/model/data.types.model';
 
 const mockAuthenticationMiddleware = authentication as jest.Mock;
 mockAuthenticationMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => next() );
@@ -29,16 +30,16 @@ describe("BENEFICIAL OWNER TYPE controller", () => {
   describe("GET tests", () => {
     test("renders the beneficial owner type page", async () => {
       mockGetApplicationData.mockReturnValueOnce(APPLICATION_DATA_MOCK);
-      const resp = await request(app).get(BENEFICIAL_OWNER_TYPE_URL);
+      const resp = await request(app).get(config.BENEFICIAL_OWNER_TYPE_URL);
 
       expect(resp.status).toEqual(200);
       expect(resp.text).toContain(BENEFICIAL_OWNER_TYPE_PAGE_HEADING);
-      expect(resp.text).toContain(ENTITY_URL);
+      expect(resp.text).toContain(config.ENTITY_URL);
     });
 
     test("catch error when rendering the page", async () => {
       mockGetApplicationData.mockImplementationOnce( () => { throw new Error(ANY_MESSAGE_ERROR); });
-      const resp = await request(app).get(BENEFICIAL_OWNER_TYPE_URL);
+      const resp = await request(app).get(config.BENEFICIAL_OWNER_TYPE_URL);
 
       expect(resp.status).toEqual(500);
       expect(resp.text).toContain(SERVICE_UNAVAILABLE);
@@ -46,26 +47,51 @@ describe("BENEFICIAL OWNER TYPE controller", () => {
   });
 
   describe("POST tests", () => {
-    test("redirects to the next page", async () => {
-      const resp = await request(app).post(BENEFICIAL_OWNER_TYPE_URL);
+    test("redirects to the beneficial owner individual page", async () => {
+      mockPrepareData.mockReturnValueOnce(BENEFICIAL_OWNER_TYPE_OBJECT_MOCK);
+      const resp = await request(app).post(config.BENEFICIAL_OWNER_TYPE_URL);
 
       expect(resp.status).toEqual(302);
-      expect(resp.header.location).toEqual("/next-page");
+      expect(resp.header.location).toEqual(config.BENEFICIAL_OWNER_INDIVIDUAL_URL);
+    });
+
+    test("redirects to the beneficial owner other page", async () => {
+      mockPrepareData.mockReturnValueOnce({ beneficialOwnerType: [ BeneficialOwnerTypeChoice.otherLegal ] });
+      const resp = await request(app).post(config.BENEFICIAL_OWNER_TYPE_URL);
+
+      expect(resp.status).toEqual(302);
+      expect(resp.header.location).toEqual(config.BENEFICIAL_OWNER_OTHER_URL);
+    });
+
+    test("redirects to the managing officer page", async () => {
+      mockPrepareData.mockReturnValueOnce({ beneficialOwnerType: [ BeneficialOwnerTypeChoice.none ] });
+      const resp = await request(app).post(config.BENEFICIAL_OWNER_TYPE_URL);
+
+      expect(resp.status).toEqual(302);
+      expect(resp.header.location).toEqual(config.MANAGING_OFFICER_URL);
+    });
+
+    test("redirects to the current page", async () => {
+      mockPrepareData.mockReturnValueOnce({ });
+      const resp = await request(app).post(config.BENEFICIAL_OWNER_TYPE_URL);
+
+      expect(resp.status).toEqual(302);
+      expect(resp.header.location).toEqual(config.BENEFICIAL_OWNER_TYPE_URL);
     });
 
     test("adds data to the session", async () => {
-      mockPrepareData.mockImplementationOnce( () => BENEFICIAL_OWNER_TYPE_OBJECT_MOCK );
-      const resp = await request(app).post(BENEFICIAL_OWNER_TYPE_URL);
+      mockPrepareData.mockReturnValueOnce(BENEFICIAL_OWNER_TYPE_OBJECT_MOCK);
+      const resp = await request(app).post(config.BENEFICIAL_OWNER_TYPE_URL);
 
       expect(mockSetApplicationData.mock.calls[0][1]).toEqual(BENEFICIAL_OWNER_TYPE_OBJECT_MOCK);
       expect(mockSetApplicationData.mock.calls[0][2]).toEqual(beneficialOwnerTypeType.BeneficialOwnerTypeKey);
       expect(resp.status).toEqual(302);
-      expect(resp.header.location).toEqual("/next-page");
+      expect(resp.header.location).toEqual(config.BENEFICIAL_OWNER_INDIVIDUAL_URL);
     });
 
     test("catch error when posting data", async () => {
       mockSetApplicationData.mockImplementationOnce( () => { throw new Error(ANY_MESSAGE_ERROR); });
-      const resp = await request(app).post(BENEFICIAL_OWNER_TYPE_URL);
+      const resp = await request(app).post(config.BENEFICIAL_OWNER_TYPE_URL);
 
       expect(resp.status).toEqual(500);
       expect(resp.text).toContain(SERVICE_UNAVAILABLE);


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/ROE-40
https://companieshouse.atlassian.net/browse/ROE-84
https://companieshouse.atlassian.net/browse/ROE-79

### Change description
Adding navigation from the beneficial owner type page
* If 'An individual beneficial owner' is selected it will take you to beneficial-owner-individual
*  If 'An individual beneficial owner' is NOT selected and 'A public authority, or other legal entity' is selected, it will take you to  beneficial-owner-other
* If only 'There is no beneficial owner' is selected then it will take you to managing-officer
* If nothing is selected, page will just redirect back to itself


### Work checklist

- [x] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
