### PR TITLE
ROE-296 adding matomo tracking to filter pages radio buttons

### DIFF
--- a/views/secure-register-filter.html
+++ b/views/secure-register-filter.html
@@ -32,12 +32,18 @@
             {
               value: 1,
               text: "Yes",
-              checked: secure_register == 1
+              checked: secure_register == 1,
+              attributes: {
+                "data-event-id": "yes-radio-button"
+              }
             },
             {
               value: 0,
               text: "No",
-              checked: secure_register == 0
+              checked: secure_register == 0,
+              attributes: {
+                "data-event-id": "no-radio-button"
+              }
             }
           ]
         }) }}

--- a/views/sold-land-filter.html
+++ b/views/sold-land-filter.html
@@ -35,12 +35,18 @@ Has the entity disposed of UK property or land since 28 February 2022?
             {
               value: 1,
               text: "Yes",
-              checked: has_sold_land == 1
+              checked: has_sold_land == 1,
+              attributes: {
+                "data-event-id": "yes-radio-button"
+              }
             },
             {
               value: 0,
               text: "No",
-              checked: has_sold_land == 0
+              checked: has_sold_land == 0,
+              attributes: {
+                "data-event-id": "no-radio-button"
+              }
             }
           ]
         }) }}


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/ROE-296
https://companieshouse.atlassian.net/browse/ROE-295


### Change description
Adding data event ids to the radio buttons located on the sold-land-filter and secure-register-filter pages so clicks on these buttons can be tracked by Matomo


### Work checklist

- [ ] Tests added where applicable
- [x] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
