### PR TITLE
ROE-878 adding validation to start date on gov BO page

### DIFF
--- a/src/validation/beneficial.owner.gov.validation.ts
+++ b/src/validation/beneficial.owner.gov.validation.ts
@@ -4,6 +4,7 @@ import { ErrorMessages } from "./error.messages";
 import { principal_address_validations, principal_service_address_validations } from "./fields/address.validation";
 import { VALID_CHARACTERS } from "./regex/regex.validation";
 import { checkAtLeastOneFieldHasValue } from "./custom.validation";
+import { start_date_validations } from "./fields/date.validation";
 
 export const beneficialOwnerGov = [
   body("name")
@@ -33,4 +34,6 @@ export const beneficialOwnerGov = [
 
   body("is_on_sanctions_list")
     .not().isEmpty().withMessage(ErrorMessages.SELECT_IF_ON_SANCTIONS_LIST),
+
+  ...start_date_validations,
 ];

--- a/src/validation/error.messages.ts
+++ b/src/validation/error.messages.ts
@@ -40,7 +40,7 @@ export enum ErrorMessages {
   ENTER_START_DATE = "Enter the date",
   INVALID_START_DATE = "Date entered must be a real date",
   INVALID_DATE_OF_BIRTH = "Date of birth must be a real date",
-  MO_START_DATE_NOT_IN_PAST = "The date it became a managing officer must be in the past",
+  START_DATE_NOT_IN_PAST = "The date must be in the past",
   // No radio selected
   SELECT_IF_ENTITY_HAS_SOLD_LAND = "Select yes if the entity has disposed of UK property or land since 28 February 2022",
   SELECT_IF_INDIVIDUAL_PERSON_HAS_FORMER_NAME = "Select yes if the individual person has any former names",

--- a/src/validation/fields/date.validation.ts
+++ b/src/validation/fields/date.validation.ts
@@ -7,7 +7,7 @@ export const start_date_validations = [
   body("start_date")
     .custom((value, { req }) => checkDate(ErrorMessages.ENTER_START_DATE, req.body["start_date-day"], req.body["start_date-month"], req.body["start_date-year"]))
     .custom((value, { req }) =>  checkDateValueIsValid(ErrorMessages.INVALID_START_DATE, req.body["start_date-day"], req.body["start_date-month"], req.body["start_date-year"]))
-    .custom((value, { req }) => checkDateIsInPast(ErrorMessages.MO_START_DATE_NOT_IN_PAST, req.body["start_date-day"], req.body["start_date-month"], req.body["start_date-year"])),
+    .custom((value, { req }) => checkDateIsInPast(ErrorMessages.START_DATE_NOT_IN_PAST, req.body["start_date-day"], req.body["start_date-month"], req.body["start_date-year"])),
   body("start_date-day").not().isEmpty({ ignore_whitespace: true }).withMessage(ErrorMessages.DAY),
   body("start_date-month").not().isEmpty({ ignore_whitespace: true }).withMessage(ErrorMessages.MONTH),
   body("start_date-year").not().isEmpty({ ignore_whitespace: true }).withMessage(ErrorMessages.YEAR)

--- a/test/__mocks__/session.mock.ts
+++ b/test/__mocks__/session.mock.ts
@@ -434,7 +434,7 @@ export const BENEFICIAL_OWNER_GOV_BODY_OBJECT_MOCK_WITH_ADDRESS = {
   is_service_address_same_as_principal_address: "1",
   legal_form: "LegalForm",
   law_governed: "a11",
-  start_date: { day: "12", month: "11", year: "1965" },
+  ...START_DATE,
   beneficial_owner_nature_of_control_types: [NatureOfControlType.OVER_25_PERCENT_OF_VOTING_RIGHTS],
   non_legal_firm_members_nature_of_control_types: [NatureOfControlType.OVER_25_PERCENT_OF_SHARES],
   is_on_sanctions_list: "1",
@@ -452,6 +452,19 @@ export const REQ_BODY_BENEFICIAL_OWNER_GOV_EMPTY = {
   start_date: { "start_date-day": "", "start_date-month": "", "start_date-year": "" },
   beneficial_owner_nature_of_control_types: "",
   non_legal_firm_members_nature_of_control_types: ""
+};
+
+export const REQ_BODY_BENEFICIAL_OWNER_GOV_FOR_DATE_VALIDATION: beneficialOwnerGovType.BeneficialOwnerGov = {
+  id: BO_GOV_ID,
+  name: COMPANY_NAME,
+  principal_address: ADDRESS,
+  is_service_address_same_as_principal_address: yesNoResponse.Yes,
+  service_address: ADDRESS,
+  legal_form: "LegalForm",
+  law_governed: "a11",
+  beneficial_owner_nature_of_control_types: [NatureOfControlType.OVER_25_PERCENT_OF_VOTING_RIGHTS],
+  non_legal_firm_members_nature_of_control_types: [NatureOfControlType.OVER_25_PERCENT_OF_SHARES],
+  is_on_sanctions_list: 1
 };
 
 export const MANAGING_OFFICER_OBJECT_MOCK: managingOfficerType.ManagingOfficerIndividual = {

--- a/test/controllers/beneficial.owner.gov.controller.spec.ts
+++ b/test/controllers/beneficial.owner.gov.controller.spec.ts
@@ -18,7 +18,7 @@ import {
   removeFromApplicationData,
   setApplicationData
 } from '../../src/utils/application.data';
-import { BENEFICIAL_OWNER_GOV_PAGE_HEADING, ERROR_LIST, MESSAGE_ERROR, SERVICE_UNAVAILABLE  } from "../__mocks__/text.mock";
+import { BENEFICIAL_OWNER_GOV_PAGE_HEADING, ERROR_LIST, MESSAGE_ERROR, SERVICE_UNAVAILABLE } from "../__mocks__/text.mock";
 import { logger } from "../../src/utils/logger";
 import {
   BENEFICIAL_OWNER_GOV_OBJECT_MOCK_WITH_SERVICE_ADDRESS_NO,
@@ -28,6 +28,7 @@ import {
   REQ_BODY_BENEFICIAL_OWNER_GOV_EMPTY,
   BO_GOV_ID,
   BO_GOV_ID_URL,
+  REQ_BODY_BENEFICIAL_OWNER_GOV_FOR_DATE_VALIDATION,
 } from "../__mocks__/session.mock";
 import { AddressKeys } from '../../src/model/data.types.model';
 import { ServiceAddressKey, ServiceAddressKeys } from "../../src/model/address.model";
@@ -210,6 +211,84 @@ describe("BENEFICIAL OWNER GOV controller", () => {
       expect(resp.text).toContain(ErrorMessages.LAW_GOVERNED);
       expect(resp.text).toContain(ErrorMessages.SELECT_NATURE_OF_CONTROL);
       expect(resp.text).toContain(ErrorMessages.SELECT_IF_ON_SANCTIONS_LIST);
+    });
+
+    test(`renders the ${config.BENEFICIAL_OWNER_GOV_PAGE} page with INVALID_START_DATE error when date is outside valid numbers`, async () => {
+      const beneficialOwnerGov = REQ_BODY_BENEFICIAL_OWNER_GOV_FOR_DATE_VALIDATION;
+      beneficialOwnerGov["start_date-day"] =  "31";
+      beneficialOwnerGov["start_date-month"] = "06";
+      beneficialOwnerGov["start_date-year"] = "2020";
+      const resp = await request(app)
+        .post(config.BENEFICIAL_OWNER_GOV_URL)
+        .send(beneficialOwnerGov);
+      expect(resp.status).toEqual(200);
+      expect(resp.text).toContain(BENEFICIAL_OWNER_GOV_PAGE_HEADING);
+      expect(resp.text).toContain(ErrorMessages.INVALID_START_DATE);
+    });
+
+    test(`renders the current page ${config.BENEFICIAL_OWNER_GOV_PAGE} with INVALID_START_DATE error when month is outside valid numbers`, async () => {
+      const beneficialOwnerGov = REQ_BODY_BENEFICIAL_OWNER_GOV_FOR_DATE_VALIDATION;
+      beneficialOwnerGov["start_date-day"] =  "30";
+      beneficialOwnerGov["start_date-month"] = "13";
+      beneficialOwnerGov["start_date-year"] = "2020";
+      const resp = await request(app)
+        .post(config.BENEFICIAL_OWNER_GOV_URL)
+        .send(beneficialOwnerGov);
+      expect(resp.status).toEqual(200);
+      expect(resp.text).toContain(BENEFICIAL_OWNER_GOV_PAGE_HEADING);
+      expect(resp.text).toContain(ErrorMessages.INVALID_START_DATE);
+    });
+
+    test(`renders the current page ${config.BENEFICIAL_OWNER_GOV_PAGE} with INVALID_START_DATE error when day is zero`, async () => {
+      const beneficialOwnerGov = REQ_BODY_BENEFICIAL_OWNER_GOV_FOR_DATE_VALIDATION;
+      beneficialOwnerGov["start_date-day"] =  "0";
+      beneficialOwnerGov["start_date-month"] = "12";
+      beneficialOwnerGov["start_date-year"] = "2020";
+      const resp = await request(app)
+        .post(config.BENEFICIAL_OWNER_GOV_URL)
+        .send(beneficialOwnerGov);
+      expect(resp.status).toEqual(200);
+      expect(resp.text).toContain(BENEFICIAL_OWNER_GOV_PAGE_HEADING);
+      expect(resp.text).toContain(ErrorMessages.INVALID_START_DATE);
+    });
+
+    test(`renders the current page ${config.BENEFICIAL_OWNER_GOV_PAGE} with INVALID_START_DATE error when month is zero`, async () => {
+      const beneficialOwnerGov = REQ_BODY_BENEFICIAL_OWNER_GOV_FOR_DATE_VALIDATION;
+      beneficialOwnerGov["start_date-day"] =  "30";
+      beneficialOwnerGov["start_date-month"] = "0";
+      beneficialOwnerGov["start_date-year"] = "2020";
+      const resp = await request(app)
+        .post(config.BENEFICIAL_OWNER_GOV_URL)
+        .send(beneficialOwnerGov);
+      expect(resp.status).toEqual(200);
+      expect(resp.text).toContain(BENEFICIAL_OWNER_GOV_PAGE_HEADING);
+      expect(resp.text).toContain(ErrorMessages.INVALID_START_DATE);
+    });
+
+    test(`renders the current page ${config.BENEFICIAL_OWNER_GOV_PAGE} with INVALID_START_DATE error when invalid characters are used`, async () => {
+      const beneficialOwnerGov = REQ_BODY_BENEFICIAL_OWNER_GOV_FOR_DATE_VALIDATION;
+      beneficialOwnerGov["start_date-day"] =  "a";
+      beneficialOwnerGov["start_date-month"] = "b";
+      beneficialOwnerGov["start_date-year"] = "c";
+      const resp = await request(app)
+        .post(config.BENEFICIAL_OWNER_GOV_URL)
+        .send(beneficialOwnerGov);
+      expect(resp.status).toEqual(200);
+      expect(resp.text).toContain(BENEFICIAL_OWNER_GOV_PAGE_HEADING);
+      expect(resp.text).toContain(ErrorMessages.INVALID_START_DATE);
+    });
+
+    test(`renders the current page ${config.BENEFICIAL_OWNER_GOV_PAGE} with START_DATE_NOT_IN_PAST error when start date is not in the past`, async () => {
+      const beneficialOwnerGov = REQ_BODY_BENEFICIAL_OWNER_GOV_FOR_DATE_VALIDATION;
+      beneficialOwnerGov["start_date-day"] =  "10";
+      beneficialOwnerGov["start_date-month"] = "10";
+      beneficialOwnerGov["start_date-year"] = "2050";
+      const resp = await request(app)
+        .post(config.BENEFICIAL_OWNER_GOV_URL)
+        .send(beneficialOwnerGov);
+      expect(resp.status).toEqual(200);
+      expect(resp.text).toContain(BENEFICIAL_OWNER_GOV_PAGE_HEADING);
+      expect(resp.text).toContain(ErrorMessages.START_DATE_NOT_IN_PAST);
     });
   });
 

--- a/views/managing-officer.html
+++ b/views/managing-officer.html
@@ -45,7 +45,7 @@
           fieldset: {
             legend: {
               text: "Do they have any former names?",
-              isPageHeading: true,
+              isPageHeading: false,
               classes: "govuk-fieldset__legend--m"
             }
           },


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/ROE-878


### Change description
adding standard validation to start date on gov BO page for missing date, invalid date and date not in the past. Also added a quick change to the managing officer html as that was flagging accessibility errors


### Work checklist

- [x] Tests added where applicable
- [x] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
