### PR TITLE
Remove session extra data when start query param present

### DIFF
--- a/src/controllers/sold.land.filter.controller.ts
+++ b/src/controllers/sold.land.filter.controller.ts
@@ -3,18 +3,23 @@ import { NextFunction, Request, Response } from "express";
 import { logger } from "../utils/logger";
 import * as config from "../config";
 import { ApplicationData } from "../model";
-import { getApplicationData, setExtraData } from "../utils/application.data";
-import { HasSoldLandKey } from "../model/data.types.model";
+import { deleteApplicationData, getApplicationData, setExtraData } from "../utils/application.data";
+import { HasSoldLandKey, LANDING_PAGE_QUERY_PARAM } from "../model/data.types.model";
 
 export const get = (req: Request, res: Response, next: NextFunction) => {
   try {
     logger.debugRequest(req, `GET ${config.SOLD_LAND_FILTER_PAGE}`);
+
+    if (req.query[LANDING_PAGE_QUERY_PARAM] === '0') {
+      deleteApplicationData(req.session);
+    }
+
     const appData: ApplicationData = getApplicationData(req.session);
 
     return res.render(config.SOLD_LAND_FILTER_PAGE, {
       backLinkUrl: config.LANDING_URL,
       templateName: config.SOLD_LAND_FILTER_PAGE,
-      [HasSoldLandKey]: appData[HasSoldLandKey]
+      [HasSoldLandKey]: appData?.[HasSoldLandKey]
     });
   } catch (error) {
     logger.errorRequest(req, error);

--- a/src/model/data.types.model.ts
+++ b/src/model/data.types.model.ts
@@ -44,6 +44,8 @@ export const InputDateKeys: string[] = [
   "year"
 ];
 
+export const LANDING_PAGE_QUERY_PARAM = "start";
+
 // BOs and MOs ID field name
 export const ID = "id";
 

--- a/test/controllers/sold.land.filter.controller.spec.ts
+++ b/test/controllers/sold.land.filter.controller.spec.ts
@@ -18,9 +18,12 @@ import {
 } from "../__mocks__/text.mock";
 import { ErrorMessages } from '../../src/validation/error.messages';
 
-import { getApplicationData, setExtraData } from "../../src/utils/application.data";
+import { deleteApplicationData, getApplicationData, setExtraData } from "../../src/utils/application.data";
 import { authentication } from "../../src/middleware/authentication.middleware";
 import { logger } from "../../src/utils/logger";
+import { LANDING_PAGE_QUERY_PARAM } from "../../src/model/data.types.model";
+
+const mockDeleteApplicationData = deleteApplicationData as jest.Mock;
 
 const mockAuthenticationMiddleware = authentication as jest.Mock;
 mockAuthenticationMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => next() );
@@ -44,6 +47,7 @@ describe("SOLD LAND FILTER controller", () => {
       expect(resp.text).toContain(SOLD_LAND_FILTER_PAGE_TITLE);
       expect(resp.text).not.toContain(RADIO_BUTTON_NO_SELECTED);
       expect(resp.text).not.toContain(RADIO_BUTTON_YES_SELECTED);
+      expect(mockDeleteApplicationData).toBeCalledTimes(0);
     });
 
     test(`renders the ${config.SOLD_LAND_FILTER_PAGE} page with radios selected to no`, async () => {
@@ -52,6 +56,7 @@ describe("SOLD LAND FILTER controller", () => {
 
       expect(resp.status).toEqual(200);
       expect(resp.text).toContain(RADIO_BUTTON_NO_SELECTED);
+      expect(mockDeleteApplicationData).toBeCalledTimes(0);
     });
 
     test(`renders the ${config.SOLD_LAND_FILTER_PAGE} page with radios selected to yes`, async () => {
@@ -60,6 +65,19 @@ describe("SOLD LAND FILTER controller", () => {
 
       expect(resp.status).toEqual(200);
       expect(resp.text).toContain(RADIO_BUTTON_YES_SELECTED);
+      expect(mockDeleteApplicationData).toBeCalledTimes(0);
+    });
+
+    test(`renders the ${config.SOLD_LAND_FILTER_PAGE} page, and calling the deleteApplicationData
+     if the following query param is present ${LANDING_PAGE_QUERY_PARAM}=0`, async () => {
+      const resp = await request(app)
+        .get(`${config.SOLD_LAND_FILTER_URL}?${LANDING_PAGE_QUERY_PARAM}=0`);
+
+      expect(resp.status).toEqual(200);
+      expect(resp.text).toContain(SOLD_LAND_FILTER_PAGE_TITLE);
+      expect(resp.text).not.toContain(RADIO_BUTTON_NO_SELECTED);
+      expect(resp.text).not.toContain(RADIO_BUTTON_YES_SELECTED);
+      expect(mockDeleteApplicationData).toBeCalledTimes(1);
     });
 
     test("catch error when rendering the page", async () => {


### PR DESCRIPTION
### JIRA link

Resolves [ROE-1080](https://companieshouse.atlassian.net/browse/ROE-1080)

### Change description

Remove session extra data on SOLD_LAND_FILTER_PAGE when `?start=0` query param is present

### Work checklist

- [x] Tests added where applicable
- [x] UI changes meet accessibility criteria
