### PR TITLE
ROE-888 Fix to remove service address country and register info from …

### DIFF
--- a/src/controllers/entity.controller.ts
+++ b/src/controllers/entity.controller.ts
@@ -9,7 +9,7 @@ import {
 } from "../utils/application.data";
 import { EntityKey, EntityKeys } from "../model/entity.model";
 import { ApplicationData, ApplicationDataType } from "../model";
-import { AddressKeys, HasSamePrincipalAddressKey, IsOnRegisterInCountryFormedInKey } from "../model/data.types.model";
+import { AddressKeys, HasSamePrincipalAddressKey, IsOnRegisterInCountryFormedInKey, PublicRegisterNameKey, RegistrationNumberKey } from "../model/data.types.model";
 import { logger } from "../utils/logger";
 import * as config from "../config";
 import { PrincipalAddressKey, PrincipalAddressKeys, ServiceAddressKey, ServiceAddressKeys } from "../model/address.model";
@@ -51,6 +51,10 @@ export const post = (req: Request, res: Response, next: NextFunction) => {
       ?  mapFieldsToDataObject(req.body, ServiceAddressKeys, AddressKeys)
       :  {};
     data[IsOnRegisterInCountryFormedInKey] = (data[IsOnRegisterInCountryFormedInKey]) ? +data[IsOnRegisterInCountryFormedInKey] : '';
+
+    // Wipe 'register in country formed in' data if IsOnRegisterInCountryFormedInKey is no or not selected
+    data[PublicRegisterNameKey] = (data[IsOnRegisterInCountryFormedInKey]) ? data[PublicRegisterNameKey] : '';
+    data[RegistrationNumberKey] = (data[IsOnRegisterInCountryFormedInKey]) ? data[RegistrationNumberKey] : '';
 
     setApplicationData(req.session, data, EntityKey);
 

--- a/src/controllers/entity.controller.ts
+++ b/src/controllers/entity.controller.ts
@@ -53,8 +53,10 @@ export const post = (req: Request, res: Response, next: NextFunction) => {
     data[IsOnRegisterInCountryFormedInKey] = (data[IsOnRegisterInCountryFormedInKey]) ? +data[IsOnRegisterInCountryFormedInKey] : '';
 
     // Wipe 'register in country formed in' data if IsOnRegisterInCountryFormedInKey is no or not selected
-    data[PublicRegisterNameKey] = (data[IsOnRegisterInCountryFormedInKey]) ? data[PublicRegisterNameKey] : '';
-    data[RegistrationNumberKey] = (data[IsOnRegisterInCountryFormedInKey]) ? data[RegistrationNumberKey] : '';
+    if (!data[IsOnRegisterInCountryFormedInKey]) {
+      data[PublicRegisterNameKey] = '';
+      data[RegistrationNumberKey] = '';
+    }
 
     setApplicationData(req.session, data, EntityKey);
 

--- a/test/controllers/entity.controller.spec.ts
+++ b/test/controllers/entity.controller.spec.ts
@@ -24,7 +24,7 @@ import {
   SERVICE_UNAVAILABLE,
   INFORMATION_ON_PUBLIC_REGISTER,
 } from "../__mocks__/text.mock";
-import { HasSamePrincipalAddressKey, IsOnRegisterInCountryFormedInKey } from '../../src/model/data.types.model';
+import { HasSamePrincipalAddressKey, IsOnRegisterInCountryFormedInKey, PublicRegisterNameKey, RegistrationNumberKey } from '../../src/model/data.types.model';
 import { ErrorMessages } from '../../src/validation/error.messages';
 import { EntityKey } from '../../src/model/entity.model';
 import {
@@ -129,6 +129,10 @@ describe("ENTITY controller", () => {
 
       expect(resp.status).toEqual(302);
       expect(resp.text).toContain(BENEFICIAL_OWNER_STATEMENTS_PAGE_REDIRECT);
+
+      const data = mockSetApplicationData.mock.calls[0][1];
+      expect(data[PublicRegisterNameKey]).toEqual('');
+      expect(data[RegistrationNumberKey]).toEqual('');
     });
 
     test("renders the current page with error messages", async () => {

--- a/views/entity.html
+++ b/views/entity.html
@@ -35,7 +35,7 @@
           value: name
       }) }}
 
-      {% set countryField = incorporation_country %}
+      {% set countryField = incorporation_country if incorporation_country else '' %}
       {% set countryFieldNameId = "incorporation_country" %}
       {% set countryFieldText = "Which country was it formed in?" %}
       {% include "includes/inputs/country/country-select.html" %}

--- a/views/includes/inputs/address/principal-address-input.html
+++ b/views/includes/inputs/address/principal-address-input.html
@@ -65,7 +65,7 @@
     value: principal_address_county
   }) }}
 
-  {% set countryField = principal_address_country %}
+  {% set countryField = principal_address_country if principal_address_country else '' %}
   {% set countryFieldNameId = "principal_address_country" %}
   {% set countryFieldText = "Country" %}
   {% include "includes/inputs/country/country-select.html" %}

--- a/views/includes/inputs/address/residential-address-input.html
+++ b/views/includes/inputs/address/residential-address-input.html
@@ -64,7 +64,7 @@
     value: usual_residential_address_county
   }) }}
 
-  {% set countryField = usual_residential_address_country %}
+  {% set countryField = usual_residential_address_country if usual_residential_address_country else '' %}
   {% set countryFieldNameId = "usual_residential_address_country" %}
   {% set countryFieldText = "Country" %}
   {% include "includes/inputs/country/country-select.html" %}

--- a/views/includes/inputs/address/service-address-input.html
+++ b/views/includes/inputs/address/service-address-input.html
@@ -63,7 +63,7 @@
     value: service_address_county
   }) }}
 
-  {% set countryField = service_address_country if service_address_country %}
+  {% set countryField = service_address_country if service_address_country else '' %}
   {% set countryFieldNameId = "service_address_country" %}
   {% set countryFieldText = "Country" %}
   {% include "includes/inputs/country/country-select.html" %}

--- a/views/includes/inputs/address/service-address-input.html
+++ b/views/includes/inputs/address/service-address-input.html
@@ -63,7 +63,7 @@
     value: service_address_county
   }) }}
 
-  {% set countryField = service_address_country %}
+  {% set countryField = service_address_country if service_address_country %}
   {% set countryFieldNameId = "service_address_country" %}
   {% set countryFieldText = "Country" %}
   {% include "includes/inputs/country/country-select.html" %}


### PR DESCRIPTION
…entity screen when not selected

### JIRA link
https://companieshouse.atlassian.net/browse/ROE-888


### Change description
Fix to remove 'register in country formed in' data when register option is selected as 'no', any data previously entered in that section gets removed on submit. Also fix service address country, it was using the same value as entity country if loading the screen with entity data and no service address.


### Work checklist

- [x] Tests added where applicable
- [x] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
