### PR TITLE
Handle scenarios with undefined data in session

### DIFF
--- a/src/utils/application.data.ts
+++ b/src/utils/application.data.ts
@@ -63,10 +63,16 @@ export const getFromApplicationData = (req: Request, key: string, id: string, er
   const appData: ApplicationData = getApplicationData(req.session);
 
   const index = getIndexInApplicationData(req, appData, key, id, errorIfNotFound);
-  if (index === -1 && errorIfNotFound) {
-    throw createAndLogErrorRequest(req, `application.data getFromApplicationData - unable to find object in session data for key ${key} and ID ${id}`);
+  if (index === -1) {
+    if (errorIfNotFound) {
+      throw createAndLogErrorRequest(req, `application.data getFromApplicationData - unable to find object in session data for key ${key} and ID ${id}`);
+    } else {
+      return undefined;
+    }
   }
-  return appData[key][index];
+  if (appData[key] !== undefined) {
+    return appData[key][index];
+  }
 };
 
 const getIndexInApplicationData = (req: Request, appData: ApplicationData, key: string, id: string, errorIfNotFound: boolean) => {

--- a/test/utils/application.data.spec.ts
+++ b/test/utils/application.data.spec.ts
@@ -147,4 +147,18 @@ describe("Application data utils", () => {
     req.session = session;
     expect(() => getFromApplicationData(req, BeneficialOwnerGovKey, undefined as unknown as string)).toThrow(`${BeneficialOwnerGovKey}`);
   });
+
+  test("getFromApplicationData should return undefined if error boolean false", () => {
+    const session = getSessionRequestWithExtraData();
+    req.session = session;
+    const bo: BeneficialOwnerGov =  getFromApplicationData(req, BeneficialOwnerGovKey, "no id", false);
+    expect(bo).toBeUndefined;
+  })
+
+  test("getFromApplicationData should return undefined if error boolean false", () => {
+    const session = getSessionRequestWithPermission();
+    req.session = session;
+    const bo: BeneficialOwnerGov =  getFromApplicationData(req, BeneficialOwnerGovKey, undefined as unknown as string, false);
+    expect(bo).toBeUndefined;
+  })
 });

--- a/test/utils/application.data.spec.ts
+++ b/test/utils/application.data.spec.ts
@@ -148,17 +148,17 @@ describe("Application data utils", () => {
     expect(() => getFromApplicationData(req, BeneficialOwnerGovKey, undefined as unknown as string)).toThrow(`${BeneficialOwnerGovKey}`);
   });
 
-  test("getFromApplicationData should return undefined if error boolean false", () => {
+  test("getFromApplicationData should return undefined if error boolean false and id not found", () => {
     const session = getSessionRequestWithExtraData();
     req.session = session;
     const bo: BeneficialOwnerGov =  getFromApplicationData(req, BeneficialOwnerGovKey, "no id", false);
     expect(bo).toBeUndefined;
-  })
+  });
 
-  test("getFromApplicationData should return undefined if error boolean false", () => {
+  test("getFromApplicationData should return undefined if error boolean false and id undefined", () => {
     const session = getSessionRequestWithPermission();
     req.session = session;
     const bo: BeneficialOwnerGov =  getFromApplicationData(req, BeneficialOwnerGovKey, undefined as unknown as string, false);
     expect(bo).toBeUndefined;
-  })
+  });
 });


### PR DESCRIPTION
### JIRA link
[ROE-526](https://companieshouse.atlassian.net/browse/ROE-526)


### Change description
Fix issue where session data is undefined if Individual or Other BO type was not stored.
Was falling over when submitting POST on Trust page.


### Work checklist

- [x] Tests added where applicable
- [ ] UI changes meet accessibility criteria
