### PR TITLE
ROE-1059 updating beneficial owner statement text on check answers page

### DIFF
--- a/test/__mocks__/text.mock.ts
+++ b/test/__mocks__/text.mock.ts
@@ -43,7 +43,7 @@ export const CREATE_OE__MSG_ERROR = "Something went wrong creating Overseas Enti
 export const FOUND_REDIRECT_TO = "Found. Redirecting to";
 export const REDIRECT_TO_SIGN_IN_PAGE = "User not authenticated, redirecting to sign in page, status_code=302";
 export const SERVICE_ADDRESS_SAME_AS_PRINCIPAL_ADDRESS_TEXT = "The correspondence address is the same as the entity's principal or registered office address";
-export const CHECK_YOUR_ANSWERS_PAGE_BENEFICIAL_OWNER_STATEMENTS_TITLE = "Have any beneficial owners been identified?";
+export const CHECK_YOUR_ANSWERS_PAGE_BENEFICIAL_OWNER_STATEMENTS_TITLE = "Have any registrable beneficial owners been identified?";
 export const CHECK_YOUR_ANSWERS_PAGE_BENEFICIAL_OWNER_STATEMENTS_SUB_TEXT = "Some beneficial owners have been identified and all required information can be provided";
 export const CHECK_YOUR_ANSWERS_PAGE_BENEFICIAL_OWNER_OTHER_SUB_TITLE = "Corporate beneficial owner";
 export const CHECK_YOUR_ANSWERS_PAGE_BENEFICIAL_OWNER_GOV_SUB_TITLE = "Government or public authority beneficial owner";

--- a/views/includes/check-your-answers/beneficial-owner-statements.html
+++ b/views/includes/check-your-answers/beneficial-owner-statements.html
@@ -8,7 +8,7 @@
     {% endif %}
 {% endset %}
 
-<h2 class="govuk-heading-l">Have any beneficial owners been identified?</h2>
+<h2 class="govuk-heading-l">Have any registrable beneficial owners been identified?</h2>
 
 {{ govukSummaryList({
     rows: [

--- a/views/interrupt-card.html
+++ b/views/interrupt-card.html
@@ -14,7 +14,7 @@
     <div class="govuk-grid-column-two-thirds">
       <div class="interrupt-card">
         <h1 class="govuk-heading-l">Before you start</h1>
-        <h2 class="govuk-heading-m">Agent assurance codes for identity checks</h2>
+        <h2 class="govuk-heading-m">Agent assurance codes for verification checks</h2>
         <p class="govuk-body">A UK-regulated agent must carry out <a href="https://www.gov.uk/guidance/register-an-overseas-entity/#what-identity-checks-are-needed" class="govuk-link" data-event-id="identity-checks-link">verification checks</a> on all beneficial owners and managing officers no more than 3 months before the overseas entity is registered. They'll need to provide an <a href="https://www.gov.uk/guidance/get-a-code-to-register-overseas-entities" class="govuk-link" data-event-id="agent-assurance-code-link">agent assurance code</a> to confirm they have authorisation to carry out verification checks.</p>
 
         <h2 class="govuk-heading-m">Trusts</h2>


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/ROE-1059


### Change description
Work to update beneficial owner statement heading text on check answers page. Also updated 'identity' to 'verification' on the interrupt-card page for missing work on ROE-1067


### Work checklist

- [ ] Tests added where applicable
- [x] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
