### PR TITLE
ROE-781 making occupation field mandatory on managing officer page

### DIFF
--- a/src/validation/error.messages.ts
+++ b/src/validation/error.messages.ts
@@ -10,6 +10,7 @@ export enum ErrorMessages {
   FORMER_NAME = "Enter the individual person’s former name or names",
   ROLE = "Enter a description of the individual person’s role and responsibilities",
   NATIONALITY = "Enter the individual person’s nationality",
+  OCCUPATION = "Enter an occupation",
   // Public Register
   PUBLIC_REGISTER_NAME = "Enter the name of the register",
   PUBLIC_REGISTER_NUMBER = "Enter the registration number",

--- a/src/validation/managing.officer.validation.ts
+++ b/src/validation/managing.officer.validation.ts
@@ -34,8 +34,9 @@ export const managingOfficerIndividual = [
     .not().isEmpty().withMessage(ErrorMessages.SELECT_IF_SERVICE_ADDRESS_SAME_AS_USER_RESIDENTIAL_ADDRESS),
 
   ...usual_residential_service_address_validations,
-  body("occupation").isLength({ max: 100 })
-    .withMessage(ErrorMessages.MAX_OCCUPATION_LENGTH)
+  body("occupation")
+    .not().isEmpty().withMessage(ErrorMessages.OCCUPATION)
+    .isLength({ max: 100 }).withMessage(ErrorMessages.MAX_OCCUPATION_LENGTH)
     .matches(VALID_CHARACTERS).withMessage(ErrorMessages.OCCUPATION_INVALID_CHARACTERS),
   body("role_and_responsibilities").isLength({ max: 4000 })
     .withMessage(ErrorMessages.MAX_ROLE_LENGTH)

--- a/test/controllers/managing.officer.controller.spec.ts
+++ b/test/controllers/managing.officer.controller.spec.ts
@@ -90,7 +90,7 @@ describe("MANAGING_OFFICER controller", () => {
 
   describe("POST tests", () => {
 
-    test(`renders the ${BENEFICIAL_OWNER_TYPE_URL} page after all mandandory fields for ${MANAGING_OFFICER_URL} have been populated`, async () => {
+    test(`renders the ${BENEFICIAL_OWNER_TYPE_URL} page after all mandatory fields for ${MANAGING_OFFICER_URL} have been populated`, async () => {
       mockPrepareData.mockImplementationOnce( () => MANAGING_OFFICER_OBJECT_MOCK );
 
       const resp = await request(app)
@@ -101,7 +101,7 @@ describe("MANAGING_OFFICER controller", () => {
       expect(resp.header.location).toEqual(BENEFICIAL_OWNER_TYPE_URL);
     });
 
-    test(`sets session data and renders the ${BENEFICIAL_OWNER_TYPE_URL} page after all mandandory fields for ${MANAGING_OFFICER_URL} have been populated`, async () => {
+    test(`sets session data and renders the ${BENEFICIAL_OWNER_TYPE_URL} page after all mandatory fields for ${MANAGING_OFFICER_URL} have been populated`, async () => {
       mockPrepareData.mockImplementationOnce( () => MANAGING_OFFICER_OBJECT_MOCK );
 
       const resp = await request(app)
@@ -164,6 +164,7 @@ describe("MANAGING_OFFICER controller", () => {
       expect(resp.text).toContain(ErrorMessages.CITY_OR_TOWN);
       expect(resp.text).toContain(ErrorMessages.COUNTRY);
       expect(resp.text).toContain(ErrorMessages.SELECT_IF_SERVICE_ADDRESS_SAME_AS_USER_RESIDENTIAL_ADDRESS);
+      expect(resp.text).toContain(ErrorMessages.OCCUPATION);
       expect(resp.text).toContain(BENEFICIAL_OWNER_TYPE_URL);
     });
 

--- a/views/managing-officer.html
+++ b/views/managing-officer.html
@@ -75,7 +75,7 @@
         {{ govukInput({
           errorMessage: errors.occupation if errors,
           label: {
-            text: "What is their occupation? (Optional)",
+            text: "What is their occupation?",
             classes: "govuk-label--m",
             isPageHeading: false
           },


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/ROE-781


### Change description
Making occupation field mandatory on managing officer page


### Work checklist

- [x] Tests updated where applicable
- [x] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
