### PR TITLE
Feature/roe 257 and roe 838 complete new identity checks pages

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -35,6 +35,7 @@ export const BENEFICIAL_OWNER_TYPE_PAGE = "beneficial-owner-type";
 export const CANNOT_USE_PAGE = "cannot-use";
 export const CHECK_YOUR_ANSWERS_PAGE = "check-your-answers";
 export const CONFIRMATION_PAGE = "confirmation";
+export const DUE_DILIGENCE_PAGE = "due-diligence";
 export const ENTITY_PAGE = "entity";
 export const ERROR_PAGE = "error-page";
 export const HEALTHCHECK_PAGE = "healthcheck";
@@ -42,6 +43,7 @@ export const LANDING_PAGE = "landing";
 export const MANAGING_OFFICER_PAGE = "managing-officer";
 export const MANAGING_OFFICER_CORPORATE_PAGE = "managing-officer-corporate";
 export const NOT_FOUND_PAGE = "page-not-found";
+export const OVERSEAS_ENTITY_DUE_DILIGENCE_PAGE = "overseas-entity-due-diligence";
 export const PRESENTER_PAGE = "presenter";
 export const SECURE_REGISTER_FILTER_PAGE = "secure-register-filter";
 export const SERVICE_OFFLINE_PAGE = "service-offline";
@@ -73,6 +75,8 @@ export const SECURE_REGISTER_FILTER_URL = REGISTER_AN_OVERSEAS_ENTITY_URL + SECU
 export const TRUST_INFO_URL = REGISTER_AN_OVERSEAS_ENTITY_URL + TRUST_INFO_PAGE;
 export const USE_PAPER_URL = REGISTER_AN_OVERSEAS_ENTITY_URL + USE_PAPER_PAGE;
 export const WHO_IS_MAKING_FILING_URL = REGISTER_AN_OVERSEAS_ENTITY_URL + WHO_IS_MAKING_FILING_PAGE;
+export const DUE_DILIGENCE_URL = REGISTER_AN_OVERSEAS_ENTITY_URL + DUE_DILIGENCE_PAGE;
+export const OVERSEAS_ENTITY_DUE_DILIGENCE_URL = REGISTER_AN_OVERSEAS_ENTITY_URL + OVERSEAS_ENTITY_DUE_DILIGENCE_PAGE;
 export const REMOVE = "/remove";
 
 // URL PARAMS

--- a/src/controllers/due.diligence.controller.ts
+++ b/src/controllers/due.diligence.controller.ts
@@ -1,0 +1,39 @@
+import { NextFunction, Request, Response } from "express";
+
+import * as config from "../config";
+import { ApplicationData } from "../model";
+import { logger } from "../utils/logger";
+import { getApplicationData, setApplicationData, prepareData } from "../utils/application.data";
+import { DueDiligenceKey, DueDiligenceKeys } from "../model/due.diligence.model";
+
+export const get = (req: Request, res: Response, next: NextFunction) => {
+  try {
+    logger.debugRequest(req, `GET ${config.DUE_DILIGENCE_PAGE}`);
+
+    const appData: ApplicationData = getApplicationData(req.session);
+    const dueDiligence = appData[DueDiligenceKey];
+
+    return res.render(config.DUE_DILIGENCE_PAGE, {
+      backLinkUrl: config.WHO_IS_MAKING_FILING_URL,
+      templateName: config.DUE_DILIGENCE_PAGE,
+      ...dueDiligence
+    });
+  } catch (error) {
+    logger.errorRequest(req, error);
+    next(error);
+  }
+};
+
+export const post = (req: Request, res: Response, next: NextFunction) => {
+  try {
+    logger.debugRequest(req, `POST ${config.DUE_DILIGENCE_PAGE}`);
+
+    const data = prepareData(req.body, DueDiligenceKeys);
+    setApplicationData(req.session, data, DueDiligenceKey);
+
+    return res.redirect(config.ENTITY_URL);
+  } catch (error) {
+    logger.errorRequest(req, error);
+    next(error);
+  }
+};

--- a/src/controllers/due.diligence.controller.ts
+++ b/src/controllers/due.diligence.controller.ts
@@ -3,23 +3,37 @@ import { NextFunction, Request, Response } from "express";
 import * as config from "../config";
 import { ApplicationData } from "../model";
 import { logger } from "../utils/logger";
-import { getApplicationData, setApplicationData, prepareData } from "../utils/application.data";
+import {
+  getApplicationData,
+  setApplicationData,
+  prepareData,
+  mapDataObjectToFields,
+  mapFieldsToDataObject,
+} from "../utils/application.data";
 import { DueDiligenceKey, DueDiligenceKeys } from "../model/due.diligence.model";
+import { OverseasEntityDueDiligenceKey } from "../model/overseas.entity.due.diligence.model";
+import { IdentityDateKey, IdentityDateKeys } from "../model/date.model";
+import { IdentityAddressKey, IdentityAddressKeys } from "../model/address.model";
+import { AddressKeys, InputDateKeys } from "../model/data.types.model";
 
 export const get = (req: Request, res: Response, next: NextFunction) => {
   try {
     logger.debugRequest(req, `GET ${config.DUE_DILIGENCE_PAGE}`);
 
     const appData: ApplicationData = getApplicationData(req.session);
-    const dueDiligence = appData[DueDiligenceKey];
+    const data = appData[DueDiligenceKey];
+
+    const identityAddress = (data?.[IdentityAddressKey]) ? mapDataObjectToFields(data[IdentityAddressKey], IdentityAddressKeys, AddressKeys) : {};
+    const identityDate = (data?.[IdentityDateKey]) ? mapDataObjectToFields(data[IdentityDateKey], IdentityDateKeys, InputDateKeys) : {};
 
     return res.render(config.DUE_DILIGENCE_PAGE, {
       backLinkUrl: config.WHO_IS_MAKING_FILING_URL,
       templateName: config.DUE_DILIGENCE_PAGE,
-      ...dueDiligence
+      ...data,
+      ...identityAddress,
+      [IdentityDateKey]: identityDate
     });
   } catch (error) {
-    logger.errorRequest(req, error);
     next(error);
   }
 };
@@ -29,11 +43,16 @@ export const post = (req: Request, res: Response, next: NextFunction) => {
     logger.debugRequest(req, `POST ${config.DUE_DILIGENCE_PAGE}`);
 
     const data = prepareData(req.body, DueDiligenceKeys);
+    data[IdentityAddressKey] = mapFieldsToDataObject(req.body, IdentityAddressKeys, AddressKeys);
+    data[IdentityDateKey] = mapFieldsToDataObject(req.body, IdentityDateKeys, InputDateKeys);
+
     setApplicationData(req.session, data, DueDiligenceKey);
+
+    // Empty OverseasEntityDueDiligence object
+    setApplicationData(req.session, {}, OverseasEntityDueDiligenceKey);
 
     return res.redirect(config.ENTITY_URL);
   } catch (error) {
-    logger.errorRequest(req, error);
     next(error);
   }
 };

--- a/src/controllers/entity.controller.ts
+++ b/src/controllers/entity.controller.ts
@@ -13,6 +13,7 @@ import { AddressKeys, HasSamePrincipalAddressKey, IsOnRegisterInCountryFormedInK
 import { logger } from "../utils/logger";
 import * as config from "../config";
 import { PrincipalAddressKey, PrincipalAddressKeys, ServiceAddressKey, ServiceAddressKeys } from "../model/address.model";
+import { getEntityBackLink } from "../utils/navigation";
 
 export const get = (req: Request, res: Response, next: NextFunction) => {
   try {
@@ -25,7 +26,7 @@ export const get = (req: Request, res: Response, next: NextFunction) => {
     const serviceAddress = (entity) ? mapDataObjectToFields(entity[ServiceAddressKey], ServiceAddressKeys, AddressKeys) : {};
 
     return res.render(config.ENTITY_PAGE, {
-      backLinkUrl: config.WHO_IS_MAKING_FILING_URL,
+      backLinkUrl: getEntityBackLink(appData),
       templateName: config.ENTITY_PAGE,
       ...entity,
       ...principalAddress,

--- a/src/controllers/index.ts
+++ b/src/controllers/index.ts
@@ -19,3 +19,5 @@ export * as healthcheck from "./healthcheck.controller";
 export * as cannotUse from "./cannot.use.controller";
 export * as usePaper from "./use.paper.contoller";
 export * as whoIsMakingFiling from "./who.is.making.filing.controller";
+export * as dueDiligence from "./due.diligence.controller";
+export * as overseasEntityDueDiligence from "./overseas.entity.due.diligence.controller";

--- a/src/controllers/overseas.entity.due.diligence.controller.ts
+++ b/src/controllers/overseas.entity.due.diligence.controller.ts
@@ -34,7 +34,6 @@ export const get = (req: Request, res: Response, next: NextFunction) => {
       [IdentityDateKey]: identityDate
     });
   } catch (error) {
-    logger.errorRequest(req, error);
     next(error);
   }
 };
@@ -54,7 +53,6 @@ export const post = (req: Request, res: Response, next: NextFunction) => {
 
     return res.redirect(config.ENTITY_URL);
   } catch (error) {
-    logger.errorRequest(req, error);
     next(error);
   }
 };

--- a/src/controllers/overseas.entity.due.diligence.controller.ts
+++ b/src/controllers/overseas.entity.due.diligence.controller.ts
@@ -3,20 +3,35 @@ import { NextFunction, Request, Response } from "express";
 import * as config from "../config";
 import { ApplicationData } from "../model";
 import { logger } from "../utils/logger";
-import { getApplicationData, setApplicationData, prepareData } from "../utils/application.data";
+import {
+  getApplicationData,
+  setApplicationData,
+  prepareData,
+  mapDataObjectToFields,
+  mapFieldsToDataObject,
+} from "../utils/application.data";
 import { OverseasEntityDueDiligenceKey, OverseasEntityDueDiligenceKeys } from "../model/overseas.entity.due.diligence.model";
+import { DueDiligenceKey } from "../model/due.diligence.model";
+import { IdentityDateKey, IdentityDateKeys } from "../model/date.model";
+import { IdentityAddressKey, IdentityAddressKeys } from "../model/address.model";
+import { AddressKeys, InputDateKeys } from "../model/data.types.model";
 
 export const get = (req: Request, res: Response, next: NextFunction) => {
   try {
     logger.debugRequest(req, `GET ${config.OVERSEAS_ENTITY_DUE_DILIGENCE_PAGE}`);
 
     const appData: ApplicationData = getApplicationData(req.session);
-    const overseasEntityDueDiligence = appData[OverseasEntityDueDiligenceKey];
+    const data = appData[OverseasEntityDueDiligenceKey];
+
+    const identityAddress = (data?.[IdentityAddressKey]) ? mapDataObjectToFields(data[IdentityAddressKey], IdentityAddressKeys, AddressKeys) : {};
+    const identityDate = (data?.[IdentityDateKey]) ? mapDataObjectToFields(data[IdentityDateKey], IdentityDateKeys, InputDateKeys) : {};
 
     return res.render(config.OVERSEAS_ENTITY_DUE_DILIGENCE_PAGE, {
       backLinkUrl: config.WHO_IS_MAKING_FILING_URL,
       templateName: config.OVERSEAS_ENTITY_DUE_DILIGENCE_PAGE,
-      ...overseasEntityDueDiligence
+      ...data,
+      ...identityAddress,
+      [IdentityDateKey]: identityDate
     });
   } catch (error) {
     logger.errorRequest(req, error);
@@ -29,7 +44,13 @@ export const post = (req: Request, res: Response, next: NextFunction) => {
     logger.debugRequest(req, `POST ${config.OVERSEAS_ENTITY_DUE_DILIGENCE_PAGE}`);
 
     const data = prepareData(req.body, OverseasEntityDueDiligenceKeys);
+    data[IdentityAddressKey] = mapFieldsToDataObject(req.body, IdentityAddressKeys, AddressKeys);
+    data[IdentityDateKey] = mapFieldsToDataObject(req.body, IdentityDateKeys, InputDateKeys);
+
     setApplicationData(req.session, data, OverseasEntityDueDiligenceKey);
+
+    // Empty DueDiligence object
+    setApplicationData(req.session, {}, DueDiligenceKey);
 
     return res.redirect(config.ENTITY_URL);
   } catch (error) {

--- a/src/controllers/overseas.entity.due.diligence.controller.ts
+++ b/src/controllers/overseas.entity.due.diligence.controller.ts
@@ -1,0 +1,39 @@
+import { NextFunction, Request, Response } from "express";
+
+import * as config from "../config";
+import { ApplicationData } from "../model";
+import { logger } from "../utils/logger";
+import { getApplicationData, setApplicationData, prepareData } from "../utils/application.data";
+import { OverseasEntityDueDiligenceKey, OverseasEntityDueDiligenceKeys } from "../model/overseas.entity.due.diligence.model";
+
+export const get = (req: Request, res: Response, next: NextFunction) => {
+  try {
+    logger.debugRequest(req, `GET ${config.OVERSEAS_ENTITY_DUE_DILIGENCE_PAGE}`);
+
+    const appData: ApplicationData = getApplicationData(req.session);
+    const overseasEntityDueDiligence = appData[OverseasEntityDueDiligenceKey];
+
+    return res.render(config.OVERSEAS_ENTITY_DUE_DILIGENCE_PAGE, {
+      backLinkUrl: config.WHO_IS_MAKING_FILING_URL,
+      templateName: config.OVERSEAS_ENTITY_DUE_DILIGENCE_PAGE,
+      ...overseasEntityDueDiligence
+    });
+  } catch (error) {
+    logger.errorRequest(req, error);
+    next(error);
+  }
+};
+
+export const post = (req: Request, res: Response, next: NextFunction) => {
+  try {
+    logger.debugRequest(req, `POST ${config.OVERSEAS_ENTITY_DUE_DILIGENCE_PAGE}`);
+
+    const data = prepareData(req.body, OverseasEntityDueDiligenceKeys);
+    setApplicationData(req.session, data, OverseasEntityDueDiligenceKey);
+
+    return res.redirect(config.ENTITY_URL);
+  } catch (error) {
+    logger.errorRequest(req, error);
+    next(error);
+  }
+};

--- a/src/controllers/who.is.making.filing.controller.ts
+++ b/src/controllers/who.is.making.filing.controller.ts
@@ -4,7 +4,7 @@ import { logger } from "../utils/logger";
 import * as config from "../config";
 import { ApplicationData } from "../model";
 import { getApplicationData, setExtraData } from "../utils/application.data";
-import { WhoIsRegisteringKey } from "../model/who.is.making.filing.model";
+import { WhoIsRegisteringKey, WhoIsRegisteringType } from "../model/who.is.making.filing.model";
 
 export const get = (req: Request, res: Response, next: NextFunction) => {
   try {
@@ -25,11 +25,15 @@ export const get = (req: Request, res: Response, next: NextFunction) => {
 export const post = (req: Request, res: Response, next: NextFunction) => {
   try {
     logger.debugRequest(req, `POST ${config.WHO_IS_MAKING_FILING_PAGE}`);
-    const whoIsRegisteringKey = req.body[WhoIsRegisteringKey];
+    const whoIsRegistering = req.body[WhoIsRegisteringKey];
 
-    setExtraData(req.session, { ...getApplicationData(req.session), [WhoIsRegisteringKey]: whoIsRegisteringKey });
+    setExtraData(req.session, { ...getApplicationData(req.session), [WhoIsRegisteringKey]: whoIsRegistering });
 
-    return res.redirect(config.ENTITY_URL);
+    if ( whoIsRegistering === WhoIsRegisteringType.AGENT ){
+      return res.redirect(config.DUE_DILIGENCE_URL);
+    } else {
+      return res.redirect(config.OVERSEAS_ENTITY_DUE_DILIGENCE_URL);
+    }
   } catch (error) {
     logger.errorRequest(req, error);
     next(error);

--- a/src/middleware/validation.middleware.ts
+++ b/src/middleware/validation.middleware.ts
@@ -7,6 +7,7 @@ import { DateOfBirthKey, StartDateKey, DateOfBirthKeys, StartDateKeys } from "..
 
 import { logger } from '../utils/logger';
 import { ID } from "../model/data.types.model";
+import { ApplicationData } from "../model/application.model";
 
 export function checkValidations(req: Request, res: Response, next: NextFunction) {
   try {
@@ -28,11 +29,12 @@ export function checkValidations(req: Request, res: Response, next: NextFunction
       // when changing BO or MO data after failing validation. If not present, undefined will be passed in, which is fine as those pages
       // that don't use id will just ignore it.
       const id = req.params[ID];
+      const appData: ApplicationData = getApplicationData(req.session);
 
       return res.render(NAVIGATION[routePath].currentPage, {
-        backLinkUrl: NAVIGATION[routePath].previousPage,
+        backLinkUrl: NAVIGATION[routePath].previousPage(appData),
         id,
-        ...getApplicationData(req.session),
+        appData,
         ...req.body,
         ...dates,
         errors

--- a/src/middleware/validation.middleware.ts
+++ b/src/middleware/validation.middleware.ts
@@ -3,7 +3,14 @@ import { validationResult, ValidationError } from "express-validator";
 
 import { getApplicationData, prepareData } from "../utils/application.data";
 import { NAVIGATION } from "../utils/navigation";
-import { DateOfBirthKey, StartDateKey, DateOfBirthKeys, StartDateKeys } from "../model/date.model";
+import {
+  DateOfBirthKey,
+  StartDateKey,
+  DateOfBirthKeys,
+  StartDateKeys,
+  IdentityDateKey,
+  IdentityDateKeys,
+} from "../model/date.model";
 
 import { logger } from '../utils/logger';
 import { ID } from "../model/data.types.model";
@@ -20,7 +27,8 @@ export function checkValidations(req: Request, res: Response, next: NextFunction
       // govukDateInput adds for day, month and year field
       const dates = {
         [DateOfBirthKey]: prepareData(req.body, DateOfBirthKeys),
-        [StartDateKey]: prepareData(req.body, StartDateKeys)
+        [StartDateKey]: prepareData(req.body, StartDateKeys),
+        [IdentityDateKey]: prepareData(req.body, IdentityDateKeys)
       };
 
       const routePath = req.route.path;

--- a/src/model/address.model.ts
+++ b/src/model/address.model.ts
@@ -1,12 +1,12 @@
 /*
-  [UsualResidential, Principal, Service, DueDiligence]AddressKey should match the address name field
+  [UsualResidential, Principal, Service, Identity]AddressKey should match the address name field
   in every data model where address object has been used
 */
 
 export const UsualResidentialAddressKey = "usual_residential_address";
 export const PrincipalAddressKey = "principal_address";
 export const ServiceAddressKey = "service_address";
-export const DueDiligenceAddressKey = "identity_address";
+export const IdentityAddressKey = "identity_address";
 
 /*
   The sub-fields for Address Objects used in the templates
@@ -42,7 +42,7 @@ export const ServiceAddressKeys: string[] = [
   "service_address_postcode"
 ];
 
-export const DueDiligenceAddressKeys: string[] = [
+export const IdentityAddressKeys: string[] = [
   "identity_address_property_name_number",
   "identity_address_line_1",
   "identity_address_line_2",

--- a/src/model/address.model.ts
+++ b/src/model/address.model.ts
@@ -1,11 +1,12 @@
 /*
-  [UsualResidential, Principal, Service]AddressKey should match the address name field
+  [UsualResidential, Principal, Service, DueDiligence]AddressKey should match the address name field
   in every data model where address object has been used
 */
 
 export const UsualResidentialAddressKey = "usual_residential_address";
 export const PrincipalAddressKey = "principal_address";
 export const ServiceAddressKey = "service_address";
+export const DueDiligenceAddressKey = "identity_address";
 
 /*
   The sub-fields for Address Objects used in the templates
@@ -39,5 +40,15 @@ export const ServiceAddressKeys: string[] = [
   "service_address_county",
   "service_address_country",
   "service_address_postcode"
+];
+
+export const DueDiligenceAddressKeys: string[] = [
+  "identity_address_property_name_number",
+  "identity_address_line_1",
+  "identity_address_line_2",
+  "identity_address_town",
+  "identity_address_county",
+  "identity_address_country",
+  "identity_address_postcode"
 ];
 

--- a/src/model/application.model.ts
+++ b/src/model/application.model.ts
@@ -8,13 +8,17 @@ import {
   beneficialOwnerStatementType,
   beneficialOwnerIndividualType,
   managingOfficerCorporateType,
-  managingOfficerType
+  managingOfficerType,
+  dueDiligenceType,
+  overseasEntityDueDiligenceType
 } from "./index";
 
 export const APPLICATION_DATA_KEY = 'roe';
 
 export interface ApplicationData {
     presenter?: presenterType.Presenter;
+    due_diligence?: dueDiligenceType.DueDiligence;
+    overseas_entity_due_diligence?: overseasEntityDueDiligenceType.OverseasEntityDueDiligence;
     entity?: entityType.Entity;
     beneficial_owners_statement?: beneficialOwnerStatementType.BeneficialOwnersStatementType;
     beneficial_owners_individual?: beneficialOwnerIndividualType.BeneficialOwnerIndividual[];
@@ -40,6 +44,8 @@ export const ApplicationDataArrayType = [
 
 export type ApplicationDataType =
   | presenterType.Presenter
+  | dueDiligenceType.DueDiligence
+  | overseasEntityDueDiligenceType.OverseasEntityDueDiligence
   | entityType.Entity
   | beneficialOwnerOtherType.BeneficialOwnerOther
   | beneficialOwnerIndividualType.BeneficialOwnerIndividual

--- a/src/model/date.model.ts
+++ b/src/model/date.model.ts
@@ -1,10 +1,11 @@
 /*
-  DateOfBirthKey and StartDateKey should match the date name field
+  DateOfBirthKey, StartDateKey and IdentityDateKey should match the date name field
   in every data model where date object has been used
 */
 
 export const DateOfBirthKey: string = "date_of_birth";
 export const StartDateKey: string = "start_date";
+export const IdentityDateKey: string = "identity_date";
 
 /*
   The sub-fields for Date Objects used in the templates
@@ -19,4 +20,10 @@ export const StartDateKeys: string[] = [
   "start_date-day",
   "start_date-month",
   "start_date-year",
+];
+
+export const IdentityDateKeys: string[] = [
+  "identity_date-day",
+  "identity_date-month",
+  "identity_date-year",
 ];

--- a/src/model/due.diligence.model.ts
+++ b/src/model/due.diligence.model.ts
@@ -1,0 +1,31 @@
+import { Address, InputDate } from "./data.types.model";
+
+export const DueDiligenceKey = "due_diligence";
+
+/*
+  The DueDiligence fields will have to match the name field on the HTML file to
+  be able to do the mapping correctly
+*/
+export const DueDiligenceKeys: string[] = [
+  "identity_date",
+  "name",
+  "identity_address",
+  "email",
+  "supervisory_name",
+  "aml_number",
+  "agent_code",
+  "partner_name",
+  "diligence"
+];
+
+export interface DueDiligence {
+  identity_date?: InputDate;
+  name?: string
+  identity_address?: Address;
+  email?: string
+  supervisory_name?: string
+  aml_number?: string
+  agent_code?: string
+  partner_name?: string
+  diligence?: string
+}

--- a/src/model/index.ts
+++ b/src/model/index.ts
@@ -9,3 +9,5 @@ export * as beneficialOwnerIndividualType from "./beneficial.owner.individual.mo
 export * as beneficialOwnerGovType from "./beneficial.owner.gov.model";
 export * as managingOfficerCorporateType from "./managing.officer.corporate.model";
 export * as beneficialOwnerType from "./beneficial.owner.type.model";
+export * as dueDiligenceType from "./due.diligence.model";
+export * as overseasEntityDueDiligenceType from "./overseas.entity.due.diligence.model";

--- a/src/model/navigation.model.ts
+++ b/src/model/navigation.model.ts
@@ -2,6 +2,6 @@ export interface Navigation {
   [x: string]: {
     currentPage: string;
     previousPage: string;
-    nextPage: string;
+    nextPage: string[];
   };
 }

--- a/src/model/navigation.model.ts
+++ b/src/model/navigation.model.ts
@@ -1,7 +1,9 @@
+import { ApplicationData } from "./application.model";
+
 export interface Navigation {
   [x: string]: {
     currentPage: string;
-    previousPage: string;
+    previousPage: ((data: ApplicationData) => string);
     nextPage: string[];
   };
 }

--- a/src/model/navigation.model.ts
+++ b/src/model/navigation.model.ts
@@ -3,7 +3,7 @@ import { ApplicationData } from "./application.model";
 export interface Navigation {
   [x: string]: {
     currentPage: string;
-    previousPage: ((data: ApplicationData) => string);
+    previousPage: ((data?: ApplicationData) => string);
     nextPage: string[];
   };
 }

--- a/src/model/overseas.entity.due.diligence.model.ts
+++ b/src/model/overseas.entity.due.diligence.model.ts
@@ -1,0 +1,27 @@
+import { Address, InputDate } from "./data.types.model";
+
+export const OverseasEntityDueDiligenceKey = "overseas_entity_due_diligence";
+
+/*
+  The OverseasEntityDueDiligence fields will have to match the name field on the HTML file to
+  be able to do the mapping correctly
+*/
+export const OverseasEntityDueDiligenceKeys: string[] = [
+  "identity_date",
+  "name",
+  "identity_address",
+  "email",
+  "supervisory_name",
+  "aml_number",
+  "partner_name"
+];
+
+export interface OverseasEntityDueDiligence {
+  identity_date?: InputDate;
+  name?: string
+  identity_address?: Address;
+  email?: string
+  supervisory_name?: string
+  aml_number?: string
+  partner_name?: string
+}

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -22,7 +22,9 @@ import {
   secureRegisterFilter,
   trustInformation,
   usePaper,
-  whoIsMakingFiling
+  whoIsMakingFiling,
+  dueDiligence,
+  overseasEntityDueDiligence
 } from "../controllers";
 
 import { serviceAvailabilityMiddleware } from "../middleware/service.availability.middleware";
@@ -56,6 +58,12 @@ router.post(config.PRESENTER_URL, authentication, navigation.isSecureRegister, .
 
 router.get(config.WHO_IS_MAKING_FILING_URL, authentication, navigation.hasPresenter, whoIsMakingFiling.get);
 router.post(config.WHO_IS_MAKING_FILING_URL, authentication, navigation.hasPresenter, ...validator.whoIsMakingFiling, checkValidations, whoIsMakingFiling.post);
+
+router.get(config.DUE_DILIGENCE_URL, authentication, navigation.hasPresenter, dueDiligence.get);
+router.post(config.DUE_DILIGENCE_URL, authentication, navigation.hasPresenter, ...validator.dueDiligence, checkValidations, dueDiligence.post);
+
+router.get(config.OVERSEAS_ENTITY_DUE_DILIGENCE_URL, authentication, navigation.hasPresenter, overseasEntityDueDiligence.get);
+router.post(config.OVERSEAS_ENTITY_DUE_DILIGENCE_URL, authentication, navigation.hasPresenter, ...validator.overseasEntityDueDiligence, checkValidations, overseasEntityDueDiligence.post);
 
 router.get(config.ENTITY_URL, authentication, navigation.hasPresenter, entity.get);
 router.post(config.ENTITY_URL, authentication, navigation.hasPresenter, ...validator.entity, checkValidations, entity.post);

--- a/src/utils/navigation.ts
+++ b/src/utils/navigation.ts
@@ -5,100 +5,106 @@ export const NAVIGATION: Navigation = {
   [config.SOLD_LAND_FILTER_URL]: {
     currentPage: config.SOLD_LAND_FILTER_PAGE,
     previousPage: config.LANDING_URL,
-    nextPage: config.SECURE_REGISTER_FILTER_URL
+    nextPage: [config.SECURE_REGISTER_FILTER_URL]
   },
   [config.SECURE_REGISTER_FILTER_URL]: {
     currentPage: config.SECURE_REGISTER_FILTER_PAGE,
     previousPage: config.SOLD_LAND_FILTER_URL,
-    nextPage: config.INTERRUPT_CARD_URL
+    nextPage: [config.INTERRUPT_CARD_URL]
   },
   [config.INTERRUPT_CARD_URL]: {
     currentPage: config.INTERRUPT_CARD_PAGE,
     previousPage: config.SECURE_REGISTER_FILTER_URL,
-    nextPage: config.PRESENTER_URL
+    nextPage: [config.PRESENTER_URL]
   },
   [config.PRESENTER_URL]: {
     currentPage: config.PRESENTER_PAGE,
     previousPage: config.INTERRUPT_CARD_URL,
-    nextPage: config.WHO_IS_MAKING_FILING_URL
+    nextPage: [config.WHO_IS_MAKING_FILING_URL]
   },
   [config.WHO_IS_MAKING_FILING_URL]: {
     currentPage: config.WHO_IS_MAKING_FILING_PAGE,
     previousPage: config.PRESENTER_URL,
-    nextPage: config.ENTITY_URL
+    nextPage: [config.DUE_DILIGENCE_URL, config.OVERSEAS_ENTITY_DUE_DILIGENCE_URL]
+  },
+  [config.DUE_DILIGENCE_URL]: {
+    currentPage: config.DUE_DILIGENCE_PAGE,
+    previousPage: config.WHO_IS_MAKING_FILING_URL,
+    nextPage: [config.ENTITY_URL]
+  },
+  [config.OVERSEAS_ENTITY_DUE_DILIGENCE_URL]: {
+    currentPage: config.OVERSEAS_ENTITY_DUE_DILIGENCE_PAGE,
+    previousPage: config.WHO_IS_MAKING_FILING_URL,
+    nextPage: [config.ENTITY_URL]
   },
   [config.ENTITY_URL]: {
     currentPage: config.ENTITY_PAGE,
-    previousPage: config.WHO_IS_MAKING_FILING_URL,
-    nextPage: config.BENEFICIAL_OWNER_STATEMENTS_URL
+    previousPage: config.WHO_IS_MAKING_FILING_URL, // TO BE DONE !!!!!!!!!!!!
+    nextPage: [config.BENEFICIAL_OWNER_STATEMENTS_URL]
   },
   [config.BENEFICIAL_OWNER_STATEMENTS_URL]: {
     currentPage: config.BENEFICIAL_OWNER_STATEMENTS_PAGE,
     previousPage: config.ENTITY_URL,
-    nextPage: config.BENEFICIAL_OWNER_TYPE_URL
+    nextPage: [config.BENEFICIAL_OWNER_TYPE_URL]
   },
   [config.BENEFICIAL_OWNER_TYPE_URL]: {
     currentPage: config.BENEFICIAL_OWNER_TYPE_PAGE,
     previousPage: config.BENEFICIAL_OWNER_STATEMENTS_URL,
-    // TODO: Currently, nextPage is a string, but there could
-    // be multiple nextPage values here depending on whether
-    // there is trust information or not. Should look like:
-    // nextPage: [config.CHECK_YOUR_ANSWERS_URL, config.TRUST_INFO_URL]
-    nextPage: config.CHECK_YOUR_ANSWERS_URL
+    nextPage: [config.CHECK_YOUR_ANSWERS_URL, config.TRUST_INFO_URL]
   },
   [config.BENEFICIAL_OWNER_INDIVIDUAL_URL]: {
     currentPage: config.BENEFICIAL_OWNER_INDIVIDUAL_PAGE,
     previousPage: config.BENEFICIAL_OWNER_TYPE_URL,
-    nextPage: config.BENEFICIAL_OWNER_TYPE_URL
+    nextPage: [config.BENEFICIAL_OWNER_TYPE_URL]
   },
   [config.BENEFICIAL_OWNER_OTHER_URL]: {
     currentPage: config.BENEFICIAL_OWNER_OTHER_PAGE,
     previousPage: config.BENEFICIAL_OWNER_TYPE_URL,
-    nextPage: config.BENEFICIAL_OWNER_TYPE_URL
+    nextPage: [config.BENEFICIAL_OWNER_TYPE_URL]
   },
   [config.BENEFICIAL_OWNER_GOV_URL]: {
     currentPage: config.BENEFICIAL_OWNER_GOV_PAGE,
     previousPage: config.BENEFICIAL_OWNER_TYPE_URL,
-    nextPage: config.BENEFICIAL_OWNER_TYPE_URL
+    nextPage: [config.BENEFICIAL_OWNER_TYPE_URL]
   },
   [config.MANAGING_OFFICER_URL]: {
     currentPage: config.MANAGING_OFFICER_PAGE,
     previousPage: config.BENEFICIAL_OWNER_TYPE_URL,
-    nextPage: config.BENEFICIAL_OWNER_TYPE_URL
+    nextPage: [config.BENEFICIAL_OWNER_TYPE_URL]
   },
   [config.MANAGING_OFFICER_CORPORATE_URL]: {
     currentPage: config.MANAGING_OFFICER_CORPORATE_PAGE,
     previousPage: config.BENEFICIAL_OWNER_TYPE_URL,
-    nextPage: config.BENEFICIAL_OWNER_TYPE_URL
+    nextPage: [config.BENEFICIAL_OWNER_TYPE_URL]
   },
   [config.BENEFICIAL_OWNER_INDIVIDUAL_URL + config.ID]: {
     currentPage: config.BENEFICIAL_OWNER_INDIVIDUAL_PAGE,
     previousPage: config.BENEFICIAL_OWNER_TYPE_URL,
-    nextPage: config.BENEFICIAL_OWNER_TYPE_URL
+    nextPage: [config.BENEFICIAL_OWNER_TYPE_URL]
   },
   [config.BENEFICIAL_OWNER_OTHER_URL + config.ID]: {
     currentPage: config.BENEFICIAL_OWNER_OTHER_PAGE,
     previousPage: config.BENEFICIAL_OWNER_TYPE_URL,
-    nextPage: config.BENEFICIAL_OWNER_TYPE_URL
+    nextPage: [config.BENEFICIAL_OWNER_TYPE_URL]
   },
   [config.BENEFICIAL_OWNER_GOV_URL + config.ID]: {
     currentPage: config.BENEFICIAL_OWNER_GOV_PAGE,
     previousPage: config.BENEFICIAL_OWNER_TYPE_URL,
-    nextPage: config.BENEFICIAL_OWNER_TYPE_URL
+    nextPage: [config.BENEFICIAL_OWNER_TYPE_URL]
   },
   [config.MANAGING_OFFICER_URL + config.ID]: {
     currentPage: config.MANAGING_OFFICER_PAGE,
     previousPage: config.BENEFICIAL_OWNER_TYPE_URL,
-    nextPage: config.BENEFICIAL_OWNER_TYPE_URL
+    nextPage: [config.BENEFICIAL_OWNER_TYPE_URL]
   },
   [config.MANAGING_OFFICER_CORPORATE_URL + config.ID]: {
     currentPage: config.MANAGING_OFFICER_CORPORATE_PAGE,
     previousPage: config.BENEFICIAL_OWNER_TYPE_URL,
-    nextPage: config.BENEFICIAL_OWNER_TYPE_URL
+    nextPage: [config.BENEFICIAL_OWNER_TYPE_URL]
   },
   [config.TRUST_INFO_URL]: {
     currentPage: config.TRUST_INFO_PAGE,
     previousPage: config.BENEFICIAL_OWNER_TYPE_URL,
-    nextPage: config.CHECK_YOUR_ANSWERS_URL
+    nextPage: [config.CHECK_YOUR_ANSWERS_URL]
   }
 };

--- a/src/utils/navigation.ts
+++ b/src/utils/navigation.ts
@@ -1,110 +1,118 @@
 import * as config from "../config";
 import { Navigation } from "../model/navigation.model";
+import { ApplicationData } from "../model/application.model";
+import { WhoIsRegisteringType } from "../model/who.is.making.filing.model";
+
+export const getEntityBackLink = (data: ApplicationData): string => {
+  return data?.who_is_registering === WhoIsRegisteringType.AGENT
+    ? config.DUE_DILIGENCE_URL
+    : config.OVERSEAS_ENTITY_DUE_DILIGENCE_URL;
+};
 
 export const NAVIGATION: Navigation = {
   [config.SOLD_LAND_FILTER_URL]: {
     currentPage: config.SOLD_LAND_FILTER_PAGE,
-    previousPage: config.LANDING_URL,
+    previousPage: () => config.LANDING_URL,
     nextPage: [config.SECURE_REGISTER_FILTER_URL]
   },
   [config.SECURE_REGISTER_FILTER_URL]: {
     currentPage: config.SECURE_REGISTER_FILTER_PAGE,
-    previousPage: config.SOLD_LAND_FILTER_URL,
+    previousPage: () => config.SOLD_LAND_FILTER_URL,
     nextPage: [config.INTERRUPT_CARD_URL]
   },
   [config.INTERRUPT_CARD_URL]: {
     currentPage: config.INTERRUPT_CARD_PAGE,
-    previousPage: config.SECURE_REGISTER_FILTER_URL,
+    previousPage: () => config.SECURE_REGISTER_FILTER_URL,
     nextPage: [config.PRESENTER_URL]
   },
   [config.PRESENTER_URL]: {
     currentPage: config.PRESENTER_PAGE,
-    previousPage: config.INTERRUPT_CARD_URL,
+    previousPage: () => config.INTERRUPT_CARD_URL,
     nextPage: [config.WHO_IS_MAKING_FILING_URL]
   },
   [config.WHO_IS_MAKING_FILING_URL]: {
     currentPage: config.WHO_IS_MAKING_FILING_PAGE,
-    previousPage: config.PRESENTER_URL,
+    previousPage: () => config.PRESENTER_URL,
     nextPage: [config.DUE_DILIGENCE_URL, config.OVERSEAS_ENTITY_DUE_DILIGENCE_URL]
   },
   [config.DUE_DILIGENCE_URL]: {
     currentPage: config.DUE_DILIGENCE_PAGE,
-    previousPage: config.WHO_IS_MAKING_FILING_URL,
+    previousPage: () => config.WHO_IS_MAKING_FILING_URL,
     nextPage: [config.ENTITY_URL]
   },
   [config.OVERSEAS_ENTITY_DUE_DILIGENCE_URL]: {
     currentPage: config.OVERSEAS_ENTITY_DUE_DILIGENCE_PAGE,
-    previousPage: config.WHO_IS_MAKING_FILING_URL,
+    previousPage: () => config.WHO_IS_MAKING_FILING_URL,
     nextPage: [config.ENTITY_URL]
   },
   [config.ENTITY_URL]: {
     currentPage: config.ENTITY_PAGE,
-    previousPage: config.WHO_IS_MAKING_FILING_URL, // TO BE DONE !!!!!!!!!!!!
+    previousPage: getEntityBackLink,
     nextPage: [config.BENEFICIAL_OWNER_STATEMENTS_URL]
   },
   [config.BENEFICIAL_OWNER_STATEMENTS_URL]: {
     currentPage: config.BENEFICIAL_OWNER_STATEMENTS_PAGE,
-    previousPage: config.ENTITY_URL,
+    previousPage: () => config.ENTITY_URL,
     nextPage: [config.BENEFICIAL_OWNER_TYPE_URL]
   },
   [config.BENEFICIAL_OWNER_TYPE_URL]: {
     currentPage: config.BENEFICIAL_OWNER_TYPE_PAGE,
-    previousPage: config.BENEFICIAL_OWNER_STATEMENTS_URL,
+    previousPage: () => config.BENEFICIAL_OWNER_STATEMENTS_URL,
     nextPage: [config.CHECK_YOUR_ANSWERS_URL, config.TRUST_INFO_URL]
   },
   [config.BENEFICIAL_OWNER_INDIVIDUAL_URL]: {
     currentPage: config.BENEFICIAL_OWNER_INDIVIDUAL_PAGE,
-    previousPage: config.BENEFICIAL_OWNER_TYPE_URL,
+    previousPage: () => config.BENEFICIAL_OWNER_TYPE_URL,
     nextPage: [config.BENEFICIAL_OWNER_TYPE_URL]
   },
   [config.BENEFICIAL_OWNER_OTHER_URL]: {
     currentPage: config.BENEFICIAL_OWNER_OTHER_PAGE,
-    previousPage: config.BENEFICIAL_OWNER_TYPE_URL,
+    previousPage: () => config.BENEFICIAL_OWNER_TYPE_URL,
     nextPage: [config.BENEFICIAL_OWNER_TYPE_URL]
   },
   [config.BENEFICIAL_OWNER_GOV_URL]: {
     currentPage: config.BENEFICIAL_OWNER_GOV_PAGE,
-    previousPage: config.BENEFICIAL_OWNER_TYPE_URL,
+    previousPage: () => config.BENEFICIAL_OWNER_TYPE_URL,
     nextPage: [config.BENEFICIAL_OWNER_TYPE_URL]
   },
   [config.MANAGING_OFFICER_URL]: {
     currentPage: config.MANAGING_OFFICER_PAGE,
-    previousPage: config.BENEFICIAL_OWNER_TYPE_URL,
+    previousPage: () => config.BENEFICIAL_OWNER_TYPE_URL,
     nextPage: [config.BENEFICIAL_OWNER_TYPE_URL]
   },
   [config.MANAGING_OFFICER_CORPORATE_URL]: {
     currentPage: config.MANAGING_OFFICER_CORPORATE_PAGE,
-    previousPage: config.BENEFICIAL_OWNER_TYPE_URL,
+    previousPage: () => config.BENEFICIAL_OWNER_TYPE_URL,
     nextPage: [config.BENEFICIAL_OWNER_TYPE_URL]
   },
   [config.BENEFICIAL_OWNER_INDIVIDUAL_URL + config.ID]: {
     currentPage: config.BENEFICIAL_OWNER_INDIVIDUAL_PAGE,
-    previousPage: config.BENEFICIAL_OWNER_TYPE_URL,
+    previousPage: () => config.BENEFICIAL_OWNER_TYPE_URL,
     nextPage: [config.BENEFICIAL_OWNER_TYPE_URL]
   },
   [config.BENEFICIAL_OWNER_OTHER_URL + config.ID]: {
     currentPage: config.BENEFICIAL_OWNER_OTHER_PAGE,
-    previousPage: config.BENEFICIAL_OWNER_TYPE_URL,
+    previousPage: () => config.BENEFICIAL_OWNER_TYPE_URL,
     nextPage: [config.BENEFICIAL_OWNER_TYPE_URL]
   },
   [config.BENEFICIAL_OWNER_GOV_URL + config.ID]: {
     currentPage: config.BENEFICIAL_OWNER_GOV_PAGE,
-    previousPage: config.BENEFICIAL_OWNER_TYPE_URL,
+    previousPage: () => config.BENEFICIAL_OWNER_TYPE_URL,
     nextPage: [config.BENEFICIAL_OWNER_TYPE_URL]
   },
   [config.MANAGING_OFFICER_URL + config.ID]: {
     currentPage: config.MANAGING_OFFICER_PAGE,
-    previousPage: config.BENEFICIAL_OWNER_TYPE_URL,
+    previousPage: () => config.BENEFICIAL_OWNER_TYPE_URL,
     nextPage: [config.BENEFICIAL_OWNER_TYPE_URL]
   },
   [config.MANAGING_OFFICER_CORPORATE_URL + config.ID]: {
     currentPage: config.MANAGING_OFFICER_CORPORATE_PAGE,
-    previousPage: config.BENEFICIAL_OWNER_TYPE_URL,
+    previousPage: () => config.BENEFICIAL_OWNER_TYPE_URL,
     nextPage: [config.BENEFICIAL_OWNER_TYPE_URL]
   },
   [config.TRUST_INFO_URL]: {
     currentPage: config.TRUST_INFO_PAGE,
-    previousPage: config.BENEFICIAL_OWNER_TYPE_URL,
+    previousPage: () => config.BENEFICIAL_OWNER_TYPE_URL,
     nextPage: [config.CHECK_YOUR_ANSWERS_URL]
   }
 };

--- a/src/validation/due.diligence.validation.ts
+++ b/src/validation/due.diligence.validation.ts
@@ -1,0 +1,7 @@
+import { body } from "express-validator";
+
+import { ErrorMessages } from "./error.messages";
+
+export const dueDiligence = [
+  body("email").not().isEmpty({ ignore_whitespace: true }).withMessage(ErrorMessages.EMAIL).isLength({ max: 250 }).withMessage(ErrorMessages.MAX_EMAIL_LENGTH).isEmail().withMessage(ErrorMessages.EMAIL_INVALID_FORMAT)
+];

--- a/src/validation/due.diligence.validation.ts
+++ b/src/validation/due.diligence.validation.ts
@@ -1,7 +1,33 @@
 import { body } from "express-validator";
 
 import { ErrorMessages } from "./error.messages";
+import { identity_address_validations } from "./fields/address.validation";
+import { VALID_CHARACTERS } from "./regex/regex.validation";
 
 export const dueDiligence = [
-  body("email").not().isEmpty({ ignore_whitespace: true }).withMessage(ErrorMessages.EMAIL).isLength({ max: 250 }).withMessage(ErrorMessages.MAX_EMAIL_LENGTH).isEmail().withMessage(ErrorMessages.EMAIL_INVALID_FORMAT)
+  body("name")
+    .not().isEmpty({ ignore_whitespace: true }).withMessage(ErrorMessages.DUE_DILIGENCE_NAME)
+    .isLength({ max: 160 }).withMessage(ErrorMessages.MAX_NAME_LENGTH)
+    .matches(VALID_CHARACTERS).withMessage(ErrorMessages.NAME_INVALID_CHARACTERS),
+
+  ...identity_address_validations,
+
+  body("email")
+    .not().isEmpty({ ignore_whitespace: true }).withMessage(ErrorMessages.EMAIL)
+    .isLength({ max: 250 }).withMessage(ErrorMessages.MAX_EMAIL_LENGTH)
+    .isEmail().withMessage(ErrorMessages.EMAIL_INVALID_FORMAT),
+
+  body("supervisory_name")
+    .not().isEmpty({ ignore_whitespace: true }).withMessage(ErrorMessages.SUPERVISORY_NAME)
+    .isLength({ max: 160 }).withMessage(ErrorMessages.MAX_NAME_LENGTH)
+    .matches(VALID_CHARACTERS).withMessage(ErrorMessages.NAME_INVALID_CHARACTERS),
+
+  body("agent_code").not().isEmpty({ ignore_whitespace: true }).withMessage(ErrorMessages.AGENT_CODE),
+
+  body("partner_name")
+    .not().isEmpty({ ignore_whitespace: true }).withMessage(ErrorMessages.PARTNER_NAME)
+    .isLength({ max: 160 }).withMessage(ErrorMessages.MAX_NAME_LENGTH)
+    .matches(VALID_CHARACTERS).withMessage(ErrorMessages.NAME_INVALID_CHARACTERS),
+
+  body("diligence").not().isEmpty().withMessage(ErrorMessages.CHECK_DILIGENCE)
 ];

--- a/src/validation/error.messages.ts
+++ b/src/validation/error.messages.ts
@@ -12,6 +12,11 @@ export enum ErrorMessages {
   ROLE_AND_RESPONSIBILITIES_CORPORATE = "Enter a description of the corporate managing officer’s role and responsibilities",
   NATIONALITY = "Enter the individual person’s nationality",
   OCCUPATION = "Enter an occupation",
+  DUE_DILIGENCE_NAME = "Enter the name of the agent that carried out identity checks",
+  OE_DUE_DILIGENCE_NAME = "Enter the name of the person or company that carried out identity checks",
+  AGENT_CODE = "Enter the agent assurance code",
+  PARTNER_NAME = "Enter the name of the person with overall responsibility for identity checks",
+  SUPERVISORY_NAME = "Enter the name of the supervisory body",
   // Public Register
   PUBLIC_REGISTER_NAME = "Enter the name of the register",
   PUBLIC_REGISTER_NUMBER = "Enter the registration number",
@@ -19,7 +24,10 @@ export enum ErrorMessages {
   PROPERTY_NAME_OR_NUMBER = "Enter a property name or number",
   ADDRESS_LINE1 = "Enter an address",
   CITY_OR_TOWN = "Enter a city or town",
+  COUNTY = "Enter a county",
   COUNTRY = "Select a country from the list",
+  UK_COUNTRY = "Select a country",
+  POSTCODE = "Enter a postcode",
   // Date
   DAY = "Date must include a day ",
   MONTH = "Date must include a month",
@@ -44,6 +52,7 @@ export enum ErrorMessages {
   SELECT_THE_TYPE_OF_BENEFICIAL_OWNER_OR_MANAGING_OFFICER_YOU_WANT_TO_ADD = "Select the type of beneficial owner or managing officer you want to add",
   SELECT_IF_SECURE_REGISTER_FILTER = "Select yes if any of the entity’s beneficial owners have ever applied to protect personal information at Companies House",
   SELECT_WHO_IS_MAKING_FILING = "Select who is completing this registration",
+  CHECK_DILIGENCE = "Check and confirm the statement of compliance",
   // MAX Lengths
   MAX_FIRST_NAME_LENGTH = "First name must be 50 characters or less",
   MAX_LAST_NAME_LENGTH = "Last name must be 160 characters or less",

--- a/src/validation/fields/address.validation.ts
+++ b/src/validation/fields/address.validation.ts
@@ -195,3 +195,30 @@ export const usual_residential_service_address_beneficial_owner_validation = [
     .custom((value, { req }) => checkInvalidCharactersIfRadioButtonSelected(req.body.is_service_address_same_as_usual_residential_address === '0', ErrorMessages.POSTCODE_ZIPCODE_INVALID_CHARACTERS, value))
     .custom((value, { req }) => checkMaxFieldIfRadioButtonSelected(req.body.is_service_address_same_as_usual_residential_address === '0', ErrorMessages.MAX_POSTCODE_LENGTH, 20, value))
 ];
+
+export const identity_address_validations = [
+  body("identity_address_property_name_number")
+    .isLength({ max: 200 }).withMessage(ErrorMessages.MAX_PROPERTY_NAME_OR_NUMBER_LENGTH)
+    .matches(VALID_CHARACTERS).withMessage(ErrorMessages.PROPERTY_NAME_OR_NUMBER_INVALID_CHARACTERS),
+  body("identity_address_line_1")
+    .not().isEmpty({ ignore_whitespace: true }).withMessage(ErrorMessages.ADDRESS_LINE1)
+    .isLength({ max: 50 }).withMessage(ErrorMessages.MAX_ADDRESS_LINE1_LENGTH)
+    .matches(VALID_CHARACTERS).withMessage(ErrorMessages.ADDRESS_LINE_1_INVALID_CHARACTERS),
+  body("identity_address_line_2")
+    .isLength({ max: 50 }).withMessage(ErrorMessages.MAX_ADDRESS_LINE2_LENGTH)
+    .matches(VALID_CHARACTERS).withMessage(ErrorMessages.ADDRESS_LINE_2_INVALID_CHARACTERS),
+  body("identity_address_town")
+    .not().isEmpty({ ignore_whitespace: true }).withMessage(ErrorMessages.CITY_OR_TOWN)
+    .isLength({ max: 50 }).withMessage(ErrorMessages.MAX_CITY_OR_TOWN_LENGTH)
+    .matches(VALID_CHARACTERS).withMessage(ErrorMessages.CITY_OR_TOWN_INVALID_CHARACTERS),
+  body("identity_address_county")
+    .not().isEmpty({ ignore_whitespace: true }).withMessage(ErrorMessages.COUNTY)
+    .isLength({ max: 50 }).withMessage(ErrorMessages.MAX_COUNTY_LENGTH)
+    .matches(VALID_CHARACTERS).withMessage(ErrorMessages.COUNTY_STATE_PROVINCE_REGION_INVALID_CHARACTERS),
+  body("identity_address_country")
+    .not().isEmpty({ ignore_whitespace: true }).withMessage(ErrorMessages.UK_COUNTRY),
+  body("identity_address_postcode")
+    .not().isEmpty({ ignore_whitespace: true }).withMessage(ErrorMessages.POSTCODE)
+    .isLength({ max: 20 }).withMessage(ErrorMessages.MAX_POSTCODE_LENGTH)
+    .matches(VALID_CHARACTERS).withMessage(ErrorMessages.POSTCODE_ZIPCODE_INVALID_CHARACTERS)
+];

--- a/src/validation/index.ts
+++ b/src/validation/index.ts
@@ -10,6 +10,8 @@ import { managingOfficerIndividual } from "./managing.officer.validation";
 import { presenter } from "./presenter.validation";
 import { secureRegisterFilter } from "./secure.register.filter.validation";
 import { whoIsMakingFiling } from "./who.is.making.filing.validation";
+import { dueDiligence } from "./due.diligence.validation";
+import { overseasEntityDueDiligence } from "./overseas.entity.due.diligence.validation";
 
 export const validator = {
   soldLandFilter,
@@ -23,5 +25,7 @@ export const validator = {
   beneficialOwnerIndividual,
   beneficialOwnerOther,
   beneficialOwnerGov,
-  whoIsMakingFiling
+  whoIsMakingFiling,
+  dueDiligence,
+  overseasEntityDueDiligence
 };

--- a/src/validation/overseas.entity.due.diligence.validation.ts
+++ b/src/validation/overseas.entity.due.diligence.validation.ts
@@ -1,7 +1,27 @@
 import { body } from "express-validator";
 
 import { ErrorMessages } from "./error.messages";
+import { identity_address_validations } from "./fields/address.validation";
+import { VALID_CHARACTERS } from "./regex/regex.validation";
 
 export const overseasEntityDueDiligence = [
-  body("email").not().isEmpty({ ignore_whitespace: true }).withMessage(ErrorMessages.EMAIL).isLength({ max: 250 }).withMessage(ErrorMessages.MAX_EMAIL_LENGTH).isEmail().withMessage(ErrorMessages.EMAIL_INVALID_FORMAT)
+  body("name")
+    .not().isEmpty({ ignore_whitespace: true }).withMessage(ErrorMessages.OE_DUE_DILIGENCE_NAME)
+    .isLength({ max: 160 }).withMessage(ErrorMessages.MAX_NAME_LENGTH)
+    .matches(VALID_CHARACTERS).withMessage(ErrorMessages.NAME_INVALID_CHARACTERS),
+
+  ...identity_address_validations,
+
+  body("email")
+    .not().isEmpty({ ignore_whitespace: true }).withMessage(ErrorMessages.EMAIL)
+    .isLength({ max: 250 }).withMessage(ErrorMessages.MAX_EMAIL_LENGTH)
+    .isEmail().withMessage(ErrorMessages.EMAIL_INVALID_FORMAT),
+
+  body("supervisory_name")
+    .isLength({ max: 160 }).withMessage(ErrorMessages.MAX_NAME_LENGTH)
+    .matches(VALID_CHARACTERS).withMessage(ErrorMessages.NAME_INVALID_CHARACTERS),
+
+  body("partner_name")
+    .isLength({ max: 160 }).withMessage(ErrorMessages.MAX_NAME_LENGTH)
+    .matches(VALID_CHARACTERS).withMessage(ErrorMessages.NAME_INVALID_CHARACTERS),
 ];

--- a/src/validation/overseas.entity.due.diligence.validation.ts
+++ b/src/validation/overseas.entity.due.diligence.validation.ts
@@ -1,0 +1,7 @@
+import { body } from "express-validator";
+
+import { ErrorMessages } from "./error.messages";
+
+export const overseasEntityDueDiligence = [
+  body("email").not().isEmpty({ ignore_whitespace: true }).withMessage(ErrorMessages.EMAIL).isLength({ max: 250 }).withMessage(ErrorMessages.MAX_EMAIL_LENGTH).isEmail().withMessage(ErrorMessages.EMAIL_INVALID_FORMAT)
+];

--- a/test/__mocks__/due.diligence.mock.ts
+++ b/test/__mocks__/due.diligence.mock.ts
@@ -1,0 +1,41 @@
+import { DueDiligence } from "../../src/model/due.diligence.model";
+import {
+  ADDRESS,
+  IDENTITY_ADDRESS_REQ_BODY_EMPTY_MOCK,
+  IDENTITY_ADDRESS_REQ_BODY_MOCK,
+} from "./fields/address.mock";
+import { DATE, EMPTY_DATE } from "./fields/date.mock";
+
+export const DUE_DILIGENCE_OBJECT_MOCK: DueDiligence = {
+  identity_date: DATE,
+  name: "Any name",
+  identity_address: ADDRESS,
+  email: "email@email.ch",
+  supervisory_name: "Any supervisory name",
+  aml_number: "Any AML number",
+  agent_code: "Any agent code",
+  partner_name: "Any partner name",
+  diligence: "agree"
+};
+
+export const DUE_DILIGENCE_REQ_BODY_OBJECT_MOCK = {
+  ...DUE_DILIGENCE_OBJECT_MOCK,
+  ...IDENTITY_ADDRESS_REQ_BODY_MOCK,
+};
+
+const DUE_DILIGENCE_EMPTY_OBJECT_MOCK: DueDiligence = {
+  identity_date: EMPTY_DATE,
+  name: "",
+  identity_address: {},
+  email: "",
+  supervisory_name: "",
+  aml_number: "",
+  agent_code: "",
+  partner_name: "",
+  diligence: ""
+};
+
+export const DUE_DILIGENCE_REQ_BODY_EMPTY_OBJECT_MOCK = {
+  ...DUE_DILIGENCE_EMPTY_OBJECT_MOCK,
+  ...IDENTITY_ADDRESS_REQ_BODY_EMPTY_MOCK,
+};

--- a/test/__mocks__/fields/address.mock.ts
+++ b/test/__mocks__/fields/address.mock.ts
@@ -1,0 +1,29 @@
+export const ADDRESS = {
+  property_name_number: "1",
+  line_1: "addressLine1",
+  line_2: "addressLine2",
+  town: "town",
+  county: "county",
+  country: "country",
+  postcode: "BY 2"
+};
+
+export const IDENTITY_ADDRESS_REQ_BODY_MOCK = {
+  identity_address_property_name_number: "1",
+  identity_address_line_1: "addressLine1",
+  identity_address_line_2: "addressLine2",
+  identity_address_town: "town",
+  identity_address_county: "county",
+  identity_address_country: "country",
+  identity_address_postcode: "BY 2"
+};
+
+export const IDENTITY_ADDRESS_REQ_BODY_EMPTY_MOCK = {
+  identity_address_property_name_number: "",
+  identity_address_line_1: "",
+  identity_address_line_2: "",
+  identity_address_town: "",
+  identity_address_county: "",
+  identity_address_country: "",
+  identity_address_postcode: ""
+};

--- a/test/__mocks__/fields/date.mock.ts
+++ b/test/__mocks__/fields/date.mock.ts
@@ -1,0 +1,20 @@
+export const DATE_OF_BIRTH = {
+  "date_of_birth-day": "1",
+  "date_of_birth-month": "1",
+  "date_of_birth-year": "2000",
+};
+
+export const START_DATE = {
+  "start_date-day": "1",
+  "start_date-month": "1",
+  "start_date-year": "2022",
+};
+
+export const IDENTITY_DATE_REQ_BODY_MOCK = {
+  "identity_date-day": "1",
+  "identity_date-month": "1",
+  "identity_date-year": "2022",
+};
+
+export const DATE = { day: "1", month: "1", year: "2000" };
+export const EMPTY_DATE = { day: "", month: "", year: "" };

--- a/test/__mocks__/overseas.entity.due.diligence.mock.ts
+++ b/test/__mocks__/overseas.entity.due.diligence.mock.ts
@@ -1,0 +1,38 @@
+import { OverseasEntityDueDiligence } from "../../src/model/overseas.entity.due.diligence.model";
+import {
+  ADDRESS,
+  IDENTITY_ADDRESS_REQ_BODY_EMPTY_MOCK,
+  IDENTITY_ADDRESS_REQ_BODY_MOCK,
+} from "./fields/address.mock";
+import { DATE, EMPTY_DATE, IDENTITY_DATE_REQ_BODY_MOCK } from "./fields/date.mock";
+
+export const OVERSEAS_ENTITY_DUE_DILIGENCE_OBJECT_MOCK: OverseasEntityDueDiligence = {
+  identity_date: DATE,
+  name: "Some name",
+  identity_address: ADDRESS,
+  email: "email@email.ch",
+  supervisory_name: "Some supervisory name",
+  aml_number: "Any AML number 123",
+  partner_name: "Some partner name"
+};
+
+export const OVERSEAS_ENTITY_DUE_DILIGENCE_REQ_BODY_OBJECT_MOCK = {
+  ...OVERSEAS_ENTITY_DUE_DILIGENCE_OBJECT_MOCK,
+  ...IDENTITY_ADDRESS_REQ_BODY_MOCK,
+  ...IDENTITY_DATE_REQ_BODY_MOCK
+};
+
+const OVERSEAS_ENTITY_DUE_DILIGENCE_EMPTY_OBJECT_MOCK: OverseasEntityDueDiligence = {
+  identity_date: EMPTY_DATE,
+  name: "",
+  identity_address: {},
+  email: "",
+  supervisory_name: "",
+  aml_number: "",
+  partner_name: ""
+};
+
+export const OVERSEAS_ENTITY_DUE_DILIGENCE_REQ_BODY_EMPTY_OBJECT_MOCK = {
+  ...OVERSEAS_ENTITY_DUE_DILIGENCE_EMPTY_OBJECT_MOCK,
+  ...IDENTITY_ADDRESS_REQ_BODY_EMPTY_MOCK,
+};

--- a/test/__mocks__/session.mock.ts
+++ b/test/__mocks__/session.mock.ts
@@ -26,6 +26,8 @@ import {
   Transactionkey,
   yesNoResponse
 } from "../../src/model/data.types.model";
+import { ADDRESS } from "./fields/address.mock";
+import { DATE_OF_BIRTH, START_DATE } from "./fields/date.mock";
 import { ANY_MESSAGE_ERROR } from "./text.mock";
 
 export const BO_GOV_ID = "10722c3c-9301-4f46-ad8b-b30f5dcd76a0";
@@ -98,19 +100,6 @@ export function getSessionRequestWithExtraData(): Session {
   session.setExtraData(APPLICATION_DATA_KEY, APPLICATION_DATA_MOCK);
   return session;
 }
-
-const date_of_birth = { 'date_of_birth-day': "1",  "date_of_birth-month": "1", "date_of_birth-year": "2000" };
-const start_date = { 'start_date-day': "1", 'start_date-month': "1", 'start_date-year': "2022" };
-
-export const ADDRESS = {
-  property_name_number: "1",
-  line_1: "addressLine1",
-  line_2: "addressLine2",
-  town: "town",
-  county: "county",
-  country: "country",
-  postcode: "BY 2"
-};
 
 export const SERVICE_ADDRESS = {
   property_name_number: "service1",
@@ -277,51 +266,51 @@ export const BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK: beneficialOwnerIndividualT
 
 export const BENEFICIAL_OWNER_INDIVIDUAL_REQ_BODY_OBJECT_MOCK = {
   ...BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK,
-  ...start_date,
-  ...date_of_birth
+  ...START_DATE,
+  ...DATE_OF_BIRTH
 };
 
 export const BENEFICIAL_OWNER_INDIVIDUAL_REQ_BODY_OBJECT_MOCK_FOR_START_DATE = {
   ...BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK,
-  ...start_date,
-  ...date_of_birth
+  ...START_DATE,
+  ...DATE_OF_BIRTH
 };
 
 export const BENEFICIAL_OWNER_INDIVIDUAL_REQ_BODY_OBJECT_MOCK_FOR_DATE_OF_BIRTH = {
   ...BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK,
-  ...start_date,
-  ...date_of_birth
+  ...START_DATE,
+  ...DATE_OF_BIRTH
 };
 
 export const BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK_WITH_SERVICE_RADIO_BUTTONS: beneficialOwnerIndividualType.BeneficialOwnerIndividual = {
   id: BO_IND_ID,
   is_on_sanctions_list: 1,
   is_service_address_same_as_usual_residential_address: 0,
-  ...start_date,
-  ...date_of_birth
+  ...START_DATE,
+  ...DATE_OF_BIRTH
 };
 
 export const BENEFICIAL_OWNER_INDIVIDUAL_REPLACE: beneficialOwnerIndividualType.BeneficialOwnerIndividual = {
   id: BO_IND_ID,
   first_name: "new name",
-  ...start_date,
-  ...date_of_birth
+  ...START_DATE,
+  ...DATE_OF_BIRTH
 };
 
 export const BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK_WITH_SERVICE_ADDRESS_YES: beneficialOwnerIndividualType.BeneficialOwnerIndividual = {
   id: BO_IND_ID,
   is_service_address_same_as_usual_residential_address: yesNoResponse.Yes,
   service_address: ADDRESS,
-  ...start_date,
-  ...date_of_birth
+  ...START_DATE,
+  ...DATE_OF_BIRTH
 };
 
 export const BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK_WITH_SERVICE_ADDRESS_NO: beneficialOwnerIndividualType.BeneficialOwnerIndividual = {
   id: BO_IND_ID,
   is_service_address_same_as_usual_residential_address: yesNoResponse.No,
   service_address: ADDRESS,
-  ...start_date,
-  ...date_of_birth
+  ...START_DATE,
+  ...DATE_OF_BIRTH
 };
 
 export const BENEFICIAL_OWNER_OTHER_OBJECT_MOCK_WITH_SERVICE_ADDRESS_YES: beneficialOwnerOtherType.BeneficialOwnerOther = {
@@ -472,7 +461,7 @@ export const REQ_BODY_MANAGING_OFFICER_MOCK_WITH_ADDRESS = {
   role_and_responsibilities: "some role and responsibilities",
   ...RESIDENTIAL_ADDRESS_MOCK,
   ...SERVICE_ADDRESS_MOCK,
-  ...date_of_birth
+  ...DATE_OF_BIRTH
 };
 
 export const REQ_BODY_MANAGING_OFFICER_FOR_DATE_VALIDATION = {
@@ -532,7 +521,7 @@ export const REQ_BODY_MANAGING_OFFICER_CORPORATE_MOCK_WITH_ADDRESS = {
   contact_email: "contact email",
   ...PRINCIPAL_ADDRESS_MOCK,
   ...SERVICE_ADDRESS_MOCK,
-  ...start_date
+  ...START_DATE
 };
 
 export const REQ_BODY_MANAGING_OFFICER_CORPORATE_FOR_DATE_VALIDATION = {

--- a/test/__mocks__/text.mock.ts
+++ b/test/__mocks__/text.mock.ts
@@ -4,6 +4,8 @@ export const SOLD_LAND_FILTER_PAGE_TITLE = "Has the entity disposed of UK proper
 export const INTERRUPT_CARD_PAGE_TITLE = "Before you start";
 export const ENTITY_PAGE_TITLE = "Tell us about the overseas entity";
 export const WHO_IS_MAKING_FILING_PAGE_TITLE = "Who is completing this registration?";
+export const OVERSEAS_ENTITY_DUE_DILIGENCE_PAGE_TITLE = "Tell us about the UK-regulated agent that carried out identity checks";
+export const DUE_DILIGENCE_PAGE_TITLE = "Complete this statement to confirm that identity checks have been completed";
 export const BENEFICIAL_OWNER_GOV_PAGE_HEADING = "Tell us about the government or public authority";
 export const BENEFICIAL_OWNER_OTHER_PAGE_HEADING = "Tell us about the other legal entity";
 export const BENEFICIAL_OWNER_STATEMENTS_PAGE_REDIRECT = "Found. Redirecting to /register-an-overseas-entity/beneficial-owner-statements";
@@ -55,3 +57,7 @@ export const RADIO_BUTTON_NO_SELECTED = "value=\"0\" checked";
 export const RADIO_BUTTON_AGENT_SELECTED = "value=\"agent\" checked";
 export const RADIO_BUTTON_SOMEONE_ELSE_SELECTED = "value=\"someone_else\" checked";
 export const INFORMATION_ON_PUBLIC_REGISTER = "All of the information provided in this section will be shown on the public Register of Overseas Entities.";
+export const OVERSEAS_ENTITY_DUE_DILIGENCE_NAME_TEXT = "What is their name?";
+export const OVERSEAS_ENTITY_DUE_DILIGENCE_INFORMATION_ON_PUBLIC_REGISTER = "The email address will not be shown";
+export const DUE_DILIGENCE_NAME_TEXT = "What is the agent’s name?";
+export const DUE_DILIGENCE_INFORMATION_ON_PUBLIC_REGISTER = "The email address, agent assurance code and date the identity checks were completed will not be shown.";

--- a/test/__mocks__/validation.mock.ts
+++ b/test/__mocks__/validation.mock.ts
@@ -1,4 +1,5 @@
-import { ADDRESS, MO_IND_ID, PRINCIPAL_ADDRESS_MOCK, SERVICE_ADDRESS_MOCK } from "./session.mock";
+import { MO_IND_ID, PRINCIPAL_ADDRESS_MOCK, SERVICE_ADDRESS_MOCK } from "./session.mock";
+import { ADDRESS } from "./fields/address.mock";
 
 const NAME_SPECIAL_CHARS = "Kurt Gödel";
 

--- a/test/controllers/due.diligence.controller.spec.ts
+++ b/test/controllers/due.diligence.controller.spec.ts
@@ -1,0 +1,134 @@
+jest.mock("ioredis");
+jest.mock('../../src/middleware/authentication.middleware');
+jest.mock('../../src/utils/application.data');
+jest.mock('../../src/middleware/navigation/has.presenter.middleware');
+
+import { describe, expect, test, jest, beforeEach } from '@jest/globals';
+import { NextFunction, Request, Response } from "express";
+import request from "supertest";
+
+import app from "../../src/app";
+import {
+  DUE_DILIGENCE_PAGE,
+  DUE_DILIGENCE_URL,
+  ENTITY_PAGE,
+  ENTITY_URL,
+  WHO_IS_MAKING_FILING_URL,
+} from "../../src/config";
+import { getApplicationData, setApplicationData, prepareData } from "../../src/utils/application.data";
+import { authentication } from "../../src/middleware/authentication.middleware";
+import {
+  ANY_MESSAGE_ERROR,
+  SERVICE_UNAVAILABLE,
+  FOUND_REDIRECT_TO,
+  DUE_DILIGENCE_PAGE_TITLE,
+  DUE_DILIGENCE_NAME_TEXT,
+  DUE_DILIGENCE_INFORMATION_ON_PUBLIC_REGISTER,
+} from "../__mocks__/text.mock";
+import { ErrorMessages } from '../../src/validation/error.messages';
+import { hasPresenter } from "../../src/middleware/navigation/has.presenter.middleware";
+import {
+  DUE_DILIGENCE_OBJECT_MOCK,
+  DUE_DILIGENCE_REQ_BODY_EMPTY_OBJECT_MOCK,
+  DUE_DILIGENCE_REQ_BODY_OBJECT_MOCK,
+} from "../__mocks__/due.diligence.mock";
+import { DueDiligenceKey } from '../../src/model/due.diligence.model';
+
+const mockHasPresenterMiddleware = hasPresenter as jest.Mock;
+mockHasPresenterMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => next() );
+
+const mockGetApplicationData = getApplicationData as jest.Mock;
+const mockSetApplicationData = setApplicationData as jest.Mock;
+const mockPrepareData = prepareData as jest.Mock;
+const mockAuthenticationMiddleware = authentication as jest.Mock;
+mockAuthenticationMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => next() );
+
+describe("DUE_DILIGENCE controller", () => {
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("GET tests", () => {
+
+    test(`renders the ${DUE_DILIGENCE_PAGE}`, async () => {
+      mockGetApplicationData.mockReturnValueOnce( { [DueDiligenceKey]: null } );
+      const resp = await request(app).get(DUE_DILIGENCE_URL);
+
+      expect(resp.status).toEqual(200);
+      expect(resp.text).toContain(DUE_DILIGENCE_PAGE_TITLE);
+      expect(resp.text).toContain(DUE_DILIGENCE_NAME_TEXT);
+      expect(resp.text).toContain(DUE_DILIGENCE_INFORMATION_ON_PUBLIC_REGISTER);
+      expect(resp.text).toContain(WHO_IS_MAKING_FILING_URL);
+    });
+
+    test(`renders the ${DUE_DILIGENCE_PAGE} page on GET method with session data populated`, async () => {
+      mockGetApplicationData.mockReturnValueOnce( { [DueDiligenceKey]: DUE_DILIGENCE_OBJECT_MOCK } );
+      const resp = await request(app).get(DUE_DILIGENCE_URL);
+
+      expect(resp.status).toEqual(200);
+      expect(resp.text).toContain(DUE_DILIGENCE_PAGE_TITLE);
+      expect(resp.text).toContain(DUE_DILIGENCE_OBJECT_MOCK.name);
+      expect(resp.text).toContain(DUE_DILIGENCE_OBJECT_MOCK.email);
+      expect(resp.text).toContain(DUE_DILIGENCE_OBJECT_MOCK.supervisory_name);
+      expect(resp.text).toContain(DUE_DILIGENCE_OBJECT_MOCK.aml_number);
+      expect(resp.text).toContain(DUE_DILIGENCE_OBJECT_MOCK.agent_code);
+      expect(resp.text).toContain(DUE_DILIGENCE_OBJECT_MOCK.partner_name);
+      expect(resp.text).toContain(DUE_DILIGENCE_OBJECT_MOCK.diligence);
+      expect(resp.text).toContain(WHO_IS_MAKING_FILING_URL);
+    });
+
+    test(`catch error when renders the ${DUE_DILIGENCE_PAGE} page on GET method`, async () => {
+      mockGetApplicationData.mockImplementationOnce( () => { throw new Error(ANY_MESSAGE_ERROR); });
+      const resp = await request(app).get(DUE_DILIGENCE_URL);
+
+      expect(resp.status).toEqual(500);
+      expect(resp.text).toContain(SERVICE_UNAVAILABLE);
+    });
+  });
+
+  describe("POST tests", () => {
+
+    test(`redirect to ${ENTITY_PAGE} page after a successful post from ${DUE_DILIGENCE_PAGE} page`, async () => {
+      mockPrepareData.mockReturnValueOnce( DUE_DILIGENCE_OBJECT_MOCK );
+      const resp = await request(app)
+        .post(DUE_DILIGENCE_URL)
+        .send(DUE_DILIGENCE_REQ_BODY_OBJECT_MOCK);
+
+      expect(resp.status).toEqual(302);
+      expect(resp.text).toContain(`${FOUND_REDIRECT_TO} ${ENTITY_URL}`);
+    });
+
+    test(`renders the ${DUE_DILIGENCE_PAGE} with error messages`, async () => {
+      const resp = await request(app)
+        .post(DUE_DILIGENCE_URL)
+        .send(DUE_DILIGENCE_REQ_BODY_EMPTY_OBJECT_MOCK);
+
+      expect(resp.status).toEqual(200);
+      expect(resp.text).toContain(DUE_DILIGENCE_PAGE_TITLE);
+      expect(resp.text).toContain(ErrorMessages.DUE_DILIGENCE_NAME);
+      expect(resp.text).not.toContain(ErrorMessages.PROPERTY_NAME_OR_NUMBER);
+      expect(resp.text).toContain(ErrorMessages.ADDRESS_LINE1);
+      expect(resp.text).toContain(ErrorMessages.CITY_OR_TOWN);
+      expect(resp.text).toContain(ErrorMessages.COUNTY);
+      expect(resp.text).toContain(ErrorMessages.UK_COUNTRY);
+      expect(resp.text).toContain(ErrorMessages.POSTCODE);
+      expect(resp.text).toContain(ErrorMessages.EMAIL);
+      expect(resp.text).toContain(ErrorMessages.SUPERVISORY_NAME);
+      expect(resp.text).toContain(ErrorMessages.AGENT_CODE);
+      expect(resp.text).toContain(ErrorMessages.PARTNER_NAME);
+      expect(resp.text).toContain(ErrorMessages.CHECK_DILIGENCE);
+      expect(resp.text).toContain(WHO_IS_MAKING_FILING_URL);
+    });
+
+    test(`catch error when renders the ${DUE_DILIGENCE_PAGE} page on POST method`, async () => {
+      mockSetApplicationData.mockImplementationOnce( () => { throw new Error(ANY_MESSAGE_ERROR); });
+      const resp = await request(app)
+        .post(DUE_DILIGENCE_URL)
+        .send(DUE_DILIGENCE_REQ_BODY_OBJECT_MOCK);
+
+      expect(resp.status).toEqual(500);
+      expect(resp.text).toContain(SERVICE_UNAVAILABLE);
+    });
+  });
+});

--- a/test/controllers/entity.controller.spec.ts
+++ b/test/controllers/entity.controller.spec.ts
@@ -8,7 +8,7 @@ import { NextFunction, Request, Response } from "express";
 import request from "supertest";
 
 import app from "../../src/app";
-import { ENTITY_PAGE, ENTITY_URL, WHO_IS_MAKING_FILING_URL } from "../../src/config";
+import { DUE_DILIGENCE_URL, ENTITY_PAGE, ENTITY_URL, OVERSEAS_ENTITY_DUE_DILIGENCE_URL } from "../../src/config";
 import { getApplicationData, setApplicationData, prepareData } from "../../src/utils/application.data";
 import { authentication } from "../../src/middleware/authentication.middleware";
 import {
@@ -32,6 +32,7 @@ import {
   ENTITY_WITH_MAX_LENGTH_FIELDS_MOCK
 } from '../__mocks__/validation.mock';
 import { hasPresenter } from "../../src/middleware/navigation/has.presenter.middleware";
+import { WhoIsRegisteringKey, WhoIsRegisteringType } from '../../src/model/who.is.making.filing.model';
 
 const mockHasPresenterMiddleware = hasPresenter as jest.Mock;
 mockHasPresenterMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => next() );
@@ -50,14 +51,24 @@ describe("ENTITY controller", () => {
 
   describe("GET tests", () => {
 
-    test(`renders the ${ENTITY_PAGE} page`, async () => {
-      mockGetApplicationData.mockReturnValueOnce( { [EntityKey]: null } );
+    test(`renders the ${ENTITY_PAGE} page with ${DUE_DILIGENCE_URL} back link`, async () => {
+      mockGetApplicationData.mockReturnValueOnce( { [EntityKey]: null, [WhoIsRegisteringKey]: WhoIsRegisteringType.AGENT } );
       const resp = await request(app).get(ENTITY_URL);
 
       expect(resp.status).toEqual(200);
       expect(resp.text).toContain(ENTITY_PAGE_TITLE);
       expect(resp.text).toContain(INFORMATION_ON_PUBLIC_REGISTER);
-      expect(resp.text).toContain(WHO_IS_MAKING_FILING_URL); // Back link
+      expect(resp.text).toContain(DUE_DILIGENCE_URL);
+    });
+
+    test(`renders the ${ENTITY_PAGE} page with ${OVERSEAS_ENTITY_DUE_DILIGENCE_URL} back link`, async () => {
+      mockGetApplicationData.mockReturnValueOnce( { [EntityKey]: null, [WhoIsRegisteringKey]: WhoIsRegisteringType.SOMEONE_ELSE } );
+      const resp = await request(app).get(ENTITY_URL);
+
+      expect(resp.status).toEqual(200);
+      expect(resp.text).toContain(ENTITY_PAGE_TITLE);
+      expect(resp.text).toContain(INFORMATION_ON_PUBLIC_REGISTER);
+      expect(resp.text).toContain(OVERSEAS_ENTITY_DUE_DILIGENCE_URL);
     });
 
     test("renders the entity page on GET method with session data populated", async () => {
@@ -138,7 +149,7 @@ describe("ENTITY controller", () => {
       expect(resp.text).toContain(ErrorMessages.SELECT_IF_REGISTER_IN_COUNTRY_FORMED_IN);
       expect(resp.text).not.toContain(ErrorMessages.PUBLIC_REGISTER_NAME);
       expect(resp.text).not.toContain(ErrorMessages.PUBLIC_REGISTER_NUMBER);
-      expect(resp.text).toContain(WHO_IS_MAKING_FILING_URL);
+      expect(resp.text).toContain(OVERSEAS_ENTITY_DUE_DILIGENCE_URL);
     });
 
     test("renders the current page with public register error messages", async () => {
@@ -152,7 +163,7 @@ describe("ENTITY controller", () => {
       expect(resp.text).not.toContain(ErrorMessages.SELECT_IF_REGISTER_IN_COUNTRY_FORMED_IN);
       expect(resp.text).toContain(ErrorMessages.PUBLIC_REGISTER_NAME);
       expect(resp.text).toContain(ErrorMessages.PUBLIC_REGISTER_NUMBER);
-      expect(resp.text).toContain(WHO_IS_MAKING_FILING_URL);
+      expect(resp.text).toContain(OVERSEAS_ENTITY_DUE_DILIGENCE_URL);
     });
 
     test("renders the current page with MAX error messages", async () => {

--- a/test/controllers/overseas.entity.due.diligence.controller.spec.ts
+++ b/test/controllers/overseas.entity.due.diligence.controller.spec.ts
@@ -1,0 +1,130 @@
+jest.mock("ioredis");
+jest.mock('../../src/middleware/authentication.middleware');
+jest.mock('../../src/utils/application.data');
+jest.mock('../../src/middleware/navigation/has.presenter.middleware');
+
+import { describe, expect, test, jest, beforeEach } from '@jest/globals';
+import { NextFunction, Request, Response } from "express";
+import request from "supertest";
+
+import app from "../../src/app";
+import {
+  ENTITY_PAGE,
+  ENTITY_URL,
+  OVERSEAS_ENTITY_DUE_DILIGENCE_PAGE,
+  OVERSEAS_ENTITY_DUE_DILIGENCE_URL,
+  WHO_IS_MAKING_FILING_URL,
+} from "../../src/config";
+import { getApplicationData, setApplicationData, prepareData } from "../../src/utils/application.data";
+import { authentication } from "../../src/middleware/authentication.middleware";
+import {
+  ANY_MESSAGE_ERROR,
+  SERVICE_UNAVAILABLE,
+  OVERSEAS_ENTITY_DUE_DILIGENCE_PAGE_TITLE,
+  OVERSEAS_ENTITY_DUE_DILIGENCE_INFORMATION_ON_PUBLIC_REGISTER,
+  OVERSEAS_ENTITY_DUE_DILIGENCE_NAME_TEXT,
+  FOUND_REDIRECT_TO,
+} from "../__mocks__/text.mock";
+import { ErrorMessages } from '../../src/validation/error.messages';
+import { hasPresenter } from "../../src/middleware/navigation/has.presenter.middleware";
+import { OverseasEntityDueDiligenceKey } from '../../src/model/overseas.entity.due.diligence.model';
+import {
+  OVERSEAS_ENTITY_DUE_DILIGENCE_OBJECT_MOCK,
+  OVERSEAS_ENTITY_DUE_DILIGENCE_REQ_BODY_EMPTY_OBJECT_MOCK,
+  OVERSEAS_ENTITY_DUE_DILIGENCE_REQ_BODY_OBJECT_MOCK,
+} from "../__mocks__/overseas.entity.due.diligence.mock";
+
+const mockHasPresenterMiddleware = hasPresenter as jest.Mock;
+mockHasPresenterMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => next() );
+
+const mockGetApplicationData = getApplicationData as jest.Mock;
+const mockSetApplicationData = setApplicationData as jest.Mock;
+const mockPrepareData = prepareData as jest.Mock;
+const mockAuthenticationMiddleware = authentication as jest.Mock;
+mockAuthenticationMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => next() );
+
+describe("OVERSEAS_ENTITY_DUE_DILIGENCE controller", () => {
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("GET tests", () => {
+
+    test(`renders the ${OVERSEAS_ENTITY_DUE_DILIGENCE_PAGE}`, async () => {
+      mockGetApplicationData.mockReturnValueOnce( { [OverseasEntityDueDiligenceKey]: null } );
+      const resp = await request(app).get(OVERSEAS_ENTITY_DUE_DILIGENCE_URL);
+
+      expect(resp.status).toEqual(200);
+      expect(resp.text).toContain(OVERSEAS_ENTITY_DUE_DILIGENCE_PAGE_TITLE);
+      expect(resp.text).toContain(OVERSEAS_ENTITY_DUE_DILIGENCE_NAME_TEXT);
+      expect(resp.text).toContain(OVERSEAS_ENTITY_DUE_DILIGENCE_INFORMATION_ON_PUBLIC_REGISTER);
+      expect(resp.text).toContain(WHO_IS_MAKING_FILING_URL);
+    });
+
+    test(`renders the ${OVERSEAS_ENTITY_DUE_DILIGENCE_PAGE} page on GET method with session data populated`, async () => {
+      mockGetApplicationData.mockReturnValueOnce( { [OverseasEntityDueDiligenceKey]: OVERSEAS_ENTITY_DUE_DILIGENCE_OBJECT_MOCK } );
+      const resp = await request(app).get(OVERSEAS_ENTITY_DUE_DILIGENCE_URL);
+
+      expect(resp.status).toEqual(200);
+      expect(resp.text).toContain(OVERSEAS_ENTITY_DUE_DILIGENCE_PAGE_TITLE);
+      expect(resp.text).toContain(OVERSEAS_ENTITY_DUE_DILIGENCE_OBJECT_MOCK.name);
+      expect(resp.text).toContain(OVERSEAS_ENTITY_DUE_DILIGENCE_OBJECT_MOCK.email);
+      expect(resp.text).toContain(OVERSEAS_ENTITY_DUE_DILIGENCE_OBJECT_MOCK.supervisory_name);
+      expect(resp.text).toContain(OVERSEAS_ENTITY_DUE_DILIGENCE_OBJECT_MOCK.aml_number);
+      expect(resp.text).toContain(OVERSEAS_ENTITY_DUE_DILIGENCE_OBJECT_MOCK.partner_name);
+      expect(resp.text).toContain(WHO_IS_MAKING_FILING_URL);
+    });
+
+    test(`catch error when renders the ${OVERSEAS_ENTITY_DUE_DILIGENCE_PAGE} page on GET method`, async () => {
+      mockGetApplicationData.mockImplementationOnce( () => { throw new Error(ANY_MESSAGE_ERROR); });
+      const resp = await request(app).get(OVERSEAS_ENTITY_DUE_DILIGENCE_URL);
+
+      expect(resp.status).toEqual(500);
+      expect(resp.text).toContain(SERVICE_UNAVAILABLE);
+    });
+  });
+
+  describe("POST tests", () => {
+
+    test(`redirect to ${ENTITY_PAGE} page after a successful post from ${OVERSEAS_ENTITY_DUE_DILIGENCE_PAGE} page`, async () => {
+      mockPrepareData.mockReturnValueOnce( OVERSEAS_ENTITY_DUE_DILIGENCE_OBJECT_MOCK );
+      const resp = await request(app)
+        .post(OVERSEAS_ENTITY_DUE_DILIGENCE_URL)
+        .send(OVERSEAS_ENTITY_DUE_DILIGENCE_REQ_BODY_OBJECT_MOCK);
+
+      expect(resp.status).toEqual(302);
+      expect(resp.text).toContain(`${FOUND_REDIRECT_TO} ${ENTITY_URL}`);
+    });
+
+    test(`renders the ${OVERSEAS_ENTITY_DUE_DILIGENCE_PAGE} with error messages`, async () => {
+      const resp = await request(app)
+        .post(OVERSEAS_ENTITY_DUE_DILIGENCE_URL)
+        .send(OVERSEAS_ENTITY_DUE_DILIGENCE_REQ_BODY_EMPTY_OBJECT_MOCK);
+
+      expect(resp.status).toEqual(200);
+      expect(resp.text).toContain(OVERSEAS_ENTITY_DUE_DILIGENCE_PAGE_TITLE);
+      expect(resp.text).toContain(ErrorMessages.OE_DUE_DILIGENCE_NAME);
+      expect(resp.text).not.toContain(ErrorMessages.PROPERTY_NAME_OR_NUMBER);
+      expect(resp.text).toContain(ErrorMessages.ADDRESS_LINE1);
+      expect(resp.text).toContain(ErrorMessages.CITY_OR_TOWN);
+      expect(resp.text).toContain(ErrorMessages.COUNTY);
+      expect(resp.text).toContain(ErrorMessages.UK_COUNTRY);
+      expect(resp.text).toContain(ErrorMessages.POSTCODE);
+      expect(resp.text).toContain(ErrorMessages.EMAIL);
+      expect(resp.text).not.toContain(ErrorMessages.SUPERVISORY_NAME);
+      expect(resp.text).not.toContain(ErrorMessages.PARTNER_NAME);
+      expect(resp.text).toContain(WHO_IS_MAKING_FILING_URL);
+    });
+
+    test(`catch error when renders the ${OVERSEAS_ENTITY_DUE_DILIGENCE_PAGE} page on POST method`, async () => {
+      mockSetApplicationData.mockImplementationOnce( () => { throw new Error(ANY_MESSAGE_ERROR); });
+      const resp = await request(app)
+        .post(OVERSEAS_ENTITY_DUE_DILIGENCE_URL)
+        .send(OVERSEAS_ENTITY_DUE_DILIGENCE_REQ_BODY_OBJECT_MOCK);
+
+      expect(resp.status).toEqual(500);
+      expect(resp.text).toContain(SERVICE_UNAVAILABLE);
+    });
+  });
+});

--- a/test/controllers/who.is.making.filing.controller.spec.ts
+++ b/test/controllers/who.is.making.filing.controller.spec.ts
@@ -78,22 +78,23 @@ describe("Who is making filing controller tests", () => {
   });
 
   describe("POST tests", () => {
-    test(`redirect the ${config.ENTITY_PAGE} page when ${WhoIsRegisteringType.SOMEONE_ELSE} is selected`, async () => {
+    test(`redirect the ${config.OVERSEAS_ENTITY_DUE_DILIGENCE_URL} page when ${WhoIsRegisteringType.SOMEONE_ELSE} is selected`, async () => {
       const resp = await request(app)
         .post(config.WHO_IS_MAKING_FILING_URL)
         .send({ [WhoIsRegisteringKey]: WhoIsRegisteringType.SOMEONE_ELSE });
 
       expect(resp.status).toEqual(302);
+      expect(resp.header.location).toEqual(config.OVERSEAS_ENTITY_DUE_DILIGENCE_URL);
       expect(mockSetExtraData).toHaveBeenCalledTimes(1);
     });
 
-    test(`redirects to the ${config.ENTITY_PAGE} page when ${WhoIsRegisteringType.AGENT} is selected`, async () => {
+    test(`redirects to the ${config.DUE_DILIGENCE_URL} page when ${WhoIsRegisteringType.AGENT} is selected`, async () => {
       const resp = await request(app)
         .post(config.WHO_IS_MAKING_FILING_URL)
         .send({ [WhoIsRegisteringKey]: WhoIsRegisteringType.AGENT });
 
       expect(resp.status).toEqual(302);
-      expect(resp.header.location).toEqual(config.ENTITY_URL);
+      expect(resp.header.location).toEqual(config.DUE_DILIGENCE_URL);
       expect(mockSetExtraData).toHaveBeenCalledTimes(1);
     });
 

--- a/test/utils/application.data.spec.ts
+++ b/test/utils/application.data.spec.ts
@@ -1,5 +1,6 @@
 import { Request } from "express";
-import { describe, expect, test } from '@jest/globals';
+import { beforeEach, describe, expect, test } from '@jest/globals';
+
 import {
   getApplicationData,
   setApplicationData,
@@ -11,7 +12,6 @@ import {
   getFromApplicationData
 } from "../../src/utils/application.data";
 import {
-  ADDRESS,
   BO_GOV_ID,
   SERVICE_ADDRESS_MOCK,
   APPLICATION_DATA_MOCK,
@@ -20,6 +20,7 @@ import {
   getSessionRequestWithExtraData,
   getSessionRequestWithPermission,
 } from "../__mocks__/session.mock";
+import { ADDRESS } from "../__mocks__/fields/address.mock";
 import { beneficialOwnerIndividualType, dataType, entityType } from "../../src/model";
 import { ServiceAddressKeys } from '../../src/model/address.model';
 import { BeneficialOwnerGov, BeneficialOwnerGovKey } from '../../src/model/beneficial.owner.gov.model';

--- a/test/utils/navigation.spec.ts
+++ b/test/utils/navigation.spec.ts
@@ -1,0 +1,119 @@
+import { describe, expect, test } from '@jest/globals';
+
+import * as config from "../../src/config";
+import { WhoIsRegisteringKey, WhoIsRegisteringType } from '../../src/model/who.is.making.filing.model';
+
+import { NAVIGATION, getEntityBackLink } from "../../src/utils/navigation";
+
+describe("NAVIGATION utils", () => {
+
+  test(`getEntityBackLink returns ${config.DUE_DILIGENCE_URL} when ${WhoIsRegisteringType.AGENT} selected`, () => {
+    const entityBackLink = getEntityBackLink({ [WhoIsRegisteringKey]: WhoIsRegisteringType.AGENT });
+    expect(entityBackLink).toEqual(config.DUE_DILIGENCE_URL);
+  });
+
+  test(`getEntityBackLink returns ${config.OVERSEAS_ENTITY_DUE_DILIGENCE_URL} when ${WhoIsRegisteringType.SOMEONE_ELSE} selected`, () => {
+    const entityBackLink = getEntityBackLink({ [WhoIsRegisteringKey]: WhoIsRegisteringType.SOMEONE_ELSE });
+    expect(entityBackLink).toEqual(config.OVERSEAS_ENTITY_DUE_DILIGENCE_URL);
+  });
+
+  test(`NAVIGATION returns ${config.LANDING_URL} when calling previousPage on ${config.SOLD_LAND_FILTER_URL} object`, () => {
+    const navigation = NAVIGATION[config.SOLD_LAND_FILTER_URL].previousPage();
+    expect(navigation).toEqual(config.LANDING_URL);
+  });
+
+  test(`NAVIGATION returns ${config.SOLD_LAND_FILTER_URL} when calling previousPage on ${config.SECURE_REGISTER_FILTER_URL} object`, () => {
+    const navigation = NAVIGATION[config.SECURE_REGISTER_FILTER_URL].previousPage();
+    expect(navigation).toEqual(config.SOLD_LAND_FILTER_URL);
+  });
+
+  test(`NAVIGATION returns ${config.SECURE_REGISTER_FILTER_URL} when calling previousPage on ${config.INTERRUPT_CARD_URL} object`, () => {
+    const navigation = NAVIGATION[config.INTERRUPT_CARD_URL].previousPage();
+    expect(navigation).toEqual(config.SECURE_REGISTER_FILTER_URL);
+  });
+
+  test(`NAVIGATION returns ${config.INTERRUPT_CARD_URL} when calling previousPage on ${config.PRESENTER_URL} object`, () => {
+    const navigation = NAVIGATION[config.PRESENTER_URL].previousPage();
+    expect(navigation).toEqual(config.INTERRUPT_CARD_URL);
+  });
+
+  test(`NAVIGATION returns ${config.PRESENTER_URL} when calling previousPage on ${config.WHO_IS_MAKING_FILING_URL} object`, () => {
+    const navigation = NAVIGATION[config.WHO_IS_MAKING_FILING_URL].previousPage();
+    expect(navigation).toEqual(config.PRESENTER_URL);
+  });
+
+  test(`NAVIGATION returns ${config.WHO_IS_MAKING_FILING_URL} when calling previousPage on ${config.DUE_DILIGENCE_URL} object`, () => {
+    const navigation = NAVIGATION[config.DUE_DILIGENCE_URL].previousPage();
+    expect(navigation).toEqual(config.WHO_IS_MAKING_FILING_URL);
+  });
+
+  test(`NAVIGATION returns ${config.WHO_IS_MAKING_FILING_URL} when calling previousPage on ${config.OVERSEAS_ENTITY_DUE_DILIGENCE_URL} object`, () => {
+    const navigation = NAVIGATION[config.OVERSEAS_ENTITY_DUE_DILIGENCE_URL].previousPage();
+    expect(navigation).toEqual(config.WHO_IS_MAKING_FILING_URL);
+  });
+
+  test(`NAVIGATION returns ${config.ENTITY_URL} when calling previousPage on ${config.BENEFICIAL_OWNER_STATEMENTS_URL} object`, () => {
+    const navigation = NAVIGATION[config.BENEFICIAL_OWNER_STATEMENTS_URL].previousPage();
+    expect(navigation).toEqual(config.ENTITY_URL);
+  });
+
+  test(`NAVIGATION returns ${config.BENEFICIAL_OWNER_STATEMENTS_URL} when calling previousPage on ${config.BENEFICIAL_OWNER_TYPE_URL} object`, () => {
+    const navigation = NAVIGATION[config.BENEFICIAL_OWNER_TYPE_URL].previousPage();
+    expect(navigation).toEqual(config.BENEFICIAL_OWNER_STATEMENTS_URL);
+  });
+
+  test(`NAVIGATION returns ${config.BENEFICIAL_OWNER_TYPE_URL} when calling previousPage on ${config.BENEFICIAL_OWNER_INDIVIDUAL_URL} object`, () => {
+    const navigation = NAVIGATION[config.BENEFICIAL_OWNER_INDIVIDUAL_URL].previousPage();
+    expect(navigation).toEqual(config.BENEFICIAL_OWNER_TYPE_URL);
+  });
+
+  test(`NAVIGATION returns ${config.BENEFICIAL_OWNER_TYPE_URL} when calling previousPage on ${config.BENEFICIAL_OWNER_OTHER_URL} object`, () => {
+    const navigation = NAVIGATION[config.BENEFICIAL_OWNER_OTHER_URL].previousPage();
+    expect(navigation).toEqual(config.BENEFICIAL_OWNER_TYPE_URL);
+  });
+
+  test(`NAVIGATION returns ${config.BENEFICIAL_OWNER_TYPE_URL} when calling previousPage on ${config.BENEFICIAL_OWNER_GOV_URL} object`, () => {
+    const navigation = NAVIGATION[config.BENEFICIAL_OWNER_GOV_URL].previousPage();
+    expect(navigation).toEqual(config.BENEFICIAL_OWNER_TYPE_URL);
+  });
+
+  test(`NAVIGATION returns ${config.BENEFICIAL_OWNER_TYPE_URL} when calling previousPage on ${config.MANAGING_OFFICER_URL} object`, () => {
+    const navigation = NAVIGATION[config.MANAGING_OFFICER_URL].previousPage();
+    expect(navigation).toEqual(config.BENEFICIAL_OWNER_TYPE_URL);
+  });
+
+  test(`NAVIGATION returns ${config.BENEFICIAL_OWNER_TYPE_URL} when calling previousPage on ${config.MANAGING_OFFICER_CORPORATE_URL} object`, () => {
+    const navigation = NAVIGATION[config.MANAGING_OFFICER_CORPORATE_URL].previousPage();
+    expect(navigation).toEqual(config.BENEFICIAL_OWNER_TYPE_URL);
+  });
+
+  test(`NAVIGATION returns ${config.BENEFICIAL_OWNER_TYPE_URL} when calling previousPage on ${config.BENEFICIAL_OWNER_INDIVIDUAL_URL + config.ID} object`, () => {
+    const navigation = NAVIGATION[config.BENEFICIAL_OWNER_INDIVIDUAL_URL + config.ID].previousPage();
+    expect(navigation).toEqual(config.BENEFICIAL_OWNER_TYPE_URL);
+  });
+
+  test(`NAVIGATION returns ${config.BENEFICIAL_OWNER_TYPE_URL} when calling previousPage on ${config.BENEFICIAL_OWNER_OTHER_URL + config.ID} object`, () => {
+    const navigation = NAVIGATION[config.BENEFICIAL_OWNER_OTHER_URL + config.ID].previousPage();
+    expect(navigation).toEqual(config.BENEFICIAL_OWNER_TYPE_URL);
+  });
+
+  test(`NAVIGATION returns ${config.BENEFICIAL_OWNER_TYPE_URL} when calling previousPage on ${config.BENEFICIAL_OWNER_GOV_URL + config.ID} object`, () => {
+    const navigation = NAVIGATION[config.BENEFICIAL_OWNER_GOV_URL + config.ID].previousPage();
+    expect(navigation).toEqual(config.BENEFICIAL_OWNER_TYPE_URL);
+  });
+
+  test(`NAVIGATION returns ${config.BENEFICIAL_OWNER_TYPE_URL} when calling previousPage on ${config.MANAGING_OFFICER_URL + config.ID} object`, () => {
+    const navigation = NAVIGATION[config.MANAGING_OFFICER_URL + config.ID].previousPage();
+    expect(navigation).toEqual(config.BENEFICIAL_OWNER_TYPE_URL);
+  });
+
+  test(`NAVIGATION returns ${config.BENEFICIAL_OWNER_TYPE_URL} when calling previousPage on ${config.MANAGING_OFFICER_CORPORATE_URL + config.ID} object`, () => {
+    const navigation = NAVIGATION[config.MANAGING_OFFICER_CORPORATE_URL + config.ID].previousPage();
+    expect(navigation).toEqual(config.BENEFICIAL_OWNER_TYPE_URL);
+  });
+
+  test(`NAVIGATION returns ${config.BENEFICIAL_OWNER_TYPE_URL} when calling previousPage on ${config.TRUST_INFO_URL} object`, () => {
+    const navigation = NAVIGATION[config.TRUST_INFO_URL].previousPage();
+    expect(navigation).toEqual(config.BENEFICIAL_OWNER_TYPE_URL);
+  });
+});

--- a/views/due-diligence.html
+++ b/views/due-diligence.html
@@ -1,0 +1,83 @@
+{% extends "layout.html" %}
+
+{% block pageTitle %}
+  Complete this statement to confirm that identity checks have been completed - {{ SERVICE_NAME }} - GOV.UK
+{% endblock %}
+
+{% block backLink %}
+  {% include "includes/back-link.html" %}
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-xl">Complete this statement to confirm that identity checks have been completed</h1>
+
+      {% include "includes/list/errors.html" %}
+
+      <form method="post">
+
+        {% include "includes/inputs/date/identity-date-input.html" %}
+
+        {% set nameFieldText = "What is the agent's name?" %}
+        {% set nameFieldTextHint = "Enter the company name, or your own name if you are self-employed" %}
+        {% include "includes/inputs/fields/identity-name-input.html" %}
+
+        {% include "includes/inputs/address/identity-address-input.html" %}
+
+        {% set emailFieldText = "What is the email address?" %}
+        {% include "includes/inputs/fields/email-input.html" %}
+
+        {% include "includes/inputs/fields/supervisory-name-input.html" %}
+        {% include "includes/inputs/fields/aml-number-input.html" %}
+
+        {{ govukInput({
+          errorMessage: errors.agent_code if errors,
+          label: {
+            text: "What is the agent assurance code?",
+            classes: "govuk-label--m",
+            isPageHeading: false
+          },
+          hint: {
+            text: "This is provided by Companies House and is used to authenticate the UK-regulated agent"
+          },
+          classes: "govuk-!-width-one-half",
+          id: "agent_code",
+          name: "agent_code",
+          value: agent_code
+        }) }}
+
+        {% include "includes/inputs/fields/partner-name-input.html" %}
+
+        {{ govukCheckboxes({
+          errorMessage: errors.diligence if errors,
+          idPrefix: "diligence",
+          name: "diligence",
+          fieldset: {
+            legend: {
+              text: "Declaration",
+              isPageHeading: false,
+              classes: "govuk-fieldset__legend--m"
+            }
+          },
+          items: [
+            {
+              value: "agree",
+              text: "I confirm that verification has been carried out as required by The Register of Overseas Entities (Verification and Provision of Information) Regulations 2022. I confirm that the information provided in this statement is accurate.",
+              checked: diligence === "agree"
+            }
+          ]
+        }) }}
+
+        {% set headerBlock = '<h2 class="govuk-heading-m">Information shown on the public register</h2>' %}
+        {% set paragraphOne = '<p>The email address, agent assurance code and date the identity checks were completed will not be shown.</p>' %}
+        {% set paragraphTwo = '<p>All other information provided in this section will be shown on the public Register of Overseas Entities.</p>' %}
+        {% include "includes/inset-text.html" %}
+
+        {% include "includes/continue-button.html" %}
+
+      </form>
+    </div>
+  </div>
+{% endblock %}

--- a/views/due-diligence.html
+++ b/views/due-diligence.html
@@ -20,7 +20,7 @@
 
         {% include "includes/inputs/date/identity-date-input.html" %}
 
-        {% set nameFieldText = "What is the agent's name?" %}
+        {% set nameFieldText = "What is the agent’s name?" %}
         {% set nameFieldTextHint = "Enter the company name, or your own name if you are self-employed" %}
         {% include "includes/inputs/fields/identity-name-input.html" %}
 

--- a/views/includes/inputs/address/identity-address-input.html
+++ b/views/includes/inputs/address/identity-address-input.html
@@ -1,0 +1,112 @@
+{% call govukFieldset({
+  legend: {
+    text: "What is the correspondence address?",
+    classes: "govuk-fieldset__legend--m",
+    isPageHeading: false
+  }
+}) %}
+
+  {{ govukInput({
+    errorMessage: errors.identity_address_property_name_number if errors,
+    label: {
+      html: 'Property name or number'
+    },
+    hint: {
+      text: "For example, 'Saron House', '116' or 'Unit 37a'"
+    },
+    id: "identity_address_property_name_number",
+    name: "identity_address_property_name_number",
+    value: identity_address_property_name_number
+  }) }}
+
+  {{ govukInput({
+    errorMessage: errors.identity_address_line_1 if errors,
+    label: {
+      text: "Address line 1"
+    },
+    classes: "govuk-!-width-two-thirds",
+    id: "identity_address_line_1",
+    name: "identity_address_line_1",
+    value: identity_address_line_1
+  }) }}
+
+  {{ govukInput({
+    errorMessage: errors.identity_address_line_2 if errors,
+    label: {
+      text: "Address line 2 (optional)"
+    },
+    classes: "govuk-!-width-two-thirds",
+    id: "identity_address_line_2",
+    name: "identity_address_line_2",
+    value: identity_address_line_2
+  }) }}
+
+  {{ govukInput({
+    errorMessage: errors.identity_address_town if errors,
+    label: {
+      text: "City or town"
+    },
+    classes: "govuk-!-width-two-thirds",
+    id: "identity_address_town",
+    name: "identity_address_town",
+    value: identity_address_town
+  }) }}
+
+  {{ govukInput({
+    errorMessage: errors.identity_address_county if errors,
+    label: {
+      text: "County"
+    },
+    classes: "govuk-!-width-two-thirds",
+    id: "identity_address_county",
+    name: "identity_address_county",
+    value: identity_address_county
+  }) }}
+
+  {{ govukRadios({
+    errorMessage: errors.identity_address_country if errors,
+    classes: "govuk-radios",
+    idPrefix: "identity_address_country",
+    name: "identity_address_country",
+    fieldset: {
+      legend: {
+        text: "Country",
+        isPageHeading: false,
+        classes: "govuk-fieldset__legend"
+      }
+    },
+    items: [
+      {
+        value: "england",
+        text: "England",
+        checked: identity_address_country === "england"
+      },
+      {
+        value: "northern-ireland",
+        text: "Northern Ireland",
+        checked: identity_address_country === "northern-ireland"
+      },
+      {
+        value: "scotland",
+        text: "Scotland",
+        checked: identity_address_country === "scotland"
+      },
+      {
+        value: "wales",
+        text: "Wales",
+        checked: identity_address_country === "wales"
+      }
+    ]
+  }) }}
+
+  {{ govukInput({
+    errorMessage: errors.identity_address_postcode if errors,
+    label: {
+      text: "Postcode"
+    },
+    classes: "govuk-input--width-10",
+    id: "identity_address_postcode",
+    name: "identity_address_postcode",
+    value: identity_address_postcode
+  }) }}
+{% endcall %}

--- a/views/includes/inputs/date/identity-date-input.html
+++ b/views/includes/inputs/date/identity-date-input.html
@@ -1,0 +1,32 @@
+{{ govukDateInput({
+  errorMessage: errors.identity_date if errors,
+  id: "identity_date",
+  namePrefix: "identity_date",
+  fieldset: {
+    legend: {
+      text: "When were the identity checks completed?",
+      isPageHeading: false,
+      classes: "govuk-fieldset__legend--m"
+    }
+  },
+  hint: {
+    html: "<p>For example, 21 7 2022</p><p>The checks must have been carried out in the last 3 months.</p>"
+  },
+  items: [
+    {
+      classes: "govuk-input--width-2 govuk-input",
+      name: "day",
+      value: identity_date["identity_date-day"] if identity_date
+    },
+    {
+      classes: "govuk-input--width-2 govuk-input",
+      name: "month",
+      value: identity_date["identity_date-month"] if identity_date
+    },
+    {
+      classes: "govuk-input--width-4 govuk-input",
+      name: "year",
+      value: identity_date["identity_date-year"] if identity_date
+    }
+  ]
+}) }}

--- a/views/includes/inputs/date/identity-date-input.html
+++ b/views/includes/inputs/date/identity-date-input.html
@@ -10,7 +10,7 @@
     }
   },
   hint: {
-    html: "<p>For example, 21 7 2022</p><p>The checks must have been carried out in the last 3 months.</p>"
+    html: "For example, 21 7 2022. <br>The checks must have been carried out in the last 3 months."
   },
   items: [
     {

--- a/views/includes/inputs/fields/aml-number-input.html
+++ b/views/includes/inputs/fields/aml-number-input.html
@@ -1,0 +1,12 @@
+{{ govukInput({
+  errorMessage: errors.aml_number if errors,
+  label: {
+    text: "What is the Anti-Money Laundering (AML) registration number (if applicable)?",
+    classes: "govuk-label--m",
+    isPageHeading: false
+  },
+  classes: "govuk-!-width-one-half",
+  id: "aml_number",
+  name: "aml_number",
+  value: aml_number
+}) }}

--- a/views/includes/inputs/fields/email-input.html
+++ b/views/includes/inputs/fields/email-input.html
@@ -1,0 +1,14 @@
+{{ govukInput({
+    errorMessage: errors.email if errors,
+    label: {
+      text: emailFieldText,
+      classes: "govuk-label--m",
+      isPageHeading: false
+    },
+    hint: {
+      text: "We'll use this if we need more information about the identity checks"
+    },
+    id: "email",
+    name: "email",
+    value: email
+}) }}

--- a/views/includes/inputs/fields/identity-name-input.html
+++ b/views/includes/inputs/fields/identity-name-input.html
@@ -1,0 +1,14 @@
+{{ govukInput({
+  errorMessage: errors.name if errors,
+  label: {
+    text: nameFieldText,
+    classes: "govuk-label--m",
+    isPageHeading: false
+  },
+  hint: {
+    text: nameFieldTextHint
+  },
+  id: "name",
+  name: "name",
+  value: name
+}) }}

--- a/views/includes/inputs/fields/partner-name-input.html
+++ b/views/includes/inputs/fields/partner-name-input.html
@@ -1,0 +1,14 @@
+{{ govukInput({
+  errorMessage: errors.partner_name if errors,
+  label: {
+    text: "What is the name of the person with overall responsibility for identity checks?",
+    classes: "govuk-label--m",
+    isPageHeading: false
+  },
+  hint: {
+    text: "For example, tell us the name of the Head of Compliance"
+  },
+  id: "partner_name",
+  name: "partner_name",
+  value: partner_name
+}) }}

--- a/views/includes/inputs/fields/supervisory-name-input.html
+++ b/views/includes/inputs/fields/supervisory-name-input.html
@@ -1,0 +1,14 @@
+{{ govukInput({
+  errorMessage: errors.supervisory_name if errors,
+  label: {
+    text: "What is the name of the supervisory body?",
+    classes: "govuk-label--m",
+    isPageHeading: false
+  },
+  hint: {
+   text: "For example, the Solicitors Regulation Authority"
+  },
+  id: "supervisory_name",
+  name: "supervisory_name",
+  value: supervisory_name
+}) }}

--- a/views/includes/inset-text.html
+++ b/views/includes/inset-text.html
@@ -1,0 +1,3 @@
+{{ govukInsetText({
+    html: headerBlock + paragraphOne + paragraphTwo
+}) }}

--- a/views/overseas-entity-due-diligence.html
+++ b/views/overseas-entity-due-diligence.html
@@ -1,0 +1,46 @@
+{% extends "layout.html" %}
+
+{% block pageTitle %}
+  Tell us about the UK-regulated agent that carried out identity checks - {{ SERVICE_NAME }} - GOV.UK
+{% endblock %}
+
+{% block backLink %}
+  {% include "includes/back-link.html" %}
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-xl">Tell us about the UK-regulated agent that carried out identity checks</h1>
+
+      {% include "includes/list/errors.html" %}
+
+      <form method="post">
+
+        {% include "includes/inputs/date/identity-date-input.html" %}
+
+        {% set nameFieldText = "What is their name?" %}
+        {% set nameFieldTextHint = "Enter the company name, or the name of the person if they are self-employed" %}
+        {% include "includes/inputs/fields/identity-name-input.html" %}
+
+        {% include "includes/inputs/address/identity-address-input.html" %}
+
+        {% set emailFieldText = "What is their email address?" %}
+        {% include "includes/inputs/fields/email-input.html" %}
+
+        {% include "includes/inputs/fields/supervisory-name-input.html" %}
+        {% include "includes/inputs/fields/aml-number-input.html" %}
+        {% include "includes/inputs/fields/partner-name-input.html" %}
+
+        {% set headerBlock = '<h2 class="govuk-heading-m">Information shown on the public register</h2>' %}
+        {% set paragraphOne = '<p>The email address will not be shown.</p>' %}
+        {% set paragraphTwo = '<p>All other information provided in this section will be shown on the public Register of Overseas Entities.</p>' %}
+        {% include "includes/inset-text.html" %}
+
+        {% include "includes/continue-button.html" %}
+
+      </form>
+    </div>
+  </div>
+{% endblock %}


### PR DESCRIPTION
### JIRA link

Resolves [ROE-257](https://companieshouse.atlassian.net/browse/ROE-257) and [ROE-838](https://companieshouse.atlassian.net/browse/ROE-838)

### Change description

- Add identity view pages
- Add data model for identity object
- Add navigation and validation checks for identity pages
- Add routing and controller for the new pages and update navigation middleware
- Update `entity` controller with dynamic backlink page
- Update `who is completing this registration?` to correctly redirect user to the related identity page

### Work checklist

- [x] Tests added where applicable
- [x] UI changes meet accessibility criteria
