### PR TITLE
ROE-779 adding validation to new contact name and email fields on corporate MO page

### DIFF
--- a/src/validation/error.messages.ts
+++ b/src/validation/error.messages.ts
@@ -76,5 +76,6 @@ export enum ErrorMessages {
   LAW_GOVERNED_INVALID_CHARACTERS = "Governing law must only include letters a to z, numbers, and special characters such as hyphens, spaces and apostrophes",
   FORMER_NAMES_INVALID_CHARACTERS = "Former name or names must only include letters a to z, numbers, and special characters such as hyphens, spaces and apostrophes",
   OCCUPATION_INVALID_CHARACTERS = "Occupation must only include letters a to z, numbers, and special characters such as hyphens, spaces and apostrophes",
-  ROLES_AND_RESPONSIBILITIES_INVALID_CHARACTERS = "Role and responsibilities must only include letters a to z, numbers, and special characters such as hyphens, spaces and apostrophes"
+  ROLES_AND_RESPONSIBILITIES_INVALID_CHARACTERS = "Role and responsibilities must only include letters a to z, numbers, and special characters such as hyphens, spaces and apostrophes",
+  CONTACT_NAME_INVALID_CHARACTERS = "Contact name must only include letters a to z, numbers, and special characters such as hyphens, spaces and apostrophes"
 }

--- a/src/validation/managing.officer.corporate.validation.ts
+++ b/src/validation/managing.officer.corporate.validation.ts
@@ -32,5 +32,14 @@ export const managingOfficerCorporate = [
     .not().isEmpty().withMessage(ErrorMessages.SELECT_IF_MANAGING_OFFICER_REGISTER_IN_COUNTRY_FORMED_IN),
 
   ...public_register_validations,
-  ...start_date_validations
+  ...start_date_validations,
+
+  body("contact_full_name")
+    .not().isEmpty().withMessage(ErrorMessages.FULL_NAME)
+    .isLength({ max: 160 }).withMessage(ErrorMessages.MAX_FULL_NAME_LENGTH)
+    .matches(VALID_CHARACTERS).withMessage(ErrorMessages.CONTACT_NAME_INVALID_CHARACTERS),
+
+  body("contact_email")
+    .not().isEmpty().withMessage(ErrorMessages.EMAIL)
+    .isLength({ max: 250 }).withMessage(ErrorMessages.MAX_EMAIL_LENGTH)
 ];

--- a/test/__mocks__/session.mock.ts
+++ b/test/__mocks__/session.mock.ts
@@ -390,6 +390,8 @@ export const REQ_BODY_MANAGING_OFFICER_CORPORATE_MOCK_WITH_ADDRESS = {
   is_on_register_in_country_formed_in: "1",
   public_register_name: "register",
   registration_number: "123456789",
+  contact_full_name: "contact name",
+  contact_email: "contact email",
   ...PRINCIPAL_ADDRESS_MOCK,
   ...SERVICE_ADDRESS_MOCK,
   ...start_date

--- a/test/__mocks__/validation.mock.ts
+++ b/test/__mocks__/validation.mock.ts
@@ -241,6 +241,8 @@ export const MANAGING_OFFICER_CORPORATE_WITH_MAX_LENGTH_FIELDS_MOCK = {
   public_register_name: MAX_4000 + "1",
   registration_number: MAX_32 + "1",
   is_service_address_same_as_principal_address: "0",
+  contact_full_name: MAX_160 + "1",
+  contact_email: MAX_250 + "1",
   ...PRINCIPAL_ADDRESS_WITH_MAX_LENGTH_FIELDS_MOCK,
   ...SERVICE_ADDRESS_WITH_MAX_LENGTH_FIELDS_MOCK,
   ...START_DATE_MOCK
@@ -285,6 +287,8 @@ export const MANAGING_OFFICER_CORPORATE_WITH_INVALID_CHARS_MOCK = {
   is_on_register_in_country_formed_in: "1",
   public_register_name: INVALID_CHARS,
   registration_number: INVALID_CHARS,
+  contact_full_name: INVALID_CHARS,
+  contact_email: INVALID_CHARS,
   ...PRINCIPAL_ADDRESS_WITH_INVALID_CHARACTERS_FIELDS_MOCK,
   ...SERVICE_ADDRESS_MOCK
 };

--- a/test/controllers/managing.officer.corporate.controller.spec.ts
+++ b/test/controllers/managing.officer.corporate.controller.spec.ts
@@ -147,6 +147,8 @@ describe("MANAGING_OFFICER CORPORATE controller", () => {
       expect(resp.text).toContain(ErrorMessages.DAY);
       expect(resp.text).toContain(ErrorMessages.MONTH);
       expect(resp.text).toContain(ErrorMessages.YEAR);
+      expect(resp.text).toContain(ErrorMessages.FULL_NAME);
+      expect(resp.text).toContain(ErrorMessages.EMAIL);
       expect(resp.text).toContain(BENEFICIAL_OWNER_TYPE_URL);
     });
 
@@ -181,6 +183,8 @@ describe("MANAGING_OFFICER CORPORATE controller", () => {
       expect(resp.text).toContain(ErrorMessages.MAX_LAW_GOVERNED_LENGTH);
       expect(resp.text).toContain(ErrorMessages.MAX_PUBLIC_REGISTER_NAME_LENGTH);
       expect(resp.text).toContain(ErrorMessages.MAX_PUBLIC_REGISTER_NUMBER_LENGTH);
+      expect(resp.text).toContain(ErrorMessages.MAX_FULL_NAME_LENGTH);
+      expect(resp.text).toContain(ErrorMessages.MAX_EMAIL_LENGTH);
       expect(resp.text).not.toContain(ErrorMessages.MANAGING_OFFICER_CORPORATE_NAME);
       expect(resp.text).not.toContain(ErrorMessages.PROPERTY_NAME_OR_NUMBER);
       expect(resp.text).not.toContain(ErrorMessages.ADDRESS_LINE1);
@@ -215,6 +219,7 @@ describe("MANAGING_OFFICER CORPORATE controller", () => {
       expect(resp.text).toContain(ErrorMessages.LAW_GOVERNED_INVALID_CHARACTERS);
       expect(resp.text).toContain(ErrorMessages.PUBLIC_REGISTER_NAME_INVALID_CHARACTERS);
       expect(resp.text).toContain(ErrorMessages.PUBLIC_REGISTER_NUMBER_INVALID_CHARACTERS);
+      expect(resp.text).toContain(ErrorMessages.CONTACT_NAME_INVALID_CHARACTERS);
     });
 
     test(`renders the current page ${MANAGING_OFFICER_CORPORATE_URL} with INVALID_CHARACTERS service address error messages`, async () => {

--- a/views/managing-officer-corporate.html
+++ b/views/managing-officer-corporate.html
@@ -41,6 +41,7 @@
       <h2 class="govuk-heading-l">Who can we contact about this managing officer?</h2>
 
       {{ govukInput({
+        errorMessage: errors.contact_full_name if errors,
         label: {
           text: "What is their full name?",
           classes: "govuk-label--m",
@@ -52,6 +53,7 @@
       }) }}
 
       {{ govukInput({
+        errorMessage: errors.contact_email if errors,
         label: {
           text: "What is their email address?",
           classes: "govuk-label--m",


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/ROE-779


### Change description
 adding mandatory, max length and invalid character validation to new contact name and email fields on corporate managing officer page


### Work checklist

- [x] Tests added where applicable
- [x] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
