### PR TITLE
ROE-786 Set company name on transaction

### DIFF
--- a/src/service/transaction.service.ts
+++ b/src/service/transaction.service.ts
@@ -6,11 +6,15 @@ import { createOAuthApiClient } from "./api.service";
 import { createAndLogErrorRequest, logger } from "../utils/logger";
 import { DESCRIPTION, REFERENCE } from "../config";
 import { ApiResponse } from "@companieshouse/api-sdk-node/dist/services/resource";
+import { getApplicationData } from "../utils/application.data";
+import { ApplicationData } from "../model";
 
 export const postTransaction = async (req: Request, session: Session): Promise<Transaction> => {
   const apiClient: ApiClient = createOAuthApiClient(session);
 
-  const transaction: Transaction = { reference: REFERENCE, description: DESCRIPTION };
+  const applicationData: ApplicationData = getApplicationData(session);
+
+  const transaction: Transaction = { reference: REFERENCE, companyName: applicationData.entity?.name, description: DESCRIPTION };
   const response = await apiClient.transaction.postTransaction(transaction) as any;
 
   if (!response.httpStatusCode || response.httpStatusCode >= 400) {

--- a/test/service/transaction.service.spec.ts
+++ b/test/service/transaction.service.spec.ts
@@ -40,7 +40,7 @@ describe('Transaction Service test suite', () => {
   });
 
   describe('POST Transaction', () => {
-    test.only('Should successfully post a transaction', async () => {
+    test('Should successfully post a transaction', async () => {
       mockPostTransaction.mockResolvedValueOnce({ httpStatusCode: 200, resource: TRANSACTION });
       const response = await postTransaction(req, session) as any;
 

--- a/test/service/transaction.service.spec.ts
+++ b/test/service/transaction.service.spec.ts
@@ -8,6 +8,7 @@ import { createApiClient } from "@companieshouse/api-sdk-node";
 import * as TransactionService from "@companieshouse/api-sdk-node/dist/services/transaction/service";
 
 import {
+  APPLICATION_DATA_MOCK,
   ERROR,
   getSessionRequestWithExtraData,
   OVERSEAS_ENTITY_ID,
@@ -18,6 +19,8 @@ import { closeTransaction, postTransaction } from "../../src/service/transaction
 import { createAndLogErrorRequest, logger } from '../../src/utils/logger';
 import { HTTP_STATUS_CODE_500, TRANSACTION_ERROR } from "../__mocks__/text.mock";
 import { Request } from "express";
+import { Transaction } from "@companieshouse/api-sdk-node/dist/services/transaction/types";
+import { DESCRIPTION, REFERENCE } from "../../src/config";
 
 const mockDebugRequestLog = logger.debugRequest as jest.Mock;
 const mockCreateAndLogErrorRequest = createAndLogErrorRequest as jest.Mock;
@@ -37,9 +40,12 @@ describe('Transaction Service test suite', () => {
   });
 
   describe('POST Transaction', () => {
-    test('Should successfully post a transaction', async () => {
+    test.only('Should successfully post a transaction', async () => {
       mockPostTransaction.mockResolvedValueOnce({ httpStatusCode: 200, resource: TRANSACTION });
       const response = await postTransaction(req, session) as any;
+
+      const transaction: Transaction = { reference: REFERENCE, companyName: APPLICATION_DATA_MOCK.entity?.name, description: DESCRIPTION };
+      expect(mockPostTransaction).toBeCalledWith(transaction);
 
       expect(response.reference).toEqual(TRANSACTION.reference);
       expect(response.description).toEqual(TRANSACTION.description);


### PR DESCRIPTION
* Company name set on transaction when overseas entity is
  being created
* This will be picked up by Transactions API when sending
  e-mails and used to populate subject and body fields
* Unit test updated to validate change in behaviour

### JIRA link

https://companieshouse.atlassian.net/browse/ROE-786

### Change description



### Work checklist

- [ X] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
