### PR TITLE
ROE-1056 add matomo tracking to trust document download

### DIFF
--- a/src/middleware/validation.middleware.ts
+++ b/src/middleware/validation.middleware.ts
@@ -42,6 +42,7 @@ export function checkValidations(req: Request, res: Response, next: NextFunction
 
       return res.render(NAVIGATION[routePath].currentPage, {
         backLinkUrl: NAVIGATION[routePath].previousPage(appData),
+        templateName: NAVIGATION[routePath].currentPage,
         id,
         appData,
         ...req.body,
@@ -67,6 +68,7 @@ export function checkTrustValidations(req: Request, res: Response, next: NextFun
 
       return res.render(NAVIGATION[routePath].currentPage, {
         backLinkUrl: NAVIGATION[routePath].previousPage(appData),
+        templateName: NAVIGATION[routePath].currentPage,
         ...req.body,
         beneficialOwners: getBeneficialOwnerList(appData),
         trusts_input: req.body.trusts?.toString(),

--- a/views/trust-information.html
+++ b/views/trust-information.html
@@ -58,7 +58,7 @@
             </span>
           </summary>
           <div class="govuk-details__text" id="more-detail" value="data.['more-detail']">
-            <p class="govuk-body">Enter the trust information into the <a href="//{{CDN_HOST}}/static/services/overseas-entities/Companies%20House%20Trust%20Excel%20Document.xlsm" class="govuk-link">Trust Excel document (58KB)</a>. Be aware that this service will time out if you do not use it for 60 minutes. Your answers will not be saved.</p>
+            <p class="govuk-body">Enter the trust information into the <a href="//{{CDN_HOST}}/static/services/overseas-entities/Companies%20House%20Trust%20Excel%20Document.xlsm" class="govuk-link" data-event-id="trust-document-download-link">Trust Excel document (58KB)</a>. Be aware that this service will time out if you do not use it for 60 minutes. Your answers will not be saved.</p>
           </div>
         </details>
 


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/ROE-1056


### Change description
Work to add matomo tracking to trust document download. Also fixed a bug with how errors are captured in matomo causing them to not be tracked effectively.


### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
