### PR TITLE
Roe 730 remove autocomplete fields

### DIFF
--- a/test/controllers/cannot.use.controller.spec.ts
+++ b/test/controllers/cannot.use.controller.spec.ts
@@ -1,3 +1,5 @@
+jest.mock("ioredis");
+
 import { expect, test } from "@jest/globals";
 import * as config from "../../src/config";
 import request from "supertest";

--- a/test/controllers/secure.register.filter.controller.spec.ts
+++ b/test/controllers/secure.register.filter.controller.spec.ts
@@ -1,3 +1,4 @@
+jest.mock("ioredis");
 jest.mock("../../src/utils/logger");
 
 import { ErrorMessages } from "../../src/validation/error.messages";

--- a/test/controllers/sold.land.filter.controller.spec.ts
+++ b/test/controllers/sold.land.filter.controller.spec.ts
@@ -1,3 +1,4 @@
+jest.mock("ioredis");
 jest.mock("../../src/utils/logger");
 
 import { expect, jest, test } from "@jest/globals";

--- a/test/controllers/use.paper.controller.spec.ts
+++ b/test/controllers/use.paper.controller.spec.ts
@@ -1,3 +1,5 @@
+jest.mock("ioredis");
+
 import { expect, test } from "@jest/globals";
 import * as config from "../../src/config";
 import request from "supertest";

--- a/views/includes/inputs/address/residential-address-input.html
+++ b/views/includes/inputs/address/residential-address-input.html
@@ -29,7 +29,6 @@
     classes: "govuk-!-width-two-thirds",
     id: "usual_residential_address_line_1",
     name: "usual_residential_address_line_1",
-    autocomplete: "usual_residential_address_line_1",
     value: usual_residential_address_line_1
   }) }}
 
@@ -40,7 +39,6 @@
     },
     id: "usual_residential_address_line_2",
     name: "usual_residential_address_line_2",
-    autocomplete: "usual_residential_address_line_2",
     value: usual_residential_address_line_2
   }) }}
 
@@ -79,7 +77,6 @@
     classes: "govuk-input--width-10",
     id: "usual_residential_address_postcode",
     name: "usual_residential_address_postcode",
-    autocomplete: "usual_residential_address_postcode",
     value: usual_residential_address_postcode
   }) }}
 

--- a/views/presenter.html
+++ b/views/presenter.html
@@ -24,7 +24,6 @@
             text: "Full name",
             isPageHeading: false
           },
-          autocomplete: "contact-full-name",
           id: "full_name",
           name: "full_name",
           value: full_name
@@ -36,7 +35,6 @@
             text: "Email address",
             isPageHeading: false
           },
-          autocomplete: "contact-email",
           id: "email",
           name: "email",
           value: email


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/jira/software/c/projects/ROE/boards/186?modal=detail&selectedIssue=ROE-730


### Change description

The Axe accessibility plugin highlighted the the autocomplete fields were incorrect. We should be using "on" or "off" according to 
https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill

But the only fields that had autocomplete set were presenter name, email and any residential address. So spoke with @mouhajer-ch and decided to remove the autocomplete fields as other fields didn't use them and was probably a carry-over from the prototype code.

Also fixed the process timeout warning messages when running the tests
### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
