### PR TITLE
ROE-1134 Change address property-name-number fields length to be 50 max

### DIFF
--- a/src/validation/error.messages.ts
+++ b/src/validation/error.messages.ts
@@ -79,7 +79,7 @@ export enum ErrorMessages {
   MAX_PARTNER_NAME_LENGTH = "Name of person with overall responsibility must be 256 characters or less",
   MAX_EMAIL_LENGTH = "Email address must be 250 characters or less",
   MAX_EMAIL_LENGTH_DUE_DILIGENCE = "Email address must be 256 characters or less",
-  MAX_PROPERTY_NAME_OR_NUMBER_LENGTH = "Property name or number must be 200 characters or less",
+  MAX_PROPERTY_NAME_OR_NUMBER_LENGTH = "Property name or number must be 50 characters or less",
   MAX_ADDRESS_LINE1_LENGTH = "Address line 1 must be 50 characters or less",
   MAX_ADDRESS_LINE2_LENGTH = "Address line 2 must be 50 characters or less",
   MAX_CITY_OR_TOWN_LENGTH = "City or town must be 50 characters or less",

--- a/src/validation/fields/address.validation.ts
+++ b/src/validation/fields/address.validation.ts
@@ -11,7 +11,7 @@ import { VALID_CHARACTERS } from "../regex/regex.validation";
 export const principal_address_validations = [
   body("principal_address_property_name_number")
     .not().isEmpty({ ignore_whitespace: true }).withMessage(ErrorMessages.PROPERTY_NAME_OR_NUMBER)
-    .isLength({ max: 200 }).withMessage(ErrorMessages.MAX_PROPERTY_NAME_OR_NUMBER_LENGTH)
+    .isLength({ max: 50 }).withMessage(ErrorMessages.MAX_PROPERTY_NAME_OR_NUMBER_LENGTH)
     .matches(VALID_CHARACTERS).withMessage(ErrorMessages.PROPERTY_NAME_OR_NUMBER_INVALID_CHARACTERS),
   body("principal_address_line_1")
     .not().isEmpty({ ignore_whitespace: true }).withMessage(ErrorMessages.ADDRESS_LINE1)
@@ -37,7 +37,7 @@ export const principal_address_validations = [
 export const principal_service_address_validations = [
   body("service_address_property_name_number")
     .custom((value, { req }) => checkFieldIfRadioButtonSelected(req.body.is_service_address_same_as_principal_address === '0', ErrorMessages.PROPERTY_NAME_OR_NUMBER, value) )
-    .custom((value, { req }) => checkMaxFieldIfRadioButtonSelected(req.body.is_service_address_same_as_principal_address === '0', ErrorMessages.MAX_PROPERTY_NAME_OR_NUMBER_LENGTH, 200, value) )
+    .custom((value, { req }) => checkMaxFieldIfRadioButtonSelected(req.body.is_service_address_same_as_principal_address === '0', ErrorMessages.MAX_PROPERTY_NAME_OR_NUMBER_LENGTH, 50, value) )
     .custom((value, { req }) => checkInvalidCharactersIfRadioButtonSelected(req.body.is_service_address_same_as_principal_address === '0', ErrorMessages.PROPERTY_NAME_OR_NUMBER_INVALID_CHARACTERS, value) ),
   body("service_address_line_1")
     .custom((value, { req }) => checkFieldIfRadioButtonSelected(req.body.is_service_address_same_as_principal_address === '0', ErrorMessages.ADDRESS_LINE1, value) )
@@ -64,7 +64,7 @@ export const usual_residential_address_validations = [
   body("usual_residential_address_property_name_number")
     .not().isEmpty({ ignore_whitespace: true }).withMessage(ErrorMessages.PROPERTY_NAME_OR_NUMBER)
     .matches(VALID_CHARACTERS).withMessage(ErrorMessages.PROPERTY_NAME_OR_NUMBER_INVALID_CHARACTERS)
-    .isLength({ max: 200 }).withMessage(ErrorMessages.MAX_PROPERTY_NAME_OR_NUMBER_LENGTH),
+    .isLength({ max: 50 }).withMessage(ErrorMessages.MAX_PROPERTY_NAME_OR_NUMBER_LENGTH),
   body("usual_residential_address_line_1")
     .not().isEmpty({ ignore_whitespace: true }).withMessage(ErrorMessages.ADDRESS_LINE1)
     .matches(VALID_CHARACTERS).withMessage(ErrorMessages.ADDRESS_LINE_1_INVALID_CHARACTERS)
@@ -89,7 +89,7 @@ export const usual_residential_address_validations = [
 export const usual_residential_service_address_validations = [
   body("service_address_property_name_number")
     .custom((value, { req }) => checkFieldIfRadioButtonSelected(req.body.is_service_address_same_as_usual_residential_address === '0', ErrorMessages.PROPERTY_NAME_OR_NUMBER, value) )
-    .custom((value, { req }) => checkMaxFieldIfRadioButtonSelected(req.body.is_service_address_same_as_usual_residential_address === '0', ErrorMessages.MAX_PROPERTY_NAME_OR_NUMBER_LENGTH, 200, value) )
+    .custom((value, { req }) => checkMaxFieldIfRadioButtonSelected(req.body.is_service_address_same_as_usual_residential_address === '0', ErrorMessages.MAX_PROPERTY_NAME_OR_NUMBER_LENGTH, 50, value) )
     .custom((value, { req }) => checkInvalidCharactersIfRadioButtonSelected(req.body.is_service_address_same_as_usual_residential_address === '0', ErrorMessages.PROPERTY_NAME_OR_NUMBER_INVALID_CHARACTERS, value)),
   body("service_address_line_1")
     .custom((value, { req }) => checkFieldIfRadioButtonSelected(req.body.is_service_address_same_as_usual_residential_address === '0', ErrorMessages.ADDRESS_LINE1, value) )
@@ -113,7 +113,7 @@ export const usual_residential_service_address_validations = [
 
 export const identity_address_validations = [
   body("identity_address_property_name_number")
-    .isLength({ max: 200 }).withMessage(ErrorMessages.MAX_PROPERTY_NAME_OR_NUMBER_LENGTH)
+    .isLength({ max: 50 }).withMessage(ErrorMessages.MAX_PROPERTY_NAME_OR_NUMBER_LENGTH)
     .matches(VALID_CHARACTERS).withMessage(ErrorMessages.PROPERTY_NAME_OR_NUMBER_INVALID_CHARACTERS),
   body("identity_address_line_1")
     .not().isEmpty({ ignore_whitespace: true }).withMessage(ErrorMessages.ADDRESS_LINE1)

--- a/test/__mocks__/fields/address.mock.ts
+++ b/test/__mocks__/fields/address.mock.ts
@@ -1,4 +1,4 @@
-import { MAX_200, MAX_50, NO_MAX } from "../max.length.mock";
+import { MAX_50, NO_MAX } from "../max.length.mock";
 
 export const ADDRESS = {
   property_name_number: "1",
@@ -31,7 +31,7 @@ export const IDENTITY_ADDRESS_REQ_BODY_EMPTY_MOCK = {
 };
 
 export const IDENTITY_ADDRESS_REQ_BODY_MAX_LENGTH_MOCK = {
-  identity_address_property_name_number: MAX_200 + "1",
+  identity_address_property_name_number: MAX_50 + "1",
   identity_address_line_1: MAX_50 + "1",
   identity_address_line_2: MAX_50 + "1",
   identity_address_town: MAX_50 + "1",

--- a/test/__mocks__/validation.mock.ts
+++ b/test/__mocks__/validation.mock.ts
@@ -11,7 +11,7 @@ const INVALID_CHARS = "Дракон";
 const EMAIL_INVALID_FORMAT = "lorem@ipsum";
 
 const PRINCIPAL_ADDRESS_WITH_MAX_LENGTH_FIELDS_MOCK = {
-  principal_address_property_name_number: maxLengthMocks.MAX_200 + "1",
+  principal_address_property_name_number: maxLengthMocks.MAX_50 + "1",
   principal_address_line_1: maxLengthMocks.MAX_50 + "1",
   principal_address_line_2: maxLengthMocks.MAX_50 + "1",
   principal_address_town: maxLengthMocks.MAX_50 + "1",
@@ -31,7 +31,7 @@ const PRINCIPAL_ADDRESS_WITH_INVALID_CHARACTERS_FIELDS_MOCK = {
 };
 
 const RESIDENTIAL_ADDRESS_WITH_MAX_LENGTH_FIELDS_MOCK = {
-  usual_residential_address_property_name_number: maxLengthMocks.MAX_200 + "1",
+  usual_residential_address_property_name_number: maxLengthMocks.MAX_50 + "1",
   usual_residential_address_line_1: maxLengthMocks.MAX_50 + "1",
   usual_residential_address_line_2: maxLengthMocks.MAX_50 + "1",
   usual_residential_address_town: maxLengthMocks.MAX_50 + "1",
@@ -41,7 +41,7 @@ const RESIDENTIAL_ADDRESS_WITH_MAX_LENGTH_FIELDS_MOCK = {
 };
 
 const SERVICE_ADDRESS_WITH_MAX_LENGTH_FIELDS_MOCK = {
-  service_address_property_name_number: maxLengthMocks.MAX_200 + "1",
+  service_address_property_name_number: maxLengthMocks.MAX_50 + "1",
   service_address_line_1: maxLengthMocks.MAX_50 + "1",
   service_address_line_2: maxLengthMocks.MAX_50 + "1",
   service_address_town: maxLengthMocks.MAX_50 + "1",


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/ROE-1134

### Change description
Changing all address "property name number" fields to be max 50 chars instead of 200


### Work checklist

- [x] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
