### PR TITLE
Fix/roe 144 fix id for bo type and remove optional text from address

### DIFF
--- a/src/controllers/beneficial.owner.type.controller.ts
+++ b/src/controllers/beneficial.owner.type.controller.ts
@@ -6,6 +6,7 @@ import { logger } from "../utils/logger";
 import * as config from "../config";
 import {
   BeneficialOwnerTypeChoice,
+  BeneficialOwnerTypeKey,
   ManagingOfficerTypeChoice,
 } from "../model/beneficial.owner.type.model";
 
@@ -27,13 +28,12 @@ export const get = (req: Request, res: Response, next: NextFunction) => {
 
 export const post = (req: Request, res: Response) => {
   logger.debugRequest(req, `POST ${config.BENEFICIAL_OWNER_TYPE_PAGE}`);
-  const { selectedOwnerOfficerType } = req.body;
 
-  return res.redirect(getNextPage(selectedOwnerOfficerType));
+  return res.redirect(getNextPage(req.body[BeneficialOwnerTypeKey]));
 };
 
 // With validation in place we have got just these 5 possible choices
-const getNextPage = (beneficialOwnerTypeChoices?: BeneficialOwnerTypeChoice): string => {
+const getNextPage = (beneficialOwnerTypeChoices?: BeneficialOwnerTypeChoice | ManagingOfficerTypeChoice): string => {
   if (beneficialOwnerTypeChoices === BeneficialOwnerTypeChoice.individual) {
     return config.BENEFICIAL_OWNER_INDIVIDUAL_URL;
   } else if (beneficialOwnerTypeChoices === BeneficialOwnerTypeChoice.otherLegal) {

--- a/src/model/beneficial.owner.type.model.ts
+++ b/src/model/beneficial.owner.type.model.ts
@@ -1,3 +1,5 @@
+export const BeneficialOwnerTypeKey = "beneficial_owner_type";
+
 export enum BeneficialOwnerTypeChoice {
     individual = "individualOwner",
     otherLegal = "otherLegalOwner",

--- a/src/validation/beneficial.owner.type.validation.ts
+++ b/src/validation/beneficial.owner.type.validation.ts
@@ -3,5 +3,5 @@ import { body } from "express-validator";
 import { ErrorMessages } from "./error.messages";
 
 export const beneficialOwnersType = [
-  body("selectedOwnerOfficerType").not().isEmpty().withMessage(ErrorMessages.SELECT_THE_TYPE_OF_BENEFICIAL_OWNER_OR_MANAGING_OFFICER_YOU_WANT_TO_ADD),
+  body("beneficial_owner_type").not().isEmpty().withMessage(ErrorMessages.SELECT_THE_TYPE_OF_BENEFICIAL_OWNER_OR_MANAGING_OFFICER_YOU_WANT_TO_ADD),
 ];

--- a/test/controllers/beneficial.owner.type.controller.spec.ts
+++ b/test/controllers/beneficial.owner.type.controller.spec.ts
@@ -17,6 +17,7 @@ import {
 import { APPLICATION_DATA_MOCK, ERROR } from '../__mocks__/session.mock';
 import {
   BeneficialOwnerTypeChoice,
+  BeneficialOwnerTypeKey,
   ManagingOfficerTypeChoice,
 } from "../../src/model/beneficial.owner.type.model";
 import { ErrorMessages } from '../../src/validation/error.messages';
@@ -55,7 +56,7 @@ describe("BENEFICIAL OWNER TYPE controller", () => {
     test(`redirects to the ${config.BENEFICIAL_OWNER_INDIVIDUAL_PAGE} page`, async () => {
       const resp = await request(app)
         .post(config.BENEFICIAL_OWNER_TYPE_URL)
-        .send({ selectedOwnerOfficerType: BeneficialOwnerTypeChoice.individual });
+        .send({ [BeneficialOwnerTypeKey]: BeneficialOwnerTypeChoice.individual });
 
       expect(resp.status).toEqual(302);
       expect(resp.header.location).toEqual(config.BENEFICIAL_OWNER_INDIVIDUAL_URL);
@@ -64,7 +65,7 @@ describe("BENEFICIAL OWNER TYPE controller", () => {
     test(`redirects to the ${config.BENEFICIAL_OWNER_OTHER_PAGE} page`, async () => {
       const resp = await request(app)
         .post(config.BENEFICIAL_OWNER_TYPE_URL)
-        .send({ selectedOwnerOfficerType: BeneficialOwnerTypeChoice.otherLegal });
+        .send({ [BeneficialOwnerTypeKey]: BeneficialOwnerTypeChoice.otherLegal });
 
       expect(resp.status).toEqual(302);
       expect(resp.header.location).toEqual(config.BENEFICIAL_OWNER_OTHER_URL);
@@ -73,7 +74,7 @@ describe("BENEFICIAL OWNER TYPE controller", () => {
     test(`redirects to the ${config.BENEFICIAL_OWNER_GOV_PAGE} page`, async () => {
       const resp = await request(app)
         .post(config.BENEFICIAL_OWNER_TYPE_URL)
-        .send({ selectedOwnerOfficerType: BeneficialOwnerTypeChoice.government });
+        .send({ [BeneficialOwnerTypeKey]: BeneficialOwnerTypeChoice.government });
 
       expect(resp.status).toEqual(302);
       expect(resp.header.location).toEqual(config.BENEFICIAL_OWNER_GOV_URL);
@@ -82,7 +83,7 @@ describe("BENEFICIAL OWNER TYPE controller", () => {
     test(`redirects to the ${config.MANAGING_OFFICER_PAGE} page`, async () => {
       const resp = await request(app)
         .post(config.BENEFICIAL_OWNER_TYPE_URL)
-        .send({ selectedOwnerOfficerType: ManagingOfficerTypeChoice.individual });
+        .send({ [BeneficialOwnerTypeKey]: ManagingOfficerTypeChoice.individual });
 
       expect(resp.status).toEqual(302);
       expect(resp.header.location).toEqual(config.MANAGING_OFFICER_URL);
@@ -91,7 +92,7 @@ describe("BENEFICIAL OWNER TYPE controller", () => {
     test(`redirects to the ${config.MANAGING_OFFICER_CORPORATE_PAGE} page`, async () => {
       const resp = await request(app)
         .post(config.BENEFICIAL_OWNER_TYPE_URL)
-        .send({ selectedOwnerOfficerType: ManagingOfficerTypeChoice.corporate });
+        .send({ [BeneficialOwnerTypeKey]: ManagingOfficerTypeChoice.corporate });
 
       expect(resp.status).toEqual(302);
       expect(resp.header.location).toEqual(config.MANAGING_OFFICER_CORPORATE_URL);

--- a/views/beneficial-owner-type.html
+++ b/views/beneficial-owner-type.html
@@ -26,9 +26,9 @@
       <form method="post">
 
         {{ govukRadios({
-          errorMessage: errors.selectedOwnerOfficerType if errors,
-          idPrefix: "beneficial-owner-type",
-          name: "selectedOwnerOfficerType",
+          errorMessage: errors.beneficial_owner_type if errors,
+          idPrefix: "beneficial_owner_type",
+          name: "beneficial_owner_type",
           fieldset: {
             legend: {
               isPageHeading: false,

--- a/views/includes/inputs/address/principal-address-input.html
+++ b/views/includes/inputs/address/principal-address-input.html
@@ -11,7 +11,7 @@
   {{ govukInput({
     errorMessage: errors.principal_address_property_name_number if errors,
     label: {
-      html: 'Property name or number (optional)'
+      html: 'Property name or number'
     },
     hint: {
       text: propertyNameNumberText

--- a/views/includes/inputs/address/residential-address-input.html
+++ b/views/includes/inputs/address/residential-address-input.html
@@ -10,7 +10,7 @@
 
   {{ govukInput({
     label: {
-      html: 'Property name or number (optional)'
+      html: 'Property name or number'
     },
     hint: {
       text: propertyNameNumberText

--- a/views/includes/inputs/address/service-address-input.html
+++ b/views/includes/inputs/address/service-address-input.html
@@ -9,7 +9,7 @@
   {{ govukInput({
     errorMessage: errors.service_address_property_name_number if errors,
     label: {
-      html: 'Property name or number (optional)'
+      html: 'Property name or number'
     },
     hint: {
       text: propertyNameNumberText


### PR DESCRIPTION
### JIRA link

Related to [ROE-378](https://companieshouse.atlassian.net/browse/ROE-378) and [ROE-246](https://companieshouse.atlassian.net/browse/ROE-246)

### Change description

- Update `beneficial owner type` key and id
- Remove `optional` text from `Property name or number` address

### Work checklist

- [x] Tests added where applicable
- [x] UI changes meet accessibility criteria
