### PR TITLE
ROE-1135 Adding trust address premises validation to match validation…

### DIFF
--- a/src/model/trust.model.ts
+++ b/src/model/trust.model.ts
@@ -40,7 +40,7 @@ interface TrustIndividual {
   sa_address_locality: string;
   sa_address_po_box: string;
   sa_address_postal_code: string;
-  sa_address_premises: string;
+  sa_address_premises?: string;
   sa_address_region: string;
   ura_address_line1: string;
   ura_address_line2: string;
@@ -49,7 +49,7 @@ interface TrustIndividual {
   ura_address_locality: string;
   ura_address_po_box: string;
   ura_address_postal_code: string;
-  ura_address_premises: string;
+  ura_address_premises?: string;
   ura_address_region: string;
   date_became_interested_person_day: string;
   date_became_interested_person_month: string;
@@ -81,7 +81,7 @@ interface TrustCorporate {
   ro_address_locality: string;
   ro_address_po_box: string;
   ro_address_postal_code: string;
-  ro_address_premises: string;
+  ro_address_premises?: string;
   ro_address_region: string;
   sa_address_line1: string;
   sa_address_line2: string;
@@ -90,7 +90,7 @@ interface TrustCorporate {
   sa_address_locality: string;
   sa_address_po_box: string;
   sa_address_postal_code: string;
-  sa_address_premises: string;
+  sa_address_premises?: string;
   sa_address_region: string;
   identification_country_registration: string;
   identification_legal_authority: string;

--- a/src/validation/custom.validation.ts
+++ b/src/validation/custom.validation.ts
@@ -91,8 +91,9 @@ export const checkAtLeastOneFieldHasValue = (errMsg: string, ...fields: any[]) =
   throw new Error(errMsg);
 };
 
-export const checkMandatoryTrustFields = (nameErrMsg, dateErrMsg, trustsJson: string) => {
+export const checkMandatoryTrustFields = (trustsJson: string) => {
   const trusts: trustType.Trust[] = JSON.parse(trustsJson);
+
   for (const trust of trusts) {
     if (
       trust.creation_date_day === undefined ||
@@ -102,10 +103,35 @@ export const checkMandatoryTrustFields = (nameErrMsg, dateErrMsg, trustsJson: st
       trust.creation_date_year === undefined ||
       trust.creation_date_year === ""
     ) {
-      throw new Error(dateErrMsg);
+      throw new Error(ErrorMessages.TRUST_CREATION_DATE);
     }
+
     if (trust.trust_name === undefined || trust.trust_name === "") {
-      throw new Error(nameErrMsg);
+      throw new Error(ErrorMessages.TRUST_NAME);
+    }
+
+    const addressMaxLength = 50;
+
+    if (trust.INDIVIDUALS) {
+      for (const individual of trust.INDIVIDUALS) {
+        if (individual.ura_address_premises?.length > addressMaxLength) {
+          throw new Error(ErrorMessages.TRUST_INDIVIDUAL_HOME_ADDRESS_LENGTH);
+        }
+        if (individual.sa_address_premises?.length > addressMaxLength) {
+          throw new Error(ErrorMessages.TRUST_INDIVIDUAL_CORRESPONDENCE_ADDRESS_LENGTH);
+        }
+      }
+    }
+
+    if (trust.CORPORATES) {
+      for (const corporate of trust.CORPORATES) {
+        if (corporate.ro_address_premises?.length > addressMaxLength) {
+          throw new Error(ErrorMessages.TRUST_CORPORATE_REGISTERED_OFFICE_ADDRESS_LENGTH);
+        }
+        if (corporate.sa_address_premises?.length > addressMaxLength) {
+          throw new Error(ErrorMessages.TRUST_CORPORATE_CORRESPONDENCE_ADDRESS_LENGTH);
+        }
+      }
     }
   }
   return true;

--- a/src/validation/custom.validation.ts
+++ b/src/validation/custom.validation.ts
@@ -91,7 +91,7 @@ export const checkAtLeastOneFieldHasValue = (errMsg: string, ...fields: any[]) =
   throw new Error(errMsg);
 };
 
-export const checkMandatoryTrustFields = (trustsJson: string) => {
+export const checkTrustFields = (trustsJson: string) => {
   const trusts: trustType.Trust[] = JSON.parse(trustsJson);
   const addressMaxLength = 50;
 
@@ -127,10 +127,10 @@ const checkTrustName = (trust: trustType.Trust) => {
 const checkIndividualsAddress = (trust: trustType.Trust, addressMaxLength: number) => {
   if (trust.INDIVIDUALS) {
     for (const individual of trust.INDIVIDUALS) {
-      if (individual.ura_address_premises?.length > addressMaxLength) {
+      if (individual.ura_address_premises && individual.ura_address_premises.length > addressMaxLength) {
         throw new Error(ErrorMessages.TRUST_INDIVIDUAL_HOME_ADDRESS_LENGTH);
       }
-      if (individual.sa_address_premises?.length > addressMaxLength) {
+      if (individual.sa_address_premises && individual.sa_address_premises.length > addressMaxLength) {
         throw new Error(ErrorMessages.TRUST_INDIVIDUAL_CORRESPONDENCE_ADDRESS_LENGTH);
       }
     }
@@ -140,10 +140,10 @@ const checkIndividualsAddress = (trust: trustType.Trust, addressMaxLength: numbe
 const checkCorporatesAddress = (trust: trustType.Trust, addressMaxLength: number) => {
   if (trust.CORPORATES) {
     for (const corporate of trust.CORPORATES) {
-      if (corporate.ro_address_premises?.length > addressMaxLength) {
+      if (corporate.ro_address_premises && corporate.ro_address_premises.length > addressMaxLength) {
         throw new Error(ErrorMessages.TRUST_CORPORATE_REGISTERED_OFFICE_ADDRESS_LENGTH);
       }
-      if (corporate.sa_address_premises?.length > addressMaxLength) {
+      if (corporate.sa_address_premises && corporate.sa_address_premises.length > addressMaxLength) {
         throw new Error(ErrorMessages.TRUST_CORPORATE_CORRESPONDENCE_ADDRESS_LENGTH);
       }
     }

--- a/src/validation/custom.validation.ts
+++ b/src/validation/custom.validation.ts
@@ -93,46 +93,59 @@ export const checkAtLeastOneFieldHasValue = (errMsg: string, ...fields: any[]) =
 
 export const checkMandatoryTrustFields = (trustsJson: string) => {
   const trusts: trustType.Trust[] = JSON.parse(trustsJson);
+  const addressMaxLength = 50;
 
   for (const trust of trusts) {
-    if (
-      trust.creation_date_day === undefined ||
-      trust.creation_date_day === "" ||
-      trust.creation_date_month === undefined ||
-      trust.creation_date_month === "" ||
-      trust.creation_date_year === undefined ||
-      trust.creation_date_year === ""
-    ) {
-      throw new Error(ErrorMessages.TRUST_CREATION_DATE);
-    }
+    checkTrustCreationDate(trust);
 
-    if (trust.trust_name === undefined || trust.trust_name === "") {
-      throw new Error(ErrorMessages.TRUST_NAME);
-    }
+    checkTrustName(trust);
 
-    const addressMaxLength = 50;
+    checkIndividualsAddress(trust, addressMaxLength);
 
-    if (trust.INDIVIDUALS) {
-      for (const individual of trust.INDIVIDUALS) {
-        if (individual.ura_address_premises?.length > addressMaxLength) {
-          throw new Error(ErrorMessages.TRUST_INDIVIDUAL_HOME_ADDRESS_LENGTH);
-        }
-        if (individual.sa_address_premises?.length > addressMaxLength) {
-          throw new Error(ErrorMessages.TRUST_INDIVIDUAL_CORRESPONDENCE_ADDRESS_LENGTH);
-        }
+    checkCorporatesAddress(trust, addressMaxLength);
+  }
+  return true;
+};
+
+const checkTrustCreationDate = (trust: trustType.Trust) => {
+  if (trust.creation_date_day === undefined ||
+    trust.creation_date_day === "" ||
+    trust.creation_date_month === undefined ||
+    trust.creation_date_month === "" ||
+    trust.creation_date_year === undefined ||
+    trust.creation_date_year === "") {
+    throw new Error(ErrorMessages.TRUST_CREATION_DATE);
+  }
+};
+
+const checkTrustName = (trust: trustType.Trust) => {
+  if (trust.trust_name === undefined || trust.trust_name === "") {
+    throw new Error(ErrorMessages.TRUST_NAME);
+  }
+};
+
+const checkIndividualsAddress = (trust: trustType.Trust, addressMaxLength: number) => {
+  if (trust.INDIVIDUALS) {
+    for (const individual of trust.INDIVIDUALS) {
+      if (individual.ura_address_premises?.length > addressMaxLength) {
+        throw new Error(ErrorMessages.TRUST_INDIVIDUAL_HOME_ADDRESS_LENGTH);
       }
-    }
-
-    if (trust.CORPORATES) {
-      for (const corporate of trust.CORPORATES) {
-        if (corporate.ro_address_premises?.length > addressMaxLength) {
-          throw new Error(ErrorMessages.TRUST_CORPORATE_REGISTERED_OFFICE_ADDRESS_LENGTH);
-        }
-        if (corporate.sa_address_premises?.length > addressMaxLength) {
-          throw new Error(ErrorMessages.TRUST_CORPORATE_CORRESPONDENCE_ADDRESS_LENGTH);
-        }
+      if (individual.sa_address_premises?.length > addressMaxLength) {
+        throw new Error(ErrorMessages.TRUST_INDIVIDUAL_CORRESPONDENCE_ADDRESS_LENGTH);
       }
     }
   }
-  return true;
+};
+
+const checkCorporatesAddress = (trust: trustType.Trust, addressMaxLength: number) => {
+  if (trust.CORPORATES) {
+    for (const corporate of trust.CORPORATES) {
+      if (corporate.ro_address_premises?.length > addressMaxLength) {
+        throw new Error(ErrorMessages.TRUST_CORPORATE_REGISTERED_OFFICE_ADDRESS_LENGTH);
+      }
+      if (corporate.sa_address_premises?.length > addressMaxLength) {
+        throw new Error(ErrorMessages.TRUST_CORPORATE_CORRESPONDENCE_ADDRESS_LENGTH);
+      }
+    }
+  }
 };

--- a/src/validation/error.messages.ts
+++ b/src/validation/error.messages.ts
@@ -36,6 +36,10 @@ export enum ErrorMessages {
   TRUST_NAME = "Enter the trust name",
   TRUST_CREATION_DATE = "Enter the trust creation date",
   TRUST_BO_CHECKBOX = "At least one listed beneficial owner must be selected",
+  TRUST_INDIVIDUAL_HOME_ADDRESS_LENGTH = "Individual home address must be 50 characters or less",
+  TRUST_INDIVIDUAL_CORRESPONDENCE_ADDRESS_LENGTH = "Individual correspondence address must be 50 characters or less",
+  TRUST_CORPORATE_REGISTERED_OFFICE_ADDRESS_LENGTH = "Corporate registered office address must be 50 characters or less",
+  TRUST_CORPORATE_CORRESPONDENCE_ADDRESS_LENGTH = "Corporate correspondence address must be 50 characters or less",
   // Date
   DAY = "Date must include a day ",
   MONTH = "Date must include a month",

--- a/src/validation/trust.information.validation.ts
+++ b/src/validation/trust.information.validation.ts
@@ -10,5 +10,5 @@ export const trustInformation = [
   body("trusts")
     .not().isEmpty({ ignore_whitespace: true }).withMessage(ErrorMessages.TRUST_DATA_EMPTY)
     .custom((value, { req }) =>
-      checkMandatoryTrustFields(ErrorMessages.TRUST_NAME, ErrorMessages.TRUST_CREATION_DATE, req.body.trusts))
+      checkMandatoryTrustFields(req.body.trusts))
 ];

--- a/src/validation/trust.information.validation.ts
+++ b/src/validation/trust.information.validation.ts
@@ -1,5 +1,5 @@
 import { body } from "express-validator";
-import { checkAtLeastOneFieldHasValue, checkMandatoryTrustFields } from "./custom.validation";
+import { checkAtLeastOneFieldHasValue, checkTrustFields } from "./custom.validation";
 
 import { ErrorMessages } from "./error.messages";
 
@@ -10,5 +10,5 @@ export const trustInformation = [
   body("trusts")
     .not().isEmpty({ ignore_whitespace: true }).withMessage(ErrorMessages.TRUST_DATA_EMPTY)
     .custom((value, { req }) =>
-      checkMandatoryTrustFields(req.body.trusts))
+      checkTrustFields(req.body.trusts))
 ];

--- a/test/__mocks__/validation.mock.ts
+++ b/test/__mocks__/validation.mock.ts
@@ -423,3 +423,59 @@ export const TRUSTS_SUBMIT_INDIVIDUAL_SA_ADDRESS_PREMISES_TOO_LONG = {
     ]
   }]`
 };
+
+export const TRUSTS_SUBMIT_INDIVIDUAL_AND_CORPORATE_NO_ADDRESS_PREMISES = {
+  submit: "submit",
+  beneficialOwners: "123",
+  [trustType.TrustKey]: `[{
+    "trust_name": "my trust",
+    "creation_date_day": "21",
+    "creation_date_month": "03",
+    "creation_date_year": "2007",
+    "unable_to_obtain_all_trust_info": "Yes",
+    "INDIVIDUALS": [
+      {
+        "type": "Beneficiary",
+        "forename": "bob",
+        "surname": "smith",
+        "dob_day": "19",
+        "dob_month": "03",
+        "dob_year": "1976",
+        "nationality": "welsh",
+        "ura_address_line_1": "ss",
+        "ura_address_locality": "dd",
+        "ura_address_region": "dd",
+        "ura_address_country": "wales",
+        "ura_address_postal_code": "cf240tl",
+        "sa_address_line_1": "ss",
+        "sa_address_locality": "dd",
+        "sa_address_region": "dd",
+        "sa_address_country": "wales",
+        "sa_address_postal_code": "cf240tl",
+        "date_became_interested_person_day": "11",
+        "date_became_interested_person_month": "11",
+        "date_became_interested_person_year": "1987"
+      }
+    ],
+    "CORPORATES": [
+      {
+        "type":"Settlor",
+        "name":"entname",
+        "ro_address_line_1":"line1",
+        "ro_address_locality":"cardiff",
+        "ro_address_country":"wales",
+        "ro_address_postal_code":"cf1 1aa",
+        "sa_address_line_1":"line1",
+        "sa_address_locality":"cardiff",
+        "sa_address_country":"wales",
+        "sa_address_postal_code":"cf1 1aa",
+        "identification_country_registration":"wales",
+        "identification_legal_authority":"mylaw",
+        "identification_legal_form":"legalform",
+        "date_became_interested_person_day":"04",
+        "date_became_interested_person_month":"04",
+        "date_became_interested_person_year":"2004"
+      }
+    ]
+  }]`
+};

--- a/test/__mocks__/validation.mock.ts
+++ b/test/__mocks__/validation.mock.ts
@@ -1,6 +1,7 @@
 import { MO_IND_ID, PRINCIPAL_ADDRESS_MOCK, SERVICE_ADDRESS_MOCK } from "./session.mock";
 import { ADDRESS } from "./fields/address.mock";
 import * as maxLengthMocks from "./max.length.mock";
+import { trustType } from "../../src/model";
 
 const NAME_SPECIAL_CHARS = "Kurt Gödel";
 
@@ -295,4 +296,130 @@ export const MANAGING_OFFICER_CORPORATE_WITH_INVALID_CHARS_SERVICE_ADDRESS_MOCK 
   registration_number: "abc123",
   ...PRINCIPAL_ADDRESS_MOCK,
   ...SERVICE_ADDRESS_WITH_INVALID_CHAR_FIELDS_MOCK
+};
+
+export const TRUSTS_SUBMIT_CORPORATE_SA_ADDRESS_PREMISES_TOO_LONG = {
+  submit: "submit",
+  beneficialOwners: "123",
+  [trustType.TrustKey]: `[{
+    "trust_name": "name of trust",
+    "creation_date_day": "31",
+    "creation_date_month": "12",
+    "creation_date_year": "1999",
+    "unable_to_obtain_all_trust_info": false,
+    "INDIVIDUALS": [],
+    "HISTORICAL_BO": [],
+    "CORPORATES": [
+      {
+        "type":"Settlor",
+        "name":"entname",
+        "sa_address_premises":"${maxLengthMocks.MAX_50}1",
+        "sa_address_line_1":"line1",
+        "sa_address_locality":"cardiff",
+        "sa_address_country":"wales",
+        "sa_address_postal_code":"cf1 1aa",
+        "identification_country_registration":"wales",
+        "identification_legal_authority":"mylaw",
+        "identification_legal_form":"legalform",
+        "date_became_interested_person_day":"04",
+        "date_became_interested_person_month":"04",
+        "date_became_interested_person_year":"2004"
+      }
+    ]
+  }]`
+};
+
+export const TRUSTS_SUBMIT_CORPORATE_RO_ADDRESS_PREMISES_TOO_LONG = {
+  submit: "submit",
+  beneficialOwners: "123",
+  [trustType.TrustKey]: `[{
+    "trust_name": "name of trust",
+    "creation_date_day": "31",
+    "creation_date_month": "12",
+    "creation_date_year": "1999",
+    "unable_to_obtain_all_trust_info": false,
+    "INDIVIDUALS": [],
+    "HISTORICAL_BO": [],
+    "CORPORATES": [
+      {
+        "type":"Settlor",
+        "name":"entname",
+        "ro_address_premises":"${maxLengthMocks.MAX_50}1",
+        "ro_address_line_1":"line1",
+        "ro_address_locality":"cardiff",
+        "ro_address_country":"wales",
+        "ro_address_postal_code":"cf1 1aa",
+        "identification_country_registration":"wales",
+        "identification_legal_authority":"mylaw",
+        "identification_legal_form":"legalform",
+        "date_became_interested_person_day":"04",
+        "date_became_interested_person_month":"04",
+        "date_became_interested_person_year":"2004"
+      }
+    ]
+  }]`
+};
+
+export const TRUSTS_SUBMIT_INDIVIDUAL_URA_ADDRESS_PREMISES_TOO_LONG = {
+  submit: "submit",
+  beneficialOwners: "123",
+  [trustType.TrustKey]: `[{
+    "trust_name": "my trust",
+    "creation_date_day": "21",
+    "creation_date_month": "03",
+    "creation_date_year": "2007",
+    "unable_to_obtain_all_trust_info": "Yes",
+    "INDIVIDUALS": [
+      {
+        "type": "Beneficiary",
+        "forename": "bob",
+        "surname": "smith",
+        "dob_day": "19",
+        "dob_month": "03",
+        "dob_year": "1976",
+        "nationality": "welsh",
+        "ura_address_premises": "${maxLengthMocks.MAX_50}1",
+        "ura_address_line_1": "ss",
+        "ura_address_locality": "dd",
+        "ura_address_region": "dd",
+        "ura_address_country": "wales",
+        "ura_address_postal_code": "cf240tl",
+        "date_became_interested_person_day": "11",
+        "date_became_interested_person_month": "11",
+        "date_became_interested_person_year": "1987"
+      }
+    ]
+  }]`
+};
+
+export const TRUSTS_SUBMIT_INDIVIDUAL_SA_ADDRESS_PREMISES_TOO_LONG = {
+  submit: "submit",
+  beneficialOwners: "123",
+  [trustType.TrustKey]: `[{
+    "trust_name": "my trust",
+    "creation_date_day": "21",
+    "creation_date_month": "03",
+    "creation_date_year": "2007",
+    "unable_to_obtain_all_trust_info": "Yes",
+    "INDIVIDUALS": [
+      {
+        "type": "Beneficiary",
+        "forename": "bob",
+        "surname": "smith",
+        "dob_day": "19",
+        "dob_month": "03",
+        "dob_year": "1976",
+        "nationality": "welsh",
+        "sa_address_premises": "${maxLengthMocks.MAX_50}1",
+        "sa_address_line_1": "ss",
+        "sa_address_locality": "dd",
+        "sa_address_region": "dd",
+        "sa_address_country": "wales",
+        "sa_address_postal_code": "cf240tl",
+        "date_became_interested_person_day": "11",
+        "date_became_interested_person_month": "11",
+        "date_became_interested_person_year": "1987"
+      }
+    ]
+  }]`
 };

--- a/test/controllers/trust.information.controller.spec.ts
+++ b/test/controllers/trust.information.controller.spec.ts
@@ -13,7 +13,7 @@ import * as config from "../../src/config";
 import { ErrorMessages } from '../../src/validation/error.messages';
 import { getApplicationData, prepareData, getFromApplicationData } from "../../src/utils/application.data";
 import { hasBOsOrMOs } from "../../src/middleware/navigation/has.beneficial.owners.or.managing.officers.middleware";
-import { TRUSTS_SUBMIT_CORPORATE_RO_ADDRESS_PREMISES_TOO_LONG, TRUSTS_SUBMIT_CORPORATE_SA_ADDRESS_PREMISES_TOO_LONG, TRUSTS_SUBMIT_INDIVIDUAL_SA_ADDRESS_PREMISES_TOO_LONG, TRUSTS_SUBMIT_INDIVIDUAL_URA_ADDRESS_PREMISES_TOO_LONG } from "../__mocks__/validation.mock";
+import { TRUSTS_SUBMIT_CORPORATE_RO_ADDRESS_PREMISES_TOO_LONG, TRUSTS_SUBMIT_CORPORATE_SA_ADDRESS_PREMISES_TOO_LONG, TRUSTS_SUBMIT_INDIVIDUAL_AND_CORPORATE_NO_ADDRESS_PREMISES, TRUSTS_SUBMIT_INDIVIDUAL_SA_ADDRESS_PREMISES_TOO_LONG, TRUSTS_SUBMIT_INDIVIDUAL_URA_ADDRESS_PREMISES_TOO_LONG } from "../__mocks__/validation.mock";
 
 const mockHasBOsOrMOsMiddleware = hasBOsOrMOs as jest.Mock;
 mockHasBOsOrMOsMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => next() );
@@ -186,6 +186,18 @@ describe("TRUST INFORMATION controller", () => {
 
       expect(resp.status).toEqual(200);
       expect(resp.text).toContain(ErrorMessages.TRUST_INDIVIDUAL_CORRESPONDENCE_ADDRESS_LENGTH);
+    });
+
+    test(`does not display error message when address premises fields are not submitted`, async () => {
+      mockPrepareData.mockImplementationOnce( () => TRUSTS_SUBMIT_INDIVIDUAL_AND_CORPORATE_NO_ADDRESS_PREMISES );
+      mockGetApplicationData.mockReturnValue(APPLICATION_DATA_MOCK);
+      const bo = BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK;
+      bo.trust_ids = undefined;
+      mockGetFromApplicationData.mockReturnValueOnce(bo);
+      const resp = await request(app).post(config.TRUST_INFO_URL).send(TRUSTS_SUBMIT);
+
+      expect(resp.status).toEqual(302);
+      expect(resp.header.location).toEqual(config.CHECK_YOUR_ANSWERS_PAGE);
     });
   });
 });

--- a/test/controllers/trust.information.controller.spec.ts
+++ b/test/controllers/trust.information.controller.spec.ts
@@ -13,6 +13,7 @@ import * as config from "../../src/config";
 import { ErrorMessages } from '../../src/validation/error.messages';
 import { getApplicationData, prepareData, getFromApplicationData } from "../../src/utils/application.data";
 import { hasBOsOrMOs } from "../../src/middleware/navigation/has.beneficial.owners.or.managing.officers.middleware";
+import { TRUSTS_SUBMIT_CORPORATE_RO_ADDRESS_PREMISES_TOO_LONG, TRUSTS_SUBMIT_CORPORATE_SA_ADDRESS_PREMISES_TOO_LONG, TRUSTS_SUBMIT_INDIVIDUAL_SA_ADDRESS_PREMISES_TOO_LONG, TRUSTS_SUBMIT_INDIVIDUAL_URA_ADDRESS_PREMISES_TOO_LONG } from "../__mocks__/validation.mock";
 
 const mockHasBOsOrMOsMiddleware = hasBOsOrMOs as jest.Mock;
 mockHasBOsOrMOsMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => next() );
@@ -149,6 +150,42 @@ describe("TRUST INFORMATION controller", () => {
       expect(resp.status).toEqual(200);
       expect(resp.text).toContain(TRUST_INFO_PAGE_TITLE);
       expect(resp.text).toContain(ErrorMessages.TRUST_BO_CHECKBOX);
+    });
+
+    test(`renders error message when corporate RO address premises field too long`, async () => {
+      mockPrepareData.mockImplementationOnce( () => TRUSTS_SUBMIT_CORPORATE_RO_ADDRESS_PREMISES_TOO_LONG );
+      mockGetApplicationData.mockReturnValue(TRUSTS_SUBMIT_CORPORATE_RO_ADDRESS_PREMISES_TOO_LONG);
+      const resp = await request(app).post(config.TRUST_INFO_URL).send(TRUSTS_SUBMIT_CORPORATE_RO_ADDRESS_PREMISES_TOO_LONG);
+
+      expect(resp.status).toEqual(200);
+      expect(resp.text).toContain(ErrorMessages.TRUST_CORPORATE_REGISTERED_OFFICE_ADDRESS_LENGTH);
+    });
+
+    test(`renders error message when corporate SA address premises field too long`, async () => {
+      mockPrepareData.mockImplementationOnce( () => TRUSTS_SUBMIT_CORPORATE_SA_ADDRESS_PREMISES_TOO_LONG );
+      mockGetApplicationData.mockReturnValue(TRUSTS_SUBMIT_CORPORATE_SA_ADDRESS_PREMISES_TOO_LONG);
+      const resp = await request(app).post(config.TRUST_INFO_URL).send(TRUSTS_SUBMIT_CORPORATE_SA_ADDRESS_PREMISES_TOO_LONG);
+
+      expect(resp.status).toEqual(200);
+      expect(resp.text).toContain(ErrorMessages.TRUST_CORPORATE_CORRESPONDENCE_ADDRESS_LENGTH);
+    });
+
+    test(`renders error message when individual URA address premises field too long`, async () => {
+      mockPrepareData.mockImplementationOnce( () => TRUSTS_SUBMIT_INDIVIDUAL_URA_ADDRESS_PREMISES_TOO_LONG );
+      mockGetApplicationData.mockReturnValue(TRUSTS_SUBMIT_INDIVIDUAL_URA_ADDRESS_PREMISES_TOO_LONG);
+      const resp = await request(app).post(config.TRUST_INFO_URL).send(TRUSTS_SUBMIT_INDIVIDUAL_URA_ADDRESS_PREMISES_TOO_LONG);
+
+      expect(resp.status).toEqual(200);
+      expect(resp.text).toContain(ErrorMessages.TRUST_INDIVIDUAL_HOME_ADDRESS_LENGTH);
+    });
+
+    test(`renders error message when individual SA address premises field too long`, async () => {
+      mockPrepareData.mockImplementationOnce( () => TRUSTS_SUBMIT_INDIVIDUAL_SA_ADDRESS_PREMISES_TOO_LONG );
+      mockGetApplicationData.mockReturnValue(TRUSTS_SUBMIT_INDIVIDUAL_SA_ADDRESS_PREMISES_TOO_LONG);
+      const resp = await request(app).post(config.TRUST_INFO_URL).send(TRUSTS_SUBMIT_INDIVIDUAL_SA_ADDRESS_PREMISES_TOO_LONG);
+
+      expect(resp.status).toEqual(200);
+      expect(resp.text).toContain(ErrorMessages.TRUST_INDIVIDUAL_CORRESPONDENCE_ADDRESS_LENGTH);
     });
   });
 });


### PR DESCRIPTION
… added to trusts spreadsheet

### JIRA link

https://companieshouse.atlassian.net/browse/ROE-1135

### Change description
Adding validation for trusts json data, ensuring the address premises fields are 50 chars or less, matching the same validation that was added to the premises field in the trusts spreadsheet


### Work checklist

- [x] Tests added where applicable
- [x] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
