### PR TITLE
Roe 189 ind mo clear optional fields

### DIFF
--- a/src/controllers/managing.officer.controller.ts
+++ b/src/controllers/managing.officer.controller.ts
@@ -4,7 +4,13 @@ import { logger } from "../utils/logger";
 import { ApplicationDataType } from "../model";
 import { getFromApplicationData, mapDataObjectToFields, mapFieldsToDataObject, prepareData, removeFromApplicationData, setApplicationData } from "../utils/application.data";
 
-import { AddressKeys, HasFormerNames, HasSameResidentialAddressKey, ID, InputDateKeys } from "../model/data.types.model";
+import {
+  AddressKeys, FormerNamesKey,
+  HasFormerNames,
+  HasSameResidentialAddressKey,
+  ID,
+  InputDateKeys
+} from "../model/data.types.model";
 import { DateOfBirthKey, DateOfBirthKeys } from "../model/date.model";
 import { ServiceAddressKey, ServiceAddressKeys, UsualResidentialAddressKey, UsualResidentialAddressKeys } from "../model/address.model";
 import { ManagingOfficerKey, ManagingOfficerKeys } from "../model/managing.officer.model";
@@ -97,13 +103,17 @@ export const remove = (req: Request, res: Response, next: NextFunction) => {
 
 const setOfficerData = (reqBody: any, id: string): ApplicationDataType => {
   const data: ApplicationDataType = prepareData(reqBody, ManagingOfficerKeys);
-
   data[UsualResidentialAddressKey] = mapFieldsToDataObject(reqBody, UsualResidentialAddressKeys, AddressKeys);
-  data[ServiceAddressKey] = mapFieldsToDataObject(reqBody, ServiceAddressKeys, AddressKeys);
   data[DateOfBirthKey] = mapFieldsToDataObject(reqBody, DateOfBirthKeys, InputDateKeys);
 
   data[HasSameResidentialAddressKey] = (data[HasSameResidentialAddressKey]) ? +data[HasSameResidentialAddressKey] : '';
+  data[ServiceAddressKey] = (!data[HasSameResidentialAddressKey])
+    ?  mapFieldsToDataObject(reqBody, ServiceAddressKeys, AddressKeys)
+    :  {};
   data[HasFormerNames] = (data[HasFormerNames]) ? +data[HasFormerNames] : '';
+  if (!data[HasFormerNames]) {
+    data[FormerNamesKey] = "";
+  }
 
   data[ID] = id;
 

--- a/src/controllers/managing.officer.controller.ts
+++ b/src/controllers/managing.officer.controller.ts
@@ -5,7 +5,7 @@ import { ApplicationDataType } from "../model";
 import { getFromApplicationData, mapDataObjectToFields, mapFieldsToDataObject, prepareData, removeFromApplicationData, setApplicationData } from "../utils/application.data";
 
 import {
-  AddressKeys, FormerNamesKey,
+  AddressKeys,
   HasFormerNames,
   HasSameResidentialAddressKey,
   ID,
@@ -13,7 +13,7 @@ import {
 } from "../model/data.types.model";
 import { DateOfBirthKey, DateOfBirthKeys } from "../model/date.model";
 import { ServiceAddressKey, ServiceAddressKeys, UsualResidentialAddressKey, UsualResidentialAddressKeys } from "../model/address.model";
-import { ManagingOfficerKey, ManagingOfficerKeys } from "../model/managing.officer.model";
+import { FormerNamesKey, ManagingOfficerKey, ManagingOfficerKeys } from "../model/managing.officer.model";
 import { v4 as uuidv4 } from 'uuid';
 import { BENEFICIAL_OWNER_TYPE_URL, MANAGING_OFFICER_PAGE } from "../config";
 

--- a/src/model/data.types.model.ts
+++ b/src/model/data.types.model.ts
@@ -67,6 +67,3 @@ export const Transactionkey = "transaction_id";
 // Register keys
 export const PublicRegisterNameKey = "public_register_name";
 export const RegistrationNumberKey = "registration_number";
-
-// Former Names key
-export const FormerNamesKey = "former_names";

--- a/src/model/data.types.model.ts
+++ b/src/model/data.types.model.ts
@@ -67,3 +67,6 @@ export const Transactionkey = "transaction_id";
 // Register keys
 export const PublicRegisterNameKey = "public_register_name";
 export const RegistrationNumberKey = "registration_number";
+
+// Former Names key
+export const FormerNamesKey = "former_names";

--- a/src/model/managing.officer.model.ts
+++ b/src/model/managing.officer.model.ts
@@ -35,3 +35,5 @@ export interface ManagingOfficerIndividual {
   occupation?: string
   role_and_responsibilities?: string
 }
+
+export const FormerNamesKey = "former_names";

--- a/test/__mocks__/session.mock.ts
+++ b/test/__mocks__/session.mock.ts
@@ -471,6 +471,30 @@ export const REQ_BODY_MANAGING_OFFICER_CORPORATE_MOCK_WITH_ADDRESS = {
   ...start_date
 };
 
+export const MANAGING_OFFICER_INDIVIDUAL_OBJECT_MOCK_WITH_SERVICE_ADDRESS_YES: managingOfficerType.ManagingOfficerIndividual = {
+  id: MO_IND_ID,
+  is_service_address_same_as_usual_residential_address: yesNoResponse.Yes,
+  service_address: ADDRESS
+};
+
+export const MANAGING_OFFICER_INDIVIDUAL_OBJECT_MOCK_WITH_SERVICE_ADDRESS_NO: managingOfficerType.ManagingOfficerIndividual = {
+  id: MO_IND_ID,
+  is_service_address_same_as_usual_residential_address: yesNoResponse.No,
+  service_address: ADDRESS
+};
+
+export const MANAGING_OFFICER_INDIVIDUAL_OBJECT_MOCK_WITH_FORMER_NAMES_YES: managingOfficerType.ManagingOfficerIndividual = {
+  id: MO_IND_ID,
+  has_former_names: yesNoResponse.Yes,
+  former_names: "John Doe"
+};
+
+export const MANAGING_OFFICER_INDIVIDUAL_OBJECT_MOCK_WITH_FORMER_NAMES_NO: managingOfficerType.ManagingOfficerIndividual = {
+  id: MO_IND_ID,
+  has_former_names: yesNoResponse.No,
+  former_names: "John Doe"
+};
+
 export const PRESENTER_OBJECT_MOCK: presenterType.Presenter = {
   full_name: "fullName",
   email: "user@domain.roe"

--- a/test/controllers/beneficial.owner.individual.controller.spec.ts
+++ b/test/controllers/beneficial.owner.individual.controller.spec.ts
@@ -121,7 +121,6 @@ describe("BENEFICIAL OWNER INDIVIDUAL controller", () => {
 
     test(`redirect to the ${BENEFICIAL_OWNER_TYPE_URL} page after a successful post from ${BENEFICIAL_OWNER_INDIVIDUAL_PAGE} page with service address data`, async () => {
       mockPrepareData.mockImplementation( () => BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK_WITH_SERVICE_ADDRESS_NO );
-      mockSetApplicationData.mockImplementation( () => setApplicationData);
       const resp = await request(app).post(BENEFICIAL_OWNER_INDIVIDUAL_URL);
 
       expect(resp.status).toEqual(302);
@@ -223,7 +222,6 @@ describe("BENEFICIAL OWNER INDIVIDUAL controller", () => {
 
     test(`Service address from the ${BENEFICIAL_OWNER_INDIVIDUAL_PAGE} is empty when same address is set to yes`, async () => {
       mockPrepareData.mockImplementation( () => BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK_WITH_SERVICE_ADDRESS_YES);
-      mockSetApplicationData.mockImplementation( () => setApplicationData);
       await request(app).post(BENEFICIAL_OWNER_INDIVIDUAL_URL);
       expect(mapFieldsToDataObject).not.toHaveBeenCalledWith({}, ServiceAddressKeys, AddressKeys);
       const data: ApplicationDataType = mockSetApplicationData.mock.calls[0][1];

--- a/test/controllers/beneficial.owner.other.controller.spec.ts
+++ b/test/controllers/beneficial.owner.other.controller.spec.ts
@@ -220,23 +220,21 @@ describe("BENEFICIAL OWNER OTHER controller", () => {
 
     test(`Service address from the ${BENEFICIAL_OWNER_OTHER_PAGE} is empty when same address is set to yes`, async () => {
       mockPrepareData.mockImplementation( () => BENEFICIAL_OWNER_OTHER_OBJECT_MOCK_WITH_SERVICE_ADDRESS_YES);
-      mockSetApplicationData.mockImplementation( () => setApplicationData);
       await request(app).post(BENEFICIAL_OWNER_OTHER_URL);
       expect(mapFieldsToDataObject).not.toHaveBeenCalledWith({}, ServiceAddressKeys, AddressKeys);
       const data: ApplicationDataType = mockSetApplicationData.mock.calls[0][1];
       expect(data[ServiceAddressKey]).toEqual({});
     });
 
-    test(`Public register data from the ${BENEFICIAL_OWNER_OTHER_PAGE} is present when same address is set to yes`, async () => {
+    test(`Public register data from the ${BENEFICIAL_OWNER_OTHER_PAGE} is present when is on register set to yes`, async () => {
       mockPrepareData.mockImplementation( () => BENEFICIAL_OWNER_OTHER_OBJECT_MOCK_WITH_PUBLIC_REGISTER_DATA_YES);
-      mockSetApplicationData.mockImplementation( () => setApplicationData);
       await request(app).post(BENEFICIAL_OWNER_OTHER_URL);
       const data: ApplicationDataType = mockSetApplicationData.mock.calls[0][1];
       expect(data[PublicRegisterNameKey]).toEqual("Reg");
       expect(data[RegistrationNumberKey]).toEqual("123456");
     });
 
-    test(`Public register data from the ${BENEFICIAL_OWNER_OTHER_PAGE} is empty when same address is set to no`, async () => {
+    test(`Public register data from the ${BENEFICIAL_OWNER_OTHER_PAGE} is empty when is on register set to no`, async () => {
       mockPrepareData.mockImplementation( () => BENEFICIAL_OWNER_OTHER_OBJECT_MOCK_WITH_PUBLIC_REGISTER_DATA_NO);
       await request(app).post(BENEFICIAL_OWNER_OTHER_URL);
       const data: ApplicationDataType = mockSetApplicationData.mock.calls[0][1];
@@ -287,23 +285,21 @@ describe("BENEFICIAL OWNER OTHER controller", () => {
 
     test(`Service address from the ${BENEFICIAL_OWNER_OTHER_PAGE} is empty when same address is set to yes`, async () => {
       mockPrepareData.mockImplementation( () => BENEFICIAL_OWNER_OTHER_OBJECT_MOCK_WITH_SERVICE_ADDRESS_YES);
-      mockSetApplicationData.mockImplementation( () => setApplicationData);
       await request(app).post(BENEFICIAL_OWNER_OTHER_URL + BO_OTHER_ID_URL);
       expect(mapFieldsToDataObject).not.toHaveBeenCalledWith({}, ServiceAddressKeys, AddressKeys);
       const data: ApplicationDataType = mockSetApplicationData.mock.calls[0][1];
       expect(data[ServiceAddressKey]).toEqual({});
     });
 
-    test(`Public register data from the ${BENEFICIAL_OWNER_OTHER_PAGE} is present when same address is set to yes`, async () => {
+    test(`Public register data from the ${BENEFICIAL_OWNER_OTHER_PAGE} is present when is on register set to yes`, async () => {
       mockPrepareData.mockImplementation( () => BENEFICIAL_OWNER_OTHER_OBJECT_MOCK_WITH_PUBLIC_REGISTER_DATA_YES);
-      mockSetApplicationData.mockImplementation( () => setApplicationData);
       await request(app).post(BENEFICIAL_OWNER_OTHER_URL + BO_OTHER_ID_URL);
       const data: ApplicationDataType = mockSetApplicationData.mock.calls[0][1];
       expect(data[PublicRegisterNameKey]).toEqual("Reg");
       expect(data[RegistrationNumberKey]).toEqual("123456");
     });
 
-    test(`Public register data from the ${BENEFICIAL_OWNER_OTHER_PAGE} is empty when same address is set to no`, async () => {
+    test(`Public register data from the ${BENEFICIAL_OWNER_OTHER_PAGE} is empty when is on register set to no`, async () => {
       mockPrepareData.mockImplementation( () => BENEFICIAL_OWNER_OTHER_OBJECT_MOCK_WITH_PUBLIC_REGISTER_DATA_NO);
       await request(app).post(BENEFICIAL_OWNER_OTHER_URL + BO_OTHER_ID_URL);
       const data: ApplicationDataType = mockSetApplicationData.mock.calls[0][1];

--- a/test/controllers/managing.officer.controller.spec.ts
+++ b/test/controllers/managing.officer.controller.spec.ts
@@ -1,3 +1,5 @@
+import { ServiceAddressKey, ServiceAddressKeys } from "../../src/model/address.model";
+
 jest.mock("ioredis");
 jest.mock('../../src/middleware/authentication.middleware');
 jest.mock('../../src/utils/application.data');
@@ -15,8 +17,18 @@ import {
   MANAGING_OFFICER_URL,
   REMOVE
 } from "../../src/config";
-import { getFromApplicationData, prepareData, removeFromApplicationData, setApplicationData } from '../../src/utils/application.data';
 import {
+  getFromApplicationData,
+  mapFieldsToDataObject,
+  prepareData,
+  removeFromApplicationData,
+  setApplicationData
+} from '../../src/utils/application.data';
+import {
+  MANAGING_OFFICER_INDIVIDUAL_OBJECT_MOCK_WITH_FORMER_NAMES_NO,
+  MANAGING_OFFICER_INDIVIDUAL_OBJECT_MOCK_WITH_FORMER_NAMES_YES,
+  MANAGING_OFFICER_INDIVIDUAL_OBJECT_MOCK_WITH_SERVICE_ADDRESS_NO,
+  MANAGING_OFFICER_INDIVIDUAL_OBJECT_MOCK_WITH_SERVICE_ADDRESS_YES,
   MANAGING_OFFICER_OBJECT_MOCK,
   MO_IND_ID,
   MO_IND_ID_URL,
@@ -30,9 +42,13 @@ import {
   MANAGING_OFFICER_PAGE_HEADING,
   SERVICE_UNAVAILABLE
 } from '../__mocks__/text.mock';
-import { managingOfficerType } from '../../src/model';
+import { ApplicationDataType, managingOfficerType } from '../../src/model';
 import { ErrorMessages } from '../../src/validation/error.messages';
-import { HasFormerNames, HasSameResidentialAddressKey } from '../../src/model/data.types.model';
+import {
+  AddressKeys, FormerNamesKey,
+  HasFormerNames,
+  HasSameResidentialAddressKey
+} from '../../src/model/data.types.model';
 import {
   MANAGING_OFFICER_INDIVIDUAL_WITH_INVALID_CHARS_MOCK,
   MANAGING_OFFICER_INDIVIDUAL_WITH_INVALID_CHARS_SERVICE_ADDRESS_MOCK,
@@ -49,12 +65,17 @@ const mockGetFromApplicationData = getFromApplicationData as jest.Mock;
 const mockSetApplicationData = setApplicationData as jest.Mock;
 const mockPrepareData = prepareData as jest.Mock;
 const mockRemoveFromApplicationData = removeFromApplicationData as unknown as jest.Mock;
+const mockMapFieldsToDataObject = mapFieldsToDataObject as jest.Mock;
+
+const DUMMY_DATA_OBJECT = { dummy: "data" };
 
 describe("MANAGING_OFFICER controller", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
     mockSetApplicationData.mockReset();
+    mockMapFieldsToDataObject.mockReset();
+    mockMapFieldsToDataObject.mockReturnValue(DUMMY_DATA_OBJECT);
   });
 
   describe("GET tests", () => {
@@ -119,7 +140,6 @@ describe("MANAGING_OFFICER controller", () => {
 
       expect(resp.header.location).toEqual(BENEFICIAL_OWNER_TYPE_URL);
     });
-
 
     test(`POST only radio buttons choices and redirect to ${BENEFICIAL_OWNER_TYPE_URL} page`, async () => {
       mockPrepareData.mockImplementationOnce( () =>  { return { [HasSameResidentialAddressKey]: 0, [HasFormerNames]: 0 }; } );
@@ -252,6 +272,45 @@ describe("MANAGING_OFFICER controller", () => {
       expect(resp.text).toContain(ErrorMessages.COUNTY_STATE_PROVINCE_REGION_INVALID_CHARACTERS);
       expect(resp.text).toContain(ErrorMessages.POSTCODE_ZIPCODE_INVALID_CHARACTERS);
     });
+
+    test(`Service address from the ${MANAGING_OFFICER_PAGE} is present when same address is set to no`, async () => {
+      mockPrepareData.mockImplementationOnce( () => MANAGING_OFFICER_INDIVIDUAL_OBJECT_MOCK_WITH_SERVICE_ADDRESS_NO);
+      await request(app)
+        .post(MANAGING_OFFICER_URL)
+        .send(REQ_BODY_MANAGING_OFFICER_MOCK_WITH_ADDRESS);
+      expect(mapFieldsToDataObject).toHaveBeenCalledWith(expect.anything(), ServiceAddressKeys, AddressKeys);
+      const data: ApplicationDataType = mockSetApplicationData.mock.calls[0][1];
+      expect(data[ServiceAddressKey]).toEqual(DUMMY_DATA_OBJECT);
+    });
+
+    test(`Service address from the ${MANAGING_OFFICER_PAGE} is empty when same address is set to yes`, async () => {
+      mockPrepareData.mockImplementationOnce( () => MANAGING_OFFICER_INDIVIDUAL_OBJECT_MOCK_WITH_SERVICE_ADDRESS_YES);
+      await request(app)
+        .post(MANAGING_OFFICER_URL)
+        .send(REQ_BODY_MANAGING_OFFICER_MOCK_WITH_ADDRESS);
+
+      expect(mapFieldsToDataObject).not.toHaveBeenCalledWith(expect.anything(), ServiceAddressKeys, AddressKeys);
+      const data: ApplicationDataType = mockSetApplicationData.mock.calls[0][1];
+      expect(data[ServiceAddressKey]).toEqual({});
+    });
+
+    test(`Former names data from the ${MANAGING_OFFICER_PAGE} is empty when has former names is set to yes`, async () => {
+      mockPrepareData.mockImplementationOnce( () => MANAGING_OFFICER_INDIVIDUAL_OBJECT_MOCK_WITH_FORMER_NAMES_YES);
+      await request(app)
+        .post(MANAGING_OFFICER_URL)
+        .send(REQ_BODY_MANAGING_OFFICER_MOCK_WITH_ADDRESS);
+      const data: ApplicationDataType = mockSetApplicationData.mock.calls[0][1];
+      expect(data[FormerNamesKey]).toEqual("John Doe");
+    });
+
+    test(`Former names data from the ${MANAGING_OFFICER_PAGE} is empty when when has former names is set to no`, async () => {
+      mockPrepareData.mockImplementationOnce( () => MANAGING_OFFICER_INDIVIDUAL_OBJECT_MOCK_WITH_FORMER_NAMES_NO);
+      await request(app)
+        .post(MANAGING_OFFICER_URL)
+        .send(REQ_BODY_MANAGING_OFFICER_MOCK_WITH_ADDRESS);
+      const data: ApplicationDataType = mockSetApplicationData.mock.calls[0][1];
+      expect(data[FormerNamesKey]).toEqual("");
+    });
   });
 
   describe("UPDATE tests", () => {
@@ -290,6 +349,45 @@ describe("MANAGING_OFFICER controller", () => {
 
       expect(resp.status).toEqual(302);
       expect(resp.header.location).toEqual(BENEFICIAL_OWNER_TYPE_URL);
+    });
+
+    test(`Service address from the ${MANAGING_OFFICER_PAGE} is present when same address is set to no`, async () => {
+      mockPrepareData.mockImplementationOnce( () => MANAGING_OFFICER_INDIVIDUAL_OBJECT_MOCK_WITH_SERVICE_ADDRESS_NO);
+      await request(app)
+        .post(MANAGING_OFFICER_URL)
+        .send(REQ_BODY_MANAGING_OFFICER_MOCK_WITH_ADDRESS);
+      expect(mapFieldsToDataObject).toHaveBeenCalledWith(expect.anything(), ServiceAddressKeys, AddressKeys);
+      const data: ApplicationDataType = mockSetApplicationData.mock.calls[0][1];
+      expect(data[ServiceAddressKey]).toEqual(DUMMY_DATA_OBJECT);
+    });
+
+    test(`Service address from the ${MANAGING_OFFICER_PAGE} is empty when same address is set to yes`, async () => {
+      mockPrepareData.mockImplementationOnce( () => MANAGING_OFFICER_INDIVIDUAL_OBJECT_MOCK_WITH_SERVICE_ADDRESS_YES );
+      await request(app)
+        .post(MANAGING_OFFICER_URL)
+        .send(REQ_BODY_MANAGING_OFFICER_MOCK_WITH_ADDRESS);
+
+      expect(mapFieldsToDataObject).not.toHaveBeenCalledWith(expect.anything(), ServiceAddressKeys, AddressKeys);
+      const data: ApplicationDataType = mockSetApplicationData.mock.calls[0][1];
+      expect(data[ServiceAddressKey]).toEqual({});
+    });
+
+    test(`Former names data from the ${MANAGING_OFFICER_PAGE} is empty when has former names is set to yes`, async () => {
+      mockPrepareData.mockImplementationOnce( () => MANAGING_OFFICER_INDIVIDUAL_OBJECT_MOCK_WITH_FORMER_NAMES_YES);
+      await request(app)
+        .post(MANAGING_OFFICER_URL)
+        .send(REQ_BODY_MANAGING_OFFICER_MOCK_WITH_ADDRESS);
+      const data: ApplicationDataType = mockSetApplicationData.mock.calls[0][1];
+      expect(data[FormerNamesKey]).toEqual("John Doe");
+    });
+
+    test(`Former names data from the ${MANAGING_OFFICER_PAGE} is empty when when has former names is set to no`, async () => {
+      mockPrepareData.mockImplementationOnce( () => MANAGING_OFFICER_INDIVIDUAL_OBJECT_MOCK_WITH_FORMER_NAMES_NO);
+      await request(app)
+        .post(MANAGING_OFFICER_URL)
+        .send(REQ_BODY_MANAGING_OFFICER_MOCK_WITH_ADDRESS);
+      const data: ApplicationDataType = mockSetApplicationData.mock.calls[0][1];
+      expect(data[FormerNamesKey]).toEqual("");
     });
   });
 

--- a/test/controllers/managing.officer.controller.spec.ts
+++ b/test/controllers/managing.officer.controller.spec.ts
@@ -1,5 +1,3 @@
-import { ServiceAddressKey, ServiceAddressKeys } from "../../src/model/address.model";
-
 jest.mock("ioredis");
 jest.mock('../../src/middleware/authentication.middleware');
 jest.mock('../../src/utils/application.data');
@@ -8,7 +6,7 @@ jest.mock("../../src/utils/logger");
 import { describe, expect, test, jest } from '@jest/globals';
 import { NextFunction, Request, Response } from "express";
 import request from "supertest";
-
+import { ServiceAddressKey, ServiceAddressKeys } from "../../src/model/address.model";
 import app from "../../src/app";
 import { authentication } from "../../src/middleware/authentication.middleware";
 import {
@@ -45,7 +43,7 @@ import {
 import { ApplicationDataType, managingOfficerType } from '../../src/model';
 import { ErrorMessages } from '../../src/validation/error.messages';
 import {
-  AddressKeys, FormerNamesKey,
+  AddressKeys,
   HasFormerNames,
   HasSameResidentialAddressKey
 } from '../../src/model/data.types.model';
@@ -55,7 +53,7 @@ import {
   MANAGING_OFFICER_INDIVIDUAL_WITH_MAX_LENGTH_FIELDS_MOCK
 } from '../__mocks__/validation.mock';
 import { logger } from "../../src/utils/logger";
-import { ManagingOfficerIndividual, ManagingOfficerKey } from '../../src/model/managing.officer.model';
+import { FormerNamesKey, ManagingOfficerIndividual, ManagingOfficerKey } from '../../src/model/managing.officer.model';
 
 const mockAuthenticationMiddleware = authentication as jest.Mock;
 mockAuthenticationMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => next() );


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/ROE-189


### Change description
Changed managing officer individual to clear the service address and former names fields when they are not selected.


### Work checklist

- [x] Tests added where applicable
- [x] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
