### PR TITLE
Bug/change return to page after auth sign in

### DIFF
--- a/src/middleware/authentication.middleware.ts
+++ b/src/middleware/authentication.middleware.ts
@@ -1,7 +1,7 @@
 import { Request, Response, NextFunction } from 'express';
 
 import { logger } from '../utils/logger';
-import { PRESENTER_URL } from '../config';
+import { SOLD_LAND_FILTER_URL } from '../config';
 
 import {
   checkUserSignedIn,
@@ -12,7 +12,7 @@ export const authentication = (req: Request, res: Response, next: NextFunction):
   try {
     if (!checkUserSignedIn(req.session)) {
       logger.infoRequest(req, 'User not authenticated, redirecting to sign in page, status_code=302');
-      return res.redirect(`/signin?return_to=${PRESENTER_URL}`);
+      return res.redirect(`/signin?return_to=${SOLD_LAND_FILTER_URL}`);
     }
 
     logger.infoRequest(req, `User (${getLoggedInUserEmail(req.session)}) is signed in`);

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -38,17 +38,17 @@ router.get(config.HEALTHCHECK_URL, healthcheck.get);
 
 router.get(config.LANDING_URL, landing.get);
 
-router.get(config.INTERRUPT_CARD_URL, interruptCard.get);
+router.get(config.SOLD_LAND_FILTER_URL, authentication, soldLandFilter.get);
+router.post(config.SOLD_LAND_FILTER_URL, authentication, ...validator.soldLandFilter, checkValidations, soldLandFilter.post);
 
-router.get(config.SOLD_LAND_FILTER_URL, soldLandFilter.get);
-router.post(config.SOLD_LAND_FILTER_URL, ...validator.soldLandFilter, checkValidations, soldLandFilter.post);
+router.get(config.CANNOT_USE_URL, authentication, cannotUse.get);
 
-router.get(config.CANNOT_USE_URL, cannotUse.get);
+router.get(config.SECURE_REGISTER_FILTER_URL, authentication, secureRegisterFilter.get);
+router.post(config.SECURE_REGISTER_FILTER_URL, authentication, ...validator.secureRegisterFilter, checkValidations, secureRegisterFilter.post);
 
-router.get(config.SECURE_REGISTER_FILTER_URL, secureRegisterFilter.get);
-router.post(config.SECURE_REGISTER_FILTER_URL, ...validator.secureRegisterFilter, checkValidations, secureRegisterFilter.post);
+router.get(config.USE_PAPER_URL, authentication, usePaper.get);
 
-router.get(config.USE_PAPER_URL, usePaper.get);
+router.get(config.INTERRUPT_CARD_URL, authentication, interruptCard.get);
 
 router.get(config.PRESENTER_URL, authentication, presenter.get);
 router.post(config.PRESENTER_URL, authentication, ...validator.presenter, checkValidations, presenter.post);

--- a/test/controllers/cannot.use.controller.spec.ts
+++ b/test/controllers/cannot.use.controller.spec.ts
@@ -1,16 +1,24 @@
 jest.mock("ioredis");
+jest.mock('../../src/middleware/authentication.middleware');
 
-import { expect, test } from "@jest/globals";
-import * as config from "../../src/config";
+import { NextFunction, Request, Response } from "express";
+import { expect, test, describe } from "@jest/globals";
 import request from "supertest";
+
 import app from "../../src/app";
+import * as config from "../../src/config";
+
+import { authentication } from "../../src/middleware/authentication.middleware";
 import { CANNOT_USE_SERVICE_HEADING } from "../__mocks__/text.mock";
+
+const mockAuthenticationMiddleware = authentication as jest.Mock;
+mockAuthenticationMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => next() );
 
 describe("CANNOT USE controller", () => {
   describe("GET tests", () => {
     test(`renders the ${config.CANNOT_USE_PAGE} page`, async () => {
-      const resp = await request(app)
-        .get(config.CANNOT_USE_URL);
+      const resp = await request(app).get(config.CANNOT_USE_URL);
+
       expect(resp.status).toEqual(200);
       expect(resp.text).toContain(CANNOT_USE_SERVICE_HEADING);
     });

--- a/test/controllers/interrupt.card.controller.spec.ts
+++ b/test/controllers/interrupt.card.controller.spec.ts
@@ -1,11 +1,20 @@
 jest.mock("ioredis");
 jest.mock("../../src/utils/application.data");
+jest.mock('../../src/middleware/authentication.middleware');
 
-import { INTERRUPT_CARD_PAGE, INTERRUPT_CARD_URL } from "../../src/config";
+import { NextFunction, Request, Response } from "express";
+import { beforeEach, expect, jest, test, describe } from "@jest/globals";
 import request from "supertest";
+
 import app from "../../src/app";
+import { INTERRUPT_CARD_PAGE, INTERRUPT_CARD_URL } from "../../src/config";
 import { ANY_MESSAGE_ERROR, INTERRUPT_CARD_PAGE_TITLE, SERVICE_UNAVAILABLE } from "../__mocks__/text.mock";
+
+import { authentication } from "../../src/middleware/authentication.middleware";
 import { deleteApplicationData } from "../../src/utils/application.data";
+
+const mockAuthenticationMiddleware = authentication as jest.Mock;
+mockAuthenticationMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => next() );
 
 const mockDeleteApplicationData = deleteApplicationData as jest.Mock;
 

--- a/test/controllers/secure.register.filter.controller.spec.ts
+++ b/test/controllers/secure.register.filter.controller.spec.ts
@@ -1,14 +1,22 @@
 jest.mock("ioredis");
 jest.mock("../../src/utils/logger");
+jest.mock('../../src/middleware/authentication.middleware');
 
-import { ErrorMessages } from "../../src/validation/error.messages";
+import { NextFunction, Request, Response } from "express";
+import { beforeEach, expect, jest, test, describe } from "@jest/globals";
 import request from "supertest";
+
 import app from "../../src/app";
 import * as config from "../../src/config";
-import { beforeEach, expect, jest, test } from "@jest/globals";
+import { ErrorMessages } from "../../src/validation/error.messages";
 import { ANY_MESSAGE_ERROR, SECURE_REGISTER_FILTER_PAGE_HEADING, SERVICE_UNAVAILABLE } from "../__mocks__/text.mock";
 import { SECURE_REGISTER_FILTER_URL } from "../../src/config";
+
+import { authentication } from "../../src/middleware/authentication.middleware";
 import { logger } from "../../src/utils/logger";
+
+const mockAuthenticationMiddleware = authentication as jest.Mock;
+mockAuthenticationMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => next() );
 
 const mockLoggerDebugRequest = logger.debugRequest as jest.Mock;
 

--- a/test/controllers/sold.land.filter.controller.spec.ts
+++ b/test/controllers/sold.land.filter.controller.spec.ts
@@ -1,13 +1,21 @@
 jest.mock("ioredis");
 jest.mock("../../src/utils/logger");
+jest.mock('../../src/middleware/authentication.middleware');
 
-import { expect, jest, test } from "@jest/globals";
-import * as config from "../../src/config";
+import { NextFunction, Request, Response } from "express";
+import { beforeEach, expect, jest, test, describe } from "@jest/globals";
 import request from "supertest";
+
+import * as config from "../../src/config";
 import app from "../../src/app";
 import { ANY_MESSAGE_ERROR, SERVICE_UNAVAILABLE, SOLD_LAND_FILTER_PAGE_TITLE } from "../__mocks__/text.mock";
 import { ErrorMessages } from '../../src/validation/error.messages';
+
+import { authentication } from "../../src/middleware/authentication.middleware";
 import { logger } from "../../src/utils/logger";
+
+const mockAuthenticationMiddleware = authentication as jest.Mock;
+mockAuthenticationMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => next() );
 
 const mockLoggerDebugRequest = logger.debugRequest as jest.Mock;
 

--- a/test/controllers/use.paper.controller.spec.ts
+++ b/test/controllers/use.paper.controller.spec.ts
@@ -1,16 +1,24 @@
 jest.mock("ioredis");
+jest.mock('../../src/middleware/authentication.middleware');
 
-import { expect, test } from "@jest/globals";
-import * as config from "../../src/config";
+import { NextFunction, Request, Response } from "express";
+import { expect, jest, test, describe } from "@jest/globals";
 import request from "supertest";
+
+import * as config from "../../src/config";
 import app from "../../src/app";
 import { CANNOT_USE_SERVICE_HEADING } from "../__mocks__/text.mock";
+
+import { authentication } from "../../src/middleware/authentication.middleware";
+
+const mockAuthenticationMiddleware = authentication as jest.Mock;
+mockAuthenticationMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => next() );
 
 describe("USE PAPER controller", () => {
   describe("GET tests", () => {
     test(`renders the ${config.USE_PAPER_URL} page`, async () => {
-      const resp = await request(app)
-        .get(config.USE_PAPER_URL);
+      const resp = await request(app).get(config.USE_PAPER_URL);
+
       expect(resp.status).toEqual(200);
       expect(resp.text).toContain(CANNOT_USE_SERVICE_HEADING);
     });

--- a/test/middleware/authentication.middleware.spec.ts
+++ b/test/middleware/authentication.middleware.spec.ts
@@ -9,7 +9,7 @@ import app from "../../src/app";
 import { getSessionRequestWithPermission, userMail } from '../__mocks__/session.mock';
 import { authentication } from "../../src/middleware/authentication.middleware";
 import { logger } from '../../src/utils/logger';
-import { PRESENTER_URL } from '../../src/config';
+import { SOLD_LAND_FILTER_URL } from '../../src/config';
 import { ANY_MESSAGE_ERROR, REDIRECT_TO_SIGN_IN_PAGE } from '../__mocks__/text.mock';
 
 jest.mock('../../src/utils/logger', () => {
@@ -42,8 +42,8 @@ describe('Authentication middleware', () => {
     expect(res.redirect).not.toHaveBeenCalled();
   });
 
-  test("should redirect to signin page with presenter page as return page", () => {
-    const signinRedirectPath = `/signin?return_to=${PRESENTER_URL}`;
+  test(`should redirect to signin page with ${SOLD_LAND_FILTER_URL} page as return page`, () => {
+    const signinRedirectPath = `/signin?return_to=${SOLD_LAND_FILTER_URL}`;
     req.session = undefined;
 
     authentication(req, res, next);
@@ -73,7 +73,7 @@ describe('Authentication middleware', () => {
   });
 
   test("should redirect to signin page", async () => {
-    const resp = await request(app).get(PRESENTER_URL);
+    const resp = await request(app).get(SOLD_LAND_FILTER_URL);
 
     expect(resp.status).toEqual(302);
     expect(resp.text).toContain('/signin');


### PR DESCRIPTION
### JIRA link

Resolves [ROE-814](https://companieshouse.atlassian.net/browse/ROE-814)

### Change description

- Change return page to `SOLD_LAND_FILTER` instead of `PRESENTER` page after the authentication to avoid bypassing the `Has the entity disposed of UK property or land since 28 February 2022? `and `Have any of the entity's beneficial owners ever applied to protect personal information at Companies House?` pages.
- Add missing authentication middleware to the `INTERRUPT_CARD`, `SOLD_LAND_FILTER`, `CANNOT_USE`, `SECURE_REGISTER_FILTER` and `USE_PAPER` Pages

### Work checklist

- [x] Tests added where applicable
- [x] UI changes meet accessibility criteria
