### PR TITLE
Roe 644 bo individual date value validation

### DIFF
--- a/src/validation/beneficial.owner.individual.validation.ts
+++ b/src/validation/beneficial.owner.individual.validation.ts
@@ -3,7 +3,7 @@ import { body } from "express-validator";
 import { ErrorMessages } from "./error.messages";
 import { usual_residential_service_address_beneficial_owner_validation, usual_residential_address_beneficial_owner_validation } from "./fields/address.validation";
 import { VALID_CHARACTERS } from "./regex/regex.validation";
-import { start_date_validations } from "./fields/date.validation";
+import { date_of_birth_validations, start_date_validations } from "./fields/date.validation";
 
 export const beneficialOwnerIndividual = [
   body("first_name").isLength({ max: 50 })
@@ -16,5 +16,6 @@ export const beneficialOwnerIndividual = [
 
   ...usual_residential_address_beneficial_owner_validation,
   ...usual_residential_service_address_beneficial_owner_validation,
-  ...start_date_validations
+  ...start_date_validations,
+  ...date_of_birth_validations
 ];

--- a/src/validation/beneficial.owner.individual.validation.ts
+++ b/src/validation/beneficial.owner.individual.validation.ts
@@ -3,6 +3,7 @@ import { body } from "express-validator";
 import { ErrorMessages } from "./error.messages";
 import { usual_residential_service_address_beneficial_owner_validation, usual_residential_address_beneficial_owner_validation } from "./fields/address.validation";
 import { VALID_CHARACTERS } from "./regex/regex.validation";
+import { start_date_validations } from "./fields/date.validation";
 
 export const beneficialOwnerIndividual = [
   body("first_name").isLength({ max: 50 })
@@ -14,5 +15,6 @@ export const beneficialOwnerIndividual = [
   body("nationality").matches(VALID_CHARACTERS).withMessage(ErrorMessages.NATIONALITY_INVALID_CHARACTERS),
 
   ...usual_residential_address_beneficial_owner_validation,
-  ...usual_residential_service_address_beneficial_owner_validation
+  ...usual_residential_service_address_beneficial_owner_validation,
+  ...start_date_validations
 ];

--- a/src/validation/custom.validation.ts
+++ b/src/validation/custom.validation.ts
@@ -43,7 +43,6 @@ export const checkDateIsInPast = (errMsg: string, day: string = "", month: strin
 
 export const checkDateValueIsValid = (errMsg: string, dayStr: string = "", monthStr: string = "", yearStr: string = "") => {
   const day = parseInt(dayStr), month = parseInt(monthStr), year = parseInt(yearStr);
-  console.log(">>>>>>>>>>>>>>>>> " + dayStr + " " + monthStr + " " + yearStr);
   if (isNaN(day) || isNaN(month) || isNaN(year) || !DateTime.utc(year, month, day).isValid) {
     throw new Error(errMsg);
   }

--- a/src/validation/custom.validation.ts
+++ b/src/validation/custom.validation.ts
@@ -43,7 +43,7 @@ export const checkDateIsInPast = (errMsg: string, day: string = "", month: strin
 
 export const checkDateValueIsValid = (errMsg: string, dayStr: string = "", monthStr: string = "", yearStr: string = "") => {
   const day = parseInt(dayStr), month = parseInt(monthStr), year = parseInt(yearStr);
-
+  console.log(">>>>>>>>>>>>>>>>> " + dayStr + " " + monthStr + " " + yearStr);
   if (isNaN(day) || isNaN(month) || isNaN(year) || !DateTime.utc(year, month, day).isValid) {
     throw new Error(errMsg);
   }

--- a/src/validation/error.messages.ts
+++ b/src/validation/error.messages.ts
@@ -29,7 +29,8 @@ export enum ErrorMessages {
   YEAR_OF_BIRTH = "Date of birth must include a year",
   DATE_OF_BIRTH = "Enter the individual person’s date of birth",
   MANAGING_OFFICER_START_DATE = "Enter the date it became a managing officer for the overseas entity",
-  INVALID_DATE = "Date they became managing officer must be a real date",
+  INVALID_DATE = "Date must be a real date",
+  INVALID_DATE_OF_BIRTH = "Date of birth must be a real date",
   // No radio selected
   SELECT_IF_ENTITY_HAS_SOLD_LAND = "Select yes if the entity has disposed of UK property or land since 28 February 2022",
   SELECT_IF_INDIVIDUAL_PERSON_HAS_FORMER_NAME = "Select yes if the individual person has any former names",

--- a/src/validation/fields/date.validation.ts
+++ b/src/validation/fields/date.validation.ts
@@ -14,7 +14,9 @@ export const start_date_validations = [
 ];
 
 export const date_of_birth_validations = [
-  body("date_of_birth").custom((value, { req }) => checkDate(ErrorMessages.DATE_OF_BIRTH, req.body["date_of_birth-day"], req.body["date_of_birth-month"], req.body["date_of_birth-year"]) ),
+  body("date_of_birth")
+    .custom((value, { req }) => checkDate(ErrorMessages.DATE_OF_BIRTH, req.body["date_of_birth-day"], req.body["date_of_birth-month"], req.body["date_of_birth-year"]) )
+    .custom((value, { req }) =>  checkDateValueIsValid(ErrorMessages.INVALID_DATE_OF_BIRTH, req.body["date_of_birth-day"], req.body["date_of_birth-month"], req.body["date_of_birth-year"])),
   body("date_of_birth-day").not().isEmpty({ ignore_whitespace: true }).withMessage(ErrorMessages.DAY_OF_BIRTH),
   body("date_of_birth-month").not().isEmpty({ ignore_whitespace: true }).withMessage(ErrorMessages.MONTH_OF_BIRTH),
   body("date_of_birth-year").not().isEmpty({ ignore_whitespace: true }).withMessage(ErrorMessages.YEAR_OF_BIRTH),

--- a/test/__mocks__/session.mock.ts
+++ b/test/__mocks__/session.mock.ts
@@ -275,8 +275,25 @@ export const BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK: beneficialOwnerIndividualT
   is_on_sanctions_list: 0
 };
 
+export const BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK_FOR_DATE_VALIDATION: beneficialOwnerIndividualType.BeneficialOwnerIndividual = {
+  id: BO_IND_ID,
+  first_name: "Joe",
+  last_name: "Bloggs",
+  date_of_birth: { day: "6", month: "9", year: "1977" },
+  nationality: "Russian",
+  usual_residential_address: ADDRESS,
+  is_service_address_same_as_usual_residential_address: 1,
+  service_address: ADDRESS,
+  start_date: { day: "1", month: "3", year: "1999" },
+  beneficial_owner_nature_of_control_types: [NatureOfControlType.OVER_25_PERCENT_OF_SHARES],
+  trustees_nature_of_control_types: [NatureOfControlType.OVER_25_PERCENT_OF_VOTING_RIGHTS],
+  non_legal_firm_members_nature_of_control_types: [NatureOfControlType.APPOINT_OR_REMOVE_MAJORITY_BOARD_DIRECTORS],
+  is_on_sanctions_list: 0
+};
+
 export const BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK_WITH_SERVICE_ADDRESS_YES: beneficialOwnerIndividualType.BeneficialOwnerIndividual = {
   id: BO_IND_ID,
+  start_date: { day: "6", month: "9", year: "1977" },
   is_service_address_same_as_usual_residential_address: yesNoResponse.Yes,
   service_address: ADDRESS
 };

--- a/test/__mocks__/session.mock.ts
+++ b/test/__mocks__/session.mock.ts
@@ -275,33 +275,53 @@ export const BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK: beneficialOwnerIndividualT
   is_on_sanctions_list: 0
 };
 
-export const BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK_FOR_DATE_VALIDATION: beneficialOwnerIndividualType.BeneficialOwnerIndividual = {
+export const BENEFICIAL_OWNER_INDIVIDUAL_REQ_BODY_OBJECT_MOCK = {
+  ...BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK,
+  ...start_date,
+  ...date_of_birth
+};
+
+export const BENEFICIAL_OWNER_INDIVIDUAL_REQ_BODY_OBJECT_MOCK_FOR_START_DATE = {
+  ...BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK,
+  ...start_date,
+  ...date_of_birth
+};
+
+export const BENEFICIAL_OWNER_INDIVIDUAL_REQ_BODY_OBJECT_MOCK_FOR_DATE_OF_BIRTH = {
+  ...BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK,
+  ...start_date,
+  ...date_of_birth
+};
+
+export const BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK_WITH_SERVICE_RADIO_BUTTONS: beneficialOwnerIndividualType.BeneficialOwnerIndividual = {
   id: BO_IND_ID,
-  first_name: "Joe",
-  last_name: "Bloggs",
-  date_of_birth: { day: "6", month: "9", year: "1977" },
-  nationality: "Russian",
-  usual_residential_address: ADDRESS,
-  is_service_address_same_as_usual_residential_address: 1,
-  service_address: ADDRESS,
-  start_date: { day: "1", month: "3", year: "1999" },
-  beneficial_owner_nature_of_control_types: [NatureOfControlType.OVER_25_PERCENT_OF_SHARES],
-  trustees_nature_of_control_types: [NatureOfControlType.OVER_25_PERCENT_OF_VOTING_RIGHTS],
-  non_legal_firm_members_nature_of_control_types: [NatureOfControlType.APPOINT_OR_REMOVE_MAJORITY_BOARD_DIRECTORS],
-  is_on_sanctions_list: 0
+  is_on_sanctions_list: 1,
+  is_service_address_same_as_usual_residential_address: 0,
+  ...start_date,
+  ...date_of_birth
+};
+
+export const BENEFICIAL_OWNER_INDIVIDUAL_REPLACE: beneficialOwnerIndividualType.BeneficialOwnerIndividual = {
+  id: BO_IND_ID,
+  first_name: "new name",
+  ...start_date,
+  ...date_of_birth
 };
 
 export const BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK_WITH_SERVICE_ADDRESS_YES: beneficialOwnerIndividualType.BeneficialOwnerIndividual = {
   id: BO_IND_ID,
-  start_date: { day: "6", month: "9", year: "1977" },
   is_service_address_same_as_usual_residential_address: yesNoResponse.Yes,
-  service_address: ADDRESS
+  service_address: ADDRESS,
+  ...start_date,
+  ...date_of_birth
 };
 
 export const BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK_WITH_SERVICE_ADDRESS_NO: beneficialOwnerIndividualType.BeneficialOwnerIndividual = {
   id: BO_IND_ID,
   is_service_address_same_as_usual_residential_address: yesNoResponse.No,
-  service_address: ADDRESS
+  service_address: ADDRESS,
+  ...start_date,
+  ...date_of_birth
 };
 
 export const BENEFICIAL_OWNER_OTHER_OBJECT_MOCK_WITH_SERVICE_ADDRESS_YES: beneficialOwnerOtherType.BeneficialOwnerOther = {

--- a/test/controllers/beneficial.owner.individual.controller.spec.ts
+++ b/test/controllers/beneficial.owner.individual.controller.spec.ts
@@ -301,7 +301,7 @@ describe("BENEFICIAL OWNER INDIVIDUAL controller", () => {
     });
 
 
-    test(`renders the current page ${BENEFICIAL_OWNER_INDIVIDUAL_PAGE} with INVALID_DATE error when date of brith day is outside valid numbers`, async () => {
+    test(`renders the current page ${BENEFICIAL_OWNER_INDIVIDUAL_PAGE} with INVALID_DATE error when date of birth day is outside valid numbers`, async () => {
       const beneficialOwnerIndividual = BENEFICIAL_OWNER_INDIVIDUAL_REQ_BODY_OBJECT_MOCK_FOR_DATE_OF_BIRTH;
       beneficialOwnerIndividual["date_of_birth-day"] =  "32";
       beneficialOwnerIndividual["date_of_birth-month"] = "11";
@@ -313,7 +313,7 @@ describe("BENEFICIAL OWNER INDIVIDUAL controller", () => {
       expect(resp.text).toContain(ErrorMessages.INVALID_DATE_OF_BIRTH);
     });
 
-    test(`renders the current page ${BENEFICIAL_OWNER_INDIVIDUAL_PAGE} with INVALID_DATE error when date of brith month is outside valid numbers`, async () => {
+    test(`renders the current page ${BENEFICIAL_OWNER_INDIVIDUAL_PAGE} with INVALID_DATE error when date of birth month is outside valid numbers`, async () => {
       const beneficialOwnerIndividual = BENEFICIAL_OWNER_INDIVIDUAL_REQ_BODY_OBJECT_MOCK_FOR_DATE_OF_BIRTH;
       beneficialOwnerIndividual["date_of_birth-day"] =  "30";
       beneficialOwnerIndividual["date_of_birth-month"] = "13";
@@ -325,7 +325,7 @@ describe("BENEFICIAL OWNER INDIVIDUAL controller", () => {
       expect(resp.text).toContain(ErrorMessages.INVALID_DATE_OF_BIRTH);
     });
 
-    test(`renders the current page ${BENEFICIAL_OWNER_INDIVIDUAL_PAGE} with INVALID_DATE error when date of brith day is zero`, async () => {
+    test(`renders the current page ${BENEFICIAL_OWNER_INDIVIDUAL_PAGE} with INVALID_DATE error when date of birth day is zero`, async () => {
       const beneficialOwnerIndividual = BENEFICIAL_OWNER_INDIVIDUAL_REQ_BODY_OBJECT_MOCK_FOR_DATE_OF_BIRTH;
       beneficialOwnerIndividual["date_of_birth-day"] =  "0";
       beneficialOwnerIndividual["date_of_birth-month"] = "11";
@@ -337,7 +337,7 @@ describe("BENEFICIAL OWNER INDIVIDUAL controller", () => {
       expect(resp.text).toContain(ErrorMessages.INVALID_DATE_OF_BIRTH);
     });
 
-    test(`renders the current page ${BENEFICIAL_OWNER_INDIVIDUAL_PAGE} with INVALID_DATE error when date of brith month is zero`, async () => {
+    test(`renders the current page ${BENEFICIAL_OWNER_INDIVIDUAL_PAGE} with INVALID_DATE error when date of birth month is zero`, async () => {
       const beneficialOwnerIndividual = BENEFICIAL_OWNER_INDIVIDUAL_REQ_BODY_OBJECT_MOCK_FOR_DATE_OF_BIRTH;
       beneficialOwnerIndividual["date_of_birth-day"] =  "30";
       beneficialOwnerIndividual["date_of_birth-month"] = "0";

--- a/test/controllers/beneficial.owner.individual.controller.spec.ts
+++ b/test/controllers/beneficial.owner.individual.controller.spec.ts
@@ -25,28 +25,28 @@ import {
 import {
   ANY_MESSAGE_ERROR,
   BENEFICIAL_OWNER_INDIVIDUAL_PAGE_HEADING,
-  BENEFICIAL_OWNER_TYPE_PAGE_REDIRECT,
+  // BENEFICIAL_OWNER_TYPE_PAGE_REDIRECT,
   ERROR_LIST,
   SERVICE_UNAVAILABLE
 } from '../__mocks__/text.mock';
 import {
-  BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK,
-  BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK_WITH_SERVICE_ADDRESS_NO,
-  BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK_WITH_SERVICE_ADDRESS_YES,
+  BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK, BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK_FOR_DATE_VALIDATION,
+  // BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK_WITH_SERVICE_ADDRESS_NO,
+  // BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK_WITH_SERVICE_ADDRESS_YES,
   BO_IND_ID,
   BO_IND_ID_URL,
-  REQ_BODY_BENEFICIAL_OWNER_INDIVIDUAL_EMPTY
+  // REQ_BODY_BENEFICIAL_OWNER_INDIVIDUAL_EMPTY,
 } from '../__mocks__/session.mock';
-import { BeneficialOwnerIndividual, BeneficialOwnerIndividualKey } from '../../src/model/beneficial.owner.individual.model';
-import { IsOnSanctionsListKey, HasSameResidentialAddressKey, AddressKeys } from '../../src/model/data.types.model';
+import { BeneficialOwnerIndividualKey } from '../../src/model/beneficial.owner.individual.model';
+// import { IsOnSanctionsListKey, HasSameResidentialAddressKey, AddressKeys } from '../../src/model/data.types.model';
 import {
   BENEFICIAL_OWNER_INDIVIDUAL_WITH_INVALID_CHARS_MOCK,
   BENEFICIAL_OWNER_INDIVIDUAL_WITH_INVALID_CHARS_SERVICE_ADDRESS_MOCK,
   BENEFICIAL_OWNER_INDIVIDUAL_WITH_MAX_LENGTH_FIELDS_MOCK
 } from '../__mocks__/validation.mock';
 import { ErrorMessages } from '../../src/validation/error.messages';
-import { ServiceAddressKey, ServiceAddressKeys } from "../../src/model/address.model";
-import { ApplicationDataType } from '../../src/model';
+// import { ServiceAddressKey, ServiceAddressKeys } from "../../src/model/address.model";
+// import { ApplicationDataType } from '../../src/model';
 import { hasBeneficialOwnersStatement } from "../../src/middleware/navigation/has.beneficial.owners.statement.middleware";
 
 const mockHasBeneficialOwnersStatementMiddleware = hasBeneficialOwnersStatement as jest.Mock;
@@ -105,10 +105,13 @@ describe("BENEFICIAL OWNER INDIVIDUAL controller", () => {
   });
 
   describe("POST tests", () => {
+    /*
     test(`redirects to ${BENEFICIAL_OWNER_TYPE_URL} page`, async () => {
       mockPrepareData.mockImplementationOnce( () => BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK );
 
-      const resp = await request(app).post(BENEFICIAL_OWNER_INDIVIDUAL_URL);
+      const resp = await request(app)
+        .post(BENEFICIAL_OWNER_INDIVIDUAL_URL)
+        .send(BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK); // Added now should have data
 
       expect(resp.status).toEqual(302);
       expect(resp.header.location).toEqual(BENEFICIAL_OWNER_TYPE_URL);
@@ -134,7 +137,8 @@ describe("BENEFICIAL OWNER INDIVIDUAL controller", () => {
     test(`POST empty object and redirect to ${BENEFICIAL_OWNER_TYPE_URL} page`, async () => {
       mockPrepareData.mockImplementationOnce( () => REQ_BODY_BENEFICIAL_OWNER_INDIVIDUAL_EMPTY );
 
-      const resp = await request(app).post(BENEFICIAL_OWNER_INDIVIDUAL_URL);
+      const resp = await request(app)
+        .post(BENEFICIAL_OWNER_INDIVIDUAL_URL);
 
       expect(resp.status).toEqual(302);
       expect(resp.header.location).toEqual(BENEFICIAL_OWNER_TYPE_URL);
@@ -153,7 +157,7 @@ describe("BENEFICIAL OWNER INDIVIDUAL controller", () => {
 
       expect(resp.header.location).toEqual(BENEFICIAL_OWNER_TYPE_URL);
     });
-
+   */
     test("catch error when posting data", async () => {
       mockPrepareData.mockImplementationOnce( () => { throw new Error(ANY_MESSAGE_ERROR); });
       const resp = await request(app).post(BENEFICIAL_OWNER_INDIVIDUAL_URL);
@@ -215,7 +219,7 @@ describe("BENEFICIAL OWNER INDIVIDUAL controller", () => {
       expect(resp.text).toContain( ErrorMessages.COUNTY_STATE_PROVINCE_REGION_INVALID_CHARACTERS);
       expect(resp.text).toContain( ErrorMessages.POSTCODE_ZIPCODE_INVALID_CHARACTERS);
     });
-
+    /*
     test(`Service address from the ${BENEFICIAL_OWNER_INDIVIDUAL_PAGE} is present when same address is set to no`, async () => {
       mockPrepareData.mockImplementation( () => BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK_WITH_SERVICE_ADDRESS_NO);
       await request(app).post(BENEFICIAL_OWNER_INDIVIDUAL_URL);
@@ -231,8 +235,56 @@ describe("BENEFICIAL OWNER INDIVIDUAL controller", () => {
       const data: ApplicationDataType = mockSetApplicationData.mock.calls[0][1];
       expect(data[ServiceAddressKey]).toEqual({});
     });
-  });
+   */
+    test(`renders the current page ${BENEFICIAL_OWNER_INDIVIDUAL_PAGE} with INVALID_DATE error when day is outside valid numbers`, async () => {
+      const beneficialOwnerIndividual = BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK_FOR_DATE_VALIDATION;
+      beneficialOwnerIndividual["start_date-day"] =  "32";
+      beneficialOwnerIndividual["start_date-month"] = "11";
+      beneficialOwnerIndividual["start_date-year"] = "2020";
+      const resp = await request(app).post(BENEFICIAL_OWNER_INDIVIDUAL_URL)
+        .send(beneficialOwnerIndividual);
+      expect(resp.status).toEqual(200);
+      expect(resp.text).toContain(BENEFICIAL_OWNER_INDIVIDUAL_PAGE_HEADING);
+      expect(resp.text).toContain(ErrorMessages.INVALID_DATE);
+    });
 
+    test(`renders the current page ${BENEFICIAL_OWNER_INDIVIDUAL_PAGE} with INVALID_DATE error when month is outside valid numbers`, async () => {
+      const beneficialOwnerIndividual = BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK_FOR_DATE_VALIDATION;
+      beneficialOwnerIndividual["start_date-day"] =  "30";
+      beneficialOwnerIndividual["start_date-month"] = "13";
+      beneficialOwnerIndividual["start_date-year"] = "2020";
+      const resp = await request(app).post(BENEFICIAL_OWNER_INDIVIDUAL_URL)
+        .send(beneficialOwnerIndividual);
+      expect(resp.status).toEqual(200);
+      expect(resp.text).toContain(BENEFICIAL_OWNER_INDIVIDUAL_PAGE_HEADING);
+      expect(resp.text).toContain(ErrorMessages.INVALID_DATE);
+    });
+
+    test(`renders the current page ${BENEFICIAL_OWNER_INDIVIDUAL_PAGE} with INVALID_DATE error when day is zero`, async () => {
+      const beneficialOwnerIndividual = BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK_FOR_DATE_VALIDATION;
+      beneficialOwnerIndividual["start_date-day"] =  "0";
+      beneficialOwnerIndividual["start_date-month"] = "11";
+      beneficialOwnerIndividual["start_date-year"] = "2020";
+      const resp = await request(app).post(BENEFICIAL_OWNER_INDIVIDUAL_URL)
+        .send(beneficialOwnerIndividual);
+      expect(resp.status).toEqual(200);
+      expect(resp.text).toContain(BENEFICIAL_OWNER_INDIVIDUAL_PAGE_HEADING);
+      expect(resp.text).toContain(ErrorMessages.INVALID_DATE);
+    });
+
+    test(`renders the current page ${BENEFICIAL_OWNER_INDIVIDUAL_PAGE} with INVALID_DATE error when month is zero`, async () => {
+      const beneficialOwnerIndividual = BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK_FOR_DATE_VALIDATION;
+      beneficialOwnerIndividual["start_date-day"] =  "30";
+      beneficialOwnerIndividual["start_date-month"] = "0";
+      beneficialOwnerIndividual["start_date-year"] = "2020";
+      const resp = await request(app).post(BENEFICIAL_OWNER_INDIVIDUAL_URL)
+        .send(beneficialOwnerIndividual);
+      expect(resp.status).toEqual(200);
+      expect(resp.text).toContain(BENEFICIAL_OWNER_INDIVIDUAL_PAGE_HEADING);
+      expect(resp.text).toContain(ErrorMessages.INVALID_DATE);
+    });
+  });
+  /*
   describe("UPDATE tests", () => {
     test(`redirects to the ${BENEFICIAL_OWNER_TYPE_URL} page`, async () => {
       mockPrepareData.mockReturnValueOnce(BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK);
@@ -281,7 +333,7 @@ describe("BENEFICIAL OWNER INDIVIDUAL controller", () => {
       expect(data[ServiceAddressKey]).toEqual({});
     });
   });
-
+  */
   describe("REMOVE tests", () => {
     test(`redirects to the ${BENEFICIAL_OWNER_TYPE_URL} page`, async () => {
       mockPrepareData.mockReturnValueOnce(BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK);

--- a/test/controllers/beneficial.owner.individual.controller.spec.ts
+++ b/test/controllers/beneficial.owner.individual.controller.spec.ts
@@ -25,28 +25,33 @@ import {
 import {
   ANY_MESSAGE_ERROR,
   BENEFICIAL_OWNER_INDIVIDUAL_PAGE_HEADING,
-  // BENEFICIAL_OWNER_TYPE_PAGE_REDIRECT,
+  BENEFICIAL_OWNER_TYPE_PAGE_REDIRECT,
   ERROR_LIST,
   SERVICE_UNAVAILABLE
 } from '../__mocks__/text.mock';
 import {
-  BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK, BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK_FOR_DATE_VALIDATION,
-  // BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK_WITH_SERVICE_ADDRESS_NO,
-  // BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK_WITH_SERVICE_ADDRESS_YES,
+  BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK,
+  BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK_WITH_SERVICE_ADDRESS_NO,
+  BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK_WITH_SERVICE_ADDRESS_YES,
+  BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK_WITH_SERVICE_RADIO_BUTTONS,
+  BENEFICIAL_OWNER_INDIVIDUAL_REPLACE,
+  BENEFICIAL_OWNER_INDIVIDUAL_REQ_BODY_OBJECT_MOCK,
+  BENEFICIAL_OWNER_INDIVIDUAL_REQ_BODY_OBJECT_MOCK_FOR_DATE_OF_BIRTH,
+  BENEFICIAL_OWNER_INDIVIDUAL_REQ_BODY_OBJECT_MOCK_FOR_START_DATE,
   BO_IND_ID,
   BO_IND_ID_URL,
-  // REQ_BODY_BENEFICIAL_OWNER_INDIVIDUAL_EMPTY,
+  REQ_BODY_BENEFICIAL_OWNER_INDIVIDUAL_EMPTY,
 } from '../__mocks__/session.mock';
 import { BeneficialOwnerIndividualKey } from '../../src/model/beneficial.owner.individual.model';
-// import { IsOnSanctionsListKey, HasSameResidentialAddressKey, AddressKeys } from '../../src/model/data.types.model';
+import { AddressKeys } from '../../src/model/data.types.model';
 import {
   BENEFICIAL_OWNER_INDIVIDUAL_WITH_INVALID_CHARS_MOCK,
   BENEFICIAL_OWNER_INDIVIDUAL_WITH_INVALID_CHARS_SERVICE_ADDRESS_MOCK,
   BENEFICIAL_OWNER_INDIVIDUAL_WITH_MAX_LENGTH_FIELDS_MOCK
 } from '../__mocks__/validation.mock';
 import { ErrorMessages } from '../../src/validation/error.messages';
-// import { ServiceAddressKey, ServiceAddressKeys } from "../../src/model/address.model";
-// import { ApplicationDataType } from '../../src/model';
+import { ServiceAddressKey, ServiceAddressKeys } from "../../src/model/address.model";
+import { ApplicationDataType } from '../../src/model';
 import { hasBeneficialOwnersStatement } from "../../src/middleware/navigation/has.beneficial.owners.statement.middleware";
 
 const mockHasBeneficialOwnersStatementMiddleware = hasBeneficialOwnersStatement as jest.Mock;
@@ -105,22 +110,24 @@ describe("BENEFICIAL OWNER INDIVIDUAL controller", () => {
   });
 
   describe("POST tests", () => {
-    /*
+
     test(`redirects to ${BENEFICIAL_OWNER_TYPE_URL} page`, async () => {
-      mockPrepareData.mockImplementationOnce( () => BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK );
+      mockPrepareData.mockImplementationOnce( () => BENEFICIAL_OWNER_INDIVIDUAL_REQ_BODY_OBJECT_MOCK );
 
       const resp = await request(app)
         .post(BENEFICIAL_OWNER_INDIVIDUAL_URL)
-        .send(BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK); // Added now should have data
+        .send(BENEFICIAL_OWNER_INDIVIDUAL_REQ_BODY_OBJECT_MOCK);
 
       expect(resp.status).toEqual(302);
       expect(resp.header.location).toEqual(BENEFICIAL_OWNER_TYPE_URL);
     });
 
     test(`POST only radio buttons choices and redirect to ${BENEFICIAL_OWNER_TYPE_URL} page`, async () => {
-      mockPrepareData.mockImplementationOnce( () =>  { return { [IsOnSanctionsListKey]: "1", [HasSameResidentialAddressKey]: "0" }; } );
+      mockPrepareData.mockImplementationOnce( () =>  { return BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK_WITH_SERVICE_RADIO_BUTTONS; } );
 
-      const resp = await request(app).post(BENEFICIAL_OWNER_INDIVIDUAL_URL);
+      const resp = await request(app)
+        .post(BENEFICIAL_OWNER_INDIVIDUAL_URL)
+        .send(BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK_WITH_SERVICE_RADIO_BUTTONS);
 
       expect(resp.status).toEqual(302);
       expect(resp.header.location).toEqual(BENEFICIAL_OWNER_TYPE_URL);
@@ -128,7 +135,9 @@ describe("BENEFICIAL OWNER INDIVIDUAL controller", () => {
 
     test(`redirect to the ${BENEFICIAL_OWNER_TYPE_URL} page after a successful post from ${BENEFICIAL_OWNER_INDIVIDUAL_PAGE} page with service address data`, async () => {
       mockPrepareData.mockImplementation( () => BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK_WITH_SERVICE_ADDRESS_NO );
-      const resp = await request(app).post(BENEFICIAL_OWNER_INDIVIDUAL_URL);
+      const resp = await request(app)
+        .post(BENEFICIAL_OWNER_INDIVIDUAL_URL)
+        .send(BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK_WITH_SERVICE_ADDRESS_NO);
 
       expect(resp.status).toEqual(302);
       expect(resp.text).toContain(BENEFICIAL_OWNER_TYPE_PAGE_REDIRECT);
@@ -138,26 +147,29 @@ describe("BENEFICIAL OWNER INDIVIDUAL controller", () => {
       mockPrepareData.mockImplementationOnce( () => REQ_BODY_BENEFICIAL_OWNER_INDIVIDUAL_EMPTY );
 
       const resp = await request(app)
-        .post(BENEFICIAL_OWNER_INDIVIDUAL_URL);
+        .post(BENEFICIAL_OWNER_INDIVIDUAL_URL)
+        .send(REQ_BODY_BENEFICIAL_OWNER_INDIVIDUAL_EMPTY);
 
-      expect(resp.status).toEqual(302);
-      expect(resp.header.location).toEqual(BENEFICIAL_OWNER_TYPE_URL);
+      expect(resp.status).toEqual(200);
+      expect(resp.header.location).not.toEqual(BENEFICIAL_OWNER_TYPE_URL);
     });
 
     test(`adds data to the session and redirects to the ${BENEFICIAL_OWNER_TYPE_URL} page`, async () => {
-      mockPrepareData.mockImplementationOnce( () => BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK );
+      mockPrepareData.mockImplementationOnce( () => BENEFICIAL_OWNER_INDIVIDUAL_REQ_BODY_OBJECT_MOCK );
 
-      const resp = await request(app).post(BENEFICIAL_OWNER_INDIVIDUAL_URL);
+      const resp = await request(app)
+        .post(BENEFICIAL_OWNER_INDIVIDUAL_URL)
+        .send(BENEFICIAL_OWNER_INDIVIDUAL_REQ_BODY_OBJECT_MOCK);
 
       const beneficialOwnerIndividual = mockSetApplicationData.mock.calls[0][1];
 
-      expect(beneficialOwnerIndividual).toEqual(BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK);
+      expect(beneficialOwnerIndividual).toEqual(BENEFICIAL_OWNER_INDIVIDUAL_REQ_BODY_OBJECT_MOCK);
       expect(mockSetApplicationData.mock.calls[0][2]).toEqual(BeneficialOwnerIndividualKey);
       expect(resp.status).toEqual(302);
 
       expect(resp.header.location).toEqual(BENEFICIAL_OWNER_TYPE_URL);
     });
-   */
+
     test("catch error when posting data", async () => {
       mockPrepareData.mockImplementationOnce( () => { throw new Error(ANY_MESSAGE_ERROR); });
       const resp = await request(app).post(BENEFICIAL_OWNER_INDIVIDUAL_URL);
@@ -219,25 +231,29 @@ describe("BENEFICIAL OWNER INDIVIDUAL controller", () => {
       expect(resp.text).toContain( ErrorMessages.COUNTY_STATE_PROVINCE_REGION_INVALID_CHARACTERS);
       expect(resp.text).toContain( ErrorMessages.POSTCODE_ZIPCODE_INVALID_CHARACTERS);
     });
-    /*
+
     test(`Service address from the ${BENEFICIAL_OWNER_INDIVIDUAL_PAGE} is present when same address is set to no`, async () => {
       mockPrepareData.mockImplementation( () => BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK_WITH_SERVICE_ADDRESS_NO);
-      await request(app).post(BENEFICIAL_OWNER_INDIVIDUAL_URL);
-      expect(mapFieldsToDataObject).toHaveBeenCalledWith({}, ServiceAddressKeys, AddressKeys);
+      await request(app)
+        .post(BENEFICIAL_OWNER_INDIVIDUAL_URL)
+        .send(BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK_WITH_SERVICE_ADDRESS_NO);
+      expect(mapFieldsToDataObject).toHaveBeenCalledWith(expect.anything(), ServiceAddressKeys, AddressKeys);
       const data: ApplicationDataType = mockSetApplicationData.mock.calls[0][1];
       expect(data[ServiceAddressKey]).toEqual(DUMMY_DATA_OBJECT);
     });
 
     test(`Service address from the ${BENEFICIAL_OWNER_INDIVIDUAL_PAGE} is empty when same address is set to yes`, async () => {
       mockPrepareData.mockImplementation( () => BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK_WITH_SERVICE_ADDRESS_YES);
-      await request(app).post(BENEFICIAL_OWNER_INDIVIDUAL_URL);
-      expect(mapFieldsToDataObject).not.toHaveBeenCalledWith({}, ServiceAddressKeys, AddressKeys);
+      await request(app)
+        .post(BENEFICIAL_OWNER_INDIVIDUAL_URL)
+        .send(BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK_WITH_SERVICE_ADDRESS_YES);
+      expect(mapFieldsToDataObject).not.toHaveBeenCalledWith(expect.anything(), ServiceAddressKeys, AddressKeys);
       const data: ApplicationDataType = mockSetApplicationData.mock.calls[0][1];
       expect(data[ServiceAddressKey]).toEqual({});
     });
-   */
-    test(`renders the current page ${BENEFICIAL_OWNER_INDIVIDUAL_PAGE} with INVALID_DATE error when day is outside valid numbers`, async () => {
-      const beneficialOwnerIndividual = BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK_FOR_DATE_VALIDATION;
+
+    test(`renders the current page ${BENEFICIAL_OWNER_INDIVIDUAL_PAGE} with INVALID_DATE error when start date day is outside valid numbers`, async () => {
+      const beneficialOwnerIndividual = BENEFICIAL_OWNER_INDIVIDUAL_REQ_BODY_OBJECT_MOCK_FOR_START_DATE;
       beneficialOwnerIndividual["start_date-day"] =  "32";
       beneficialOwnerIndividual["start_date-month"] = "11";
       beneficialOwnerIndividual["start_date-year"] = "2020";
@@ -248,8 +264,8 @@ describe("BENEFICIAL OWNER INDIVIDUAL controller", () => {
       expect(resp.text).toContain(ErrorMessages.INVALID_DATE);
     });
 
-    test(`renders the current page ${BENEFICIAL_OWNER_INDIVIDUAL_PAGE} with INVALID_DATE error when month is outside valid numbers`, async () => {
-      const beneficialOwnerIndividual = BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK_FOR_DATE_VALIDATION;
+    test(`renders the current page ${BENEFICIAL_OWNER_INDIVIDUAL_PAGE} with INVALID_DATE error when start date month is outside valid numbers`, async () => {
+      const beneficialOwnerIndividual = BENEFICIAL_OWNER_INDIVIDUAL_REQ_BODY_OBJECT_MOCK_FOR_START_DATE;
       beneficialOwnerIndividual["start_date-day"] =  "30";
       beneficialOwnerIndividual["start_date-month"] = "13";
       beneficialOwnerIndividual["start_date-year"] = "2020";
@@ -260,8 +276,8 @@ describe("BENEFICIAL OWNER INDIVIDUAL controller", () => {
       expect(resp.text).toContain(ErrorMessages.INVALID_DATE);
     });
 
-    test(`renders the current page ${BENEFICIAL_OWNER_INDIVIDUAL_PAGE} with INVALID_DATE error when day is zero`, async () => {
-      const beneficialOwnerIndividual = BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK_FOR_DATE_VALIDATION;
+    test(`renders the current page ${BENEFICIAL_OWNER_INDIVIDUAL_PAGE} with INVALID_DATE error when start date day is zero`, async () => {
+      const beneficialOwnerIndividual = BENEFICIAL_OWNER_INDIVIDUAL_REQ_BODY_OBJECT_MOCK_FOR_START_DATE;
       beneficialOwnerIndividual["start_date-day"] =  "0";
       beneficialOwnerIndividual["start_date-month"] = "11";
       beneficialOwnerIndividual["start_date-year"] = "2020";
@@ -272,8 +288,8 @@ describe("BENEFICIAL OWNER INDIVIDUAL controller", () => {
       expect(resp.text).toContain(ErrorMessages.INVALID_DATE);
     });
 
-    test(`renders the current page ${BENEFICIAL_OWNER_INDIVIDUAL_PAGE} with INVALID_DATE error when month is zero`, async () => {
-      const beneficialOwnerIndividual = BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK_FOR_DATE_VALIDATION;
+    test(`renders the current page ${BENEFICIAL_OWNER_INDIVIDUAL_PAGE} with INVALID_DATE error when start date month is zero`, async () => {
+      const beneficialOwnerIndividual = BENEFICIAL_OWNER_INDIVIDUAL_REQ_BODY_OBJECT_MOCK_FOR_START_DATE;
       beneficialOwnerIndividual["start_date-day"] =  "30";
       beneficialOwnerIndividual["start_date-month"] = "0";
       beneficialOwnerIndividual["start_date-year"] = "2020";
@@ -283,12 +299,63 @@ describe("BENEFICIAL OWNER INDIVIDUAL controller", () => {
       expect(resp.text).toContain(BENEFICIAL_OWNER_INDIVIDUAL_PAGE_HEADING);
       expect(resp.text).toContain(ErrorMessages.INVALID_DATE);
     });
+
+
+    test(`renders the current page ${BENEFICIAL_OWNER_INDIVIDUAL_PAGE} with INVALID_DATE error when date of brith day is outside valid numbers`, async () => {
+      const beneficialOwnerIndividual = BENEFICIAL_OWNER_INDIVIDUAL_REQ_BODY_OBJECT_MOCK_FOR_DATE_OF_BIRTH;
+      beneficialOwnerIndividual["date_of_birth-day"] =  "32";
+      beneficialOwnerIndividual["date_of_birth-month"] = "11";
+      beneficialOwnerIndividual["date_of_birth-year"] = "1970";
+      const resp = await request(app).post(BENEFICIAL_OWNER_INDIVIDUAL_URL)
+        .send(beneficialOwnerIndividual);
+      expect(resp.status).toEqual(200);
+      expect(resp.text).toContain(BENEFICIAL_OWNER_INDIVIDUAL_PAGE_HEADING);
+      expect(resp.text).toContain(ErrorMessages.INVALID_DATE_OF_BIRTH);
+    });
+
+    test(`renders the current page ${BENEFICIAL_OWNER_INDIVIDUAL_PAGE} with INVALID_DATE error when date of brith month is outside valid numbers`, async () => {
+      const beneficialOwnerIndividual = BENEFICIAL_OWNER_INDIVIDUAL_REQ_BODY_OBJECT_MOCK_FOR_DATE_OF_BIRTH;
+      beneficialOwnerIndividual["date_of_birth-day"] =  "30";
+      beneficialOwnerIndividual["date_of_birth-month"] = "13";
+      beneficialOwnerIndividual["date_of_birth-year"] = "1970";
+      const resp = await request(app).post(BENEFICIAL_OWNER_INDIVIDUAL_URL)
+        .send(beneficialOwnerIndividual);
+      expect(resp.status).toEqual(200);
+      expect(resp.text).toContain(BENEFICIAL_OWNER_INDIVIDUAL_PAGE_HEADING);
+      expect(resp.text).toContain(ErrorMessages.INVALID_DATE_OF_BIRTH);
+    });
+
+    test(`renders the current page ${BENEFICIAL_OWNER_INDIVIDUAL_PAGE} with INVALID_DATE error when date of brith day is zero`, async () => {
+      const beneficialOwnerIndividual = BENEFICIAL_OWNER_INDIVIDUAL_REQ_BODY_OBJECT_MOCK_FOR_DATE_OF_BIRTH;
+      beneficialOwnerIndividual["date_of_birth-day"] =  "0";
+      beneficialOwnerIndividual["date_of_birth-month"] = "11";
+      beneficialOwnerIndividual["date_of_birth-year"] = "1970";
+      const resp = await request(app).post(BENEFICIAL_OWNER_INDIVIDUAL_URL)
+        .send(beneficialOwnerIndividual);
+      expect(resp.status).toEqual(200);
+      expect(resp.text).toContain(BENEFICIAL_OWNER_INDIVIDUAL_PAGE_HEADING);
+      expect(resp.text).toContain(ErrorMessages.INVALID_DATE_OF_BIRTH);
+    });
+
+    test(`renders the current page ${BENEFICIAL_OWNER_INDIVIDUAL_PAGE} with INVALID_DATE error when date of brith month is zero`, async () => {
+      const beneficialOwnerIndividual = BENEFICIAL_OWNER_INDIVIDUAL_REQ_BODY_OBJECT_MOCK_FOR_DATE_OF_BIRTH;
+      beneficialOwnerIndividual["date_of_birth-day"] =  "30";
+      beneficialOwnerIndividual["date_of_birth-month"] = "0";
+      beneficialOwnerIndividual["date_of_birth-year"] = "1970";
+      const resp = await request(app).post(BENEFICIAL_OWNER_INDIVIDUAL_URL)
+        .send(beneficialOwnerIndividual);
+      expect(resp.status).toEqual(200);
+      expect(resp.text).toContain(BENEFICIAL_OWNER_INDIVIDUAL_PAGE_HEADING);
+      expect(resp.text).toContain(ErrorMessages.INVALID_DATE_OF_BIRTH);
+    });
   });
-  /*
+
   describe("UPDATE tests", () => {
     test(`redirects to the ${BENEFICIAL_OWNER_TYPE_URL} page`, async () => {
-      mockPrepareData.mockReturnValueOnce(BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK);
-      const resp = await request(app).post(BENEFICIAL_OWNER_INDIVIDUAL_URL + BO_IND_ID_URL);
+      mockPrepareData.mockReturnValueOnce(BENEFICIAL_OWNER_INDIVIDUAL_REQ_BODY_OBJECT_MOCK);
+      const resp = await request(app)
+        .post(BENEFICIAL_OWNER_INDIVIDUAL_URL + BO_IND_ID_URL)
+        .send(BENEFICIAL_OWNER_INDIVIDUAL_REQ_BODY_OBJECT_MOCK);
 
       expect(resp.status).toEqual(302);
       expect(resp.header.location).toEqual(BENEFICIAL_OWNER_TYPE_URL);
@@ -296,16 +363,19 @@ describe("BENEFICIAL OWNER INDIVIDUAL controller", () => {
 
     test("catch error when updating data", async () => {
       mockSetApplicationData.mockImplementationOnce( () => { throw new Error(ANY_MESSAGE_ERROR); });
-      const resp = await request(app).post(BENEFICIAL_OWNER_INDIVIDUAL_URL + BO_IND_ID_URL);
+      const resp = await request(app)
+        .post(BENEFICIAL_OWNER_INDIVIDUAL_URL + BO_IND_ID_URL)
+        .send(BENEFICIAL_OWNER_INDIVIDUAL_REQ_BODY_OBJECT_MOCK);
 
       expect(resp.status).toEqual(500);
       expect(resp.text).toContain(SERVICE_UNAVAILABLE);
     });
 
     test(`replaces existing object on submit`, async () => {
-      const newIndData: BeneficialOwnerIndividual = { id: BO_IND_ID, first_name: "new name" };
-      mockPrepareData.mockReturnValueOnce(newIndData);
-      const resp = await request(app).post(BENEFICIAL_OWNER_INDIVIDUAL_URL + BO_IND_ID_URL);
+      mockPrepareData.mockReturnValueOnce(BENEFICIAL_OWNER_INDIVIDUAL_REPLACE);
+      const resp = await request(app)
+        .post(BENEFICIAL_OWNER_INDIVIDUAL_URL + BO_IND_ID_URL)
+        .send(BENEFICIAL_OWNER_INDIVIDUAL_REPLACE);
 
       expect(mockRemoveFromApplicationData.mock.calls[0][1]).toEqual(BeneficialOwnerIndividualKey);
       expect(mockRemoveFromApplicationData.mock.calls[0][2]).toEqual(BO_IND_ID);
@@ -319,21 +389,25 @@ describe("BENEFICIAL OWNER INDIVIDUAL controller", () => {
 
     test(`Service address from the ${BENEFICIAL_OWNER_INDIVIDUAL_PAGE} is present when same address is set to no`, async () => {
       mockPrepareData.mockImplementation( () => BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK_WITH_SERVICE_ADDRESS_NO);
-      await request(app).post(BENEFICIAL_OWNER_INDIVIDUAL_URL + BO_IND_ID_URL);
-      expect(mapFieldsToDataObject).toHaveBeenCalledWith({}, ServiceAddressKeys, AddressKeys);
+      await request(app)
+        .post(BENEFICIAL_OWNER_INDIVIDUAL_URL + BO_IND_ID_URL)
+        .send(BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK_WITH_SERVICE_ADDRESS_NO);
+      expect(mapFieldsToDataObject).toHaveBeenCalledWith(expect.anything(), ServiceAddressKeys, AddressKeys);
       const data: ApplicationDataType = mockSetApplicationData.mock.calls[0][1];
       expect(data[ServiceAddressKey]).toEqual(DUMMY_DATA_OBJECT);
     });
 
     test(`Service address from the ${BENEFICIAL_OWNER_INDIVIDUAL_PAGE} is empty when same address is set to yes`, async () => {
       mockPrepareData.mockImplementation( () => BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK_WITH_SERVICE_ADDRESS_YES);
-      await request(app).post(BENEFICIAL_OWNER_INDIVIDUAL_URL + BO_IND_ID_URL);
-      expect(mapFieldsToDataObject).not.toHaveBeenCalledWith({}, ServiceAddressKeys, AddressKeys);
+      await request(app)
+        .post(BENEFICIAL_OWNER_INDIVIDUAL_URL + BO_IND_ID_URL)
+        .send(BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK_WITH_SERVICE_ADDRESS_YES);
+      expect(mapFieldsToDataObject).not.toHaveBeenCalledWith(expect.anything(), ServiceAddressKeys, AddressKeys);
       const data: ApplicationDataType = mockSetApplicationData.mock.calls[0][1];
       expect(data[ServiceAddressKey]).toEqual({});
     });
   });
-  */
+
   describe("REMOVE tests", () => {
     test(`redirects to the ${BENEFICIAL_OWNER_TYPE_URL} page`, async () => {
       mockPrepareData.mockReturnValueOnce(BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK);


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/ROE-644

### Change description

Had to update a number of unit tests to send data, so they can test what they are supposed to without triggering the date validation error.

Changed "POST empty object and redirect to ${BENEFICIAL_OWNER_TYPE_URL} page"
as I am not sure that it was correct anymore and empty page submit should have errors rather than redirect to the next page.

Also the error messages seem to specific: "Date they became a beneficial owner must be a real date" not sure how that would fit in with the validation we may need something more generic so have changed this for now and we can go back to the analysts about this.

### Work checklist

- [x] Tests added where applicable
- [x] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
