### PR TITLE
ROE-156 Update beneficial owners statement page with new radio option

### DIFF
--- a/src/model/data.types.model.ts
+++ b/src/model/data.types.model.ts
@@ -16,6 +16,7 @@ export enum yesNoResponse {
 export enum BeneficialOwnerStatementChoice {
   allIdentifiedAllSupplied = "allIdentifiedAllSupplied",
   allIdentifiedSomeSupplied = "allIdentifiedSomeSupplied",
+  someIdentifiedAllDetails = "someIdentifiedAllDetails",
   someIdentifiedSomeDetails = "someIdentifiedSomeDetails",
   noneIdentified = "noneIdentified",
 }

--- a/views/beneficial-owner-statements.html
+++ b/views/beneficial-owner-statements.html
@@ -36,33 +36,26 @@
             {
               value: "allIdentifiedAllSupplied",
               text: "All beneficial owners have been identified and all relevant information can be supplied",
-              hint: {
-                text: "Only beneficial owners required"
-              },
               checked: beneficialOwnerStatement == "allIdentifiedAllSupplied"
             },
             {
               value: "allIdentifiedSomeSupplied",
               text: "All beneficial owners identified but only some relevant information can be supplied",
-              hint: {
-                text: "At least one managing officer will be required"
-              },
+              checked: beneficialOwnerStatement == "allIdentifiedSomeSupplied"
+            },
+            {
+              value: "someIdentifiedAllSupplied",
+              text: "Some beneficial owners identified and all relevant information can be supplied",
               checked: beneficialOwnerStatement == "allIdentifiedSomeSupplied"
             },
             {
               value: "someIdentifiedSomeDetails",
-              text: "Some beneficial owners have been identified but not all details can be obtained",
-              hint: {
-                text: "At least one managing officer will be required"
-              },
+              text: "Some beneficial owners have been identified but only some relevant information can be supplied",
               checked: beneficialOwnerStatement == "someIdentifiedSomeDetails"
             },
             {
               value: "noneIdentified",
               text: "No beneficial owners have been identified",
-              hint: {
-                text: "At least one managing officer will be required"
-              },
               checked: beneficialOwnerStatement == "noneIdentified"
             }
           ]


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/ROE-156

### Change description

Updating page with new "Some beneficial owners identified and all relevant information can be supplied" option and adding it to the BeneficialOwnerStatementChoice enum. Also removed the hints from the page as they aren't present in the new iteration.

### Work checklist

- [ ] Tests added where applicable
- [x] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
