### PR TITLE
roe-1066 Ensure whitespaces are invalid  mo occupation field

### DIFF
--- a/src/validation/managing.officer.validation.ts
+++ b/src/validation/managing.officer.validation.ts
@@ -35,7 +35,7 @@ export const managingOfficerIndividual = [
 
   ...usual_residential_service_address_validations,
   body("occupation")
-    .not().isEmpty().withMessage(ErrorMessages.OCCUPATION)
+    .not().isEmpty({ ignore_whitespace: true }).withMessage(ErrorMessages.OCCUPATION)
     .isLength({ max: 100 }).withMessage(ErrorMessages.MAX_OCCUPATION_LENGTH)
     .matches(VALID_CHARACTERS).withMessage(ErrorMessages.OCCUPATION_INVALID_CHARACTERS),
 

--- a/test/__mocks__/session.mock.ts
+++ b/test/__mocks__/session.mock.ts
@@ -525,7 +525,7 @@ export const REQ_BODY_MANAGING_OFFICER_OBJECT_EMPTY = {
   usual_residential_address: {},
   service_address: {},
   is_service_address_same_as_usual_residential_address: "",
-  occupation: "",
+  occupation: " ",
   role_and_responsibilities: ""
 };
 


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/ROE-1066


### Change description
Added ignore whitespace to validation checks for the occupation field on Individual managing officer page.


### Work checklist

- [x] Tests added where applicable
- [x] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
