### PR TITLE
ROE-807 ensure that the date on the MO page is in the past

### DIFF
--- a/test/controllers/beneficial.owner.individual.controller.spec.ts
+++ b/test/controllers/beneficial.owner.individual.controller.spec.ts
@@ -407,7 +407,7 @@ describe("BENEFICIAL OWNER INDIVIDUAL controller", () => {
       expect(resp.text).toContain(ErrorMessages.DATE_NOT_IN_PAST);
     });
 
-    test(`renders the current page ${BENEFICIAL_OWNER_INDIVIDUAL_PAGE} with DATE_NOT_IN_PAST_OR_TODAY error when start date is today`, async () => {
+    test(`renders the current page ${BENEFICIAL_OWNER_INDIVIDUAL_PAGE} with DATE_NOT_IN_PAST error when start date is today`, async () => {
       const beneficialOwnerOther = { ...BENEFICIAL_OWNER_INDIVIDUAL_REQ_BODY_OBJECT_MOCK_FOR_START_DATE };
       const today = DateTime.now();
       beneficialOwnerOther["date_of_birth-day"] =  today.day.toString();

--- a/test/controllers/managing.officer.controller.spec.ts
+++ b/test/controllers/managing.officer.controller.spec.ts
@@ -1,3 +1,5 @@
+import { DateTime } from "luxon";
+
 jest.mock("ioredis");
 jest.mock('../../src/middleware/authentication.middleware');
 jest.mock('../../src/utils/application.data');
@@ -329,71 +331,99 @@ describe("MANAGING_OFFICER controller", () => {
       const data: ApplicationDataType = mockSetApplicationData.mock.calls[0][1];
       expect(data[FormerNamesKey]).toEqual("");
     });
-  });
 
-  test(`renders the current page ${MANAGING_OFFICER_PAGE} with INVALID_DATE_OF_BIRTH error when date is outside valid numbers`, async () => {
-    const managingOfficer = REQ_BODY_MANAGING_OFFICER_FOR_DATE_VALIDATION;
-    managingOfficer["date_of_birth-day"] =  "31";
-    managingOfficer["date_of_birth-month"] = "06";
-    managingOfficer["date_of_birth-year"] = "2020";
-    const resp = await request(app)
-      .post(MANAGING_OFFICER_URL)
-      .send(managingOfficer);
-    expect(resp.status).toEqual(200);
-    expect(resp.text).toContain(MANAGING_OFFICER_PAGE_HEADING);
-    expect(resp.text).toContain(ErrorMessages.INVALID_DATE_OF_BIRTH);
-  });
+    test(`renders the current page ${MANAGING_OFFICER_PAGE} with INVALID_DATE_OF_BIRTH error when date is outside valid numbers`, async () => {
+      const managingOfficer = { ...REQ_BODY_MANAGING_OFFICER_FOR_DATE_VALIDATION };
+      managingOfficer["date_of_birth-day"] =  "31";
+      managingOfficer["date_of_birth-month"] = "06";
+      managingOfficer["date_of_birth-year"] = "2020";
+      const resp = await request(app)
+        .post(MANAGING_OFFICER_URL)
+        .send(managingOfficer);
+      expect(resp.status).toEqual(200);
+      expect(resp.text).toContain(MANAGING_OFFICER_PAGE_HEADING);
+      expect(resp.text).toContain(ErrorMessages.INVALID_DATE_OF_BIRTH);
+    });
 
-  test(`renders the current page ${MANAGING_OFFICER_PAGE} with INVALID_DATE_OF_BIRTH error when month is outside valid numbers`, async () => {
-    const managingOfficer = REQ_BODY_MANAGING_OFFICER_FOR_DATE_VALIDATION;
-    managingOfficer["date_of_birth-day"] =  "30";
-    managingOfficer["date_of_birth-month"] = "13";
-    managingOfficer["date_of_birth-year"] = "2020";
-    const resp = await request(app)
-      .post(MANAGING_OFFICER_URL)
-      .send(managingOfficer);
-    expect(resp.status).toEqual(200);
-    expect(resp.text).toContain(MANAGING_OFFICER_PAGE_HEADING);
-    expect(resp.text).toContain(ErrorMessages.INVALID_DATE_OF_BIRTH);
-  });
+    test(`renders the current page ${MANAGING_OFFICER_PAGE} with INVALID_DATE_OF_BIRTH error when month is outside valid numbers`, async () => {
+      const managingOfficer = { ...REQ_BODY_MANAGING_OFFICER_FOR_DATE_VALIDATION };
+      managingOfficer["date_of_birth-day"] =  "30";
+      managingOfficer["date_of_birth-month"] = "13";
+      managingOfficer["date_of_birth-year"] = "2020";
+      const resp = await request(app)
+        .post(MANAGING_OFFICER_URL)
+        .send(managingOfficer);
+      expect(resp.status).toEqual(200);
+      expect(resp.text).toContain(MANAGING_OFFICER_PAGE_HEADING);
+      expect(resp.text).toContain(ErrorMessages.INVALID_DATE_OF_BIRTH);
+    });
 
-  test(`renders the current page ${MANAGING_OFFICER_PAGE} with INVALID_DATE_OF_BIRTH error when day is zero`, async () => {
-    const managingOfficer = REQ_BODY_MANAGING_OFFICER_FOR_DATE_VALIDATION;
-    managingOfficer["date_of_birth-day"] =  "0";
-    managingOfficer["date_of_birth-month"] = "12";
-    managingOfficer["date_of_birth-year"] = "2020";
-    const resp = await request(app)
-      .post(MANAGING_OFFICER_URL)
-      .send(managingOfficer);
-    expect(resp.status).toEqual(200);
-    expect(resp.text).toContain(MANAGING_OFFICER_PAGE_HEADING);
-    expect(resp.text).toContain(ErrorMessages.INVALID_DATE_OF_BIRTH);
-  });
+    test(`renders the current page ${MANAGING_OFFICER_PAGE} with INVALID_DATE_OF_BIRTH error when day is zero`, async () => {
+      const managingOfficer = { ...REQ_BODY_MANAGING_OFFICER_FOR_DATE_VALIDATION };
+      managingOfficer["date_of_birth-day"] =  "0";
+      managingOfficer["date_of_birth-month"] = "12";
+      managingOfficer["date_of_birth-year"] = "2020";
+      const resp = await request(app)
+        .post(MANAGING_OFFICER_URL)
+        .send(managingOfficer);
+      expect(resp.status).toEqual(200);
+      expect(resp.text).toContain(MANAGING_OFFICER_PAGE_HEADING);
+      expect(resp.text).toContain(ErrorMessages.INVALID_DATE_OF_BIRTH);
+    });
 
-  test(`renders the current page ${MANAGING_OFFICER_PAGE} with INVALID_DATE_OF_BIRTH error when month is zero`, async () => {
-    const managingOfficer = REQ_BODY_MANAGING_OFFICER_FOR_DATE_VALIDATION;
-    managingOfficer["date_of_birth-day"] =  "30";
-    managingOfficer["date_of_birth-month"] = "0";
-    managingOfficer["date_of_birth-year"] = "2020";
-    const resp = await request(app)
-      .post(MANAGING_OFFICER_URL)
-      .send(managingOfficer);
-    expect(resp.status).toEqual(200);
-    expect(resp.text).toContain(MANAGING_OFFICER_PAGE_HEADING);
-    expect(resp.text).toContain(ErrorMessages.INVALID_DATE_OF_BIRTH);
-  });
+    test(`renders the current page ${MANAGING_OFFICER_PAGE} with INVALID_DATE_OF_BIRTH error when month is zero`, async () => {
+      const managingOfficer = { ...REQ_BODY_MANAGING_OFFICER_FOR_DATE_VALIDATION };
+      managingOfficer["date_of_birth-day"] =  "30";
+      managingOfficer["date_of_birth-month"] = "0";
+      managingOfficer["date_of_birth-year"] = "2020";
+      const resp = await request(app)
+        .post(MANAGING_OFFICER_URL)
+        .send(managingOfficer);
+      expect(resp.status).toEqual(200);
+      expect(resp.text).toContain(MANAGING_OFFICER_PAGE_HEADING);
+      expect(resp.text).toContain(ErrorMessages.INVALID_DATE_OF_BIRTH);
+    });
 
-  test(`renders the current page ${MANAGING_OFFICER_PAGE} with INVALID_DATE_OF_BIRTH error when invalid characters are used`, async () => {
-    const managingOfficer = REQ_BODY_MANAGING_OFFICER_FOR_DATE_VALIDATION;
-    managingOfficer["date_of_birth-day"] =  "a";
-    managingOfficer["date_of_birth-month"] = "b";
-    managingOfficer["date_of_birth-year"] = "c";
-    const resp = await request(app)
-      .post(MANAGING_OFFICER_URL)
-      .send(managingOfficer);
-    expect(resp.status).toEqual(200);
-    expect(resp.text).toContain(MANAGING_OFFICER_PAGE_HEADING);
-    expect(resp.text).toContain(ErrorMessages.INVALID_DATE_OF_BIRTH);
+    test(`renders the current page ${MANAGING_OFFICER_PAGE} with INVALID_DATE_OF_BIRTH error when invalid characters are used`, async () => {
+      const managingOfficer = { ...REQ_BODY_MANAGING_OFFICER_FOR_DATE_VALIDATION };
+      managingOfficer["date_of_birth-day"] =  "a";
+      managingOfficer["date_of_birth-month"] = "b";
+      managingOfficer["date_of_birth-year"] = "c";
+      const resp = await request(app)
+        .post(MANAGING_OFFICER_URL)
+        .send(managingOfficer);
+      expect(resp.status).toEqual(200);
+      expect(resp.text).toContain(MANAGING_OFFICER_PAGE_HEADING);
+      expect(resp.text).toContain(ErrorMessages.INVALID_DATE_OF_BIRTH);
+    });
+
+    test(`renders the current page ${MANAGING_OFFICER_PAGE} with DATE_NOT_IN_PAST error when start date is in the future`, async () => {
+      const managingOfficer = { ...REQ_BODY_MANAGING_OFFICER_FOR_DATE_VALIDATION };
+      const today = DateTime.now().plus({ days: 1 });
+      managingOfficer["date_of_birth-day"] =  today.day.toString();
+      managingOfficer["date_of_birth-month"] = today.month.toString();
+      managingOfficer["date_of_birth-year"] = today.year.toString();
+      const resp = await request(app)
+        .post(MANAGING_OFFICER_URL)
+        .send(managingOfficer);
+      expect(resp.status).toEqual(200);
+      expect(resp.text).toContain(MANAGING_OFFICER_PAGE_HEADING);
+      expect(resp.text).toContain(ErrorMessages.DATE_NOT_IN_PAST);
+    });
+
+    test(`renders the current page ${MANAGING_OFFICER_PAGE} with DATE_NOT_IN_PAST error when start date is today`, async () => {
+      const managingOfficer = { ...REQ_BODY_MANAGING_OFFICER_FOR_DATE_VALIDATION };
+      const today = DateTime.now();
+      managingOfficer["date_of_birth-day"] =  today.day.toString();
+      managingOfficer["date_of_birth-month"] = today.month.toString();
+      managingOfficer["date_of_birth-year"] = today.year.toString();
+      const resp = await request(app)
+        .post(MANAGING_OFFICER_URL)
+        .send(managingOfficer);
+      expect(resp.status).toEqual(200);
+      expect(resp.text).toContain(MANAGING_OFFICER_PAGE_HEADING);
+      expect(resp.text).toContain(ErrorMessages.DATE_NOT_IN_PAST);
+    });
   });
 
   describe("UPDATE tests", () => {


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/ROE-807


### Change description

MO Individual page was not unit tested to ensure that the date of birth is in the past. Corporate MO page has no dates.

Also a few indentation problems fixed. Updated tests to use copies of the MO mock object.

### Work checklist

- [x] Tests added where applicable
- [x] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
