### PR TITLE
Roe 1089 use the logic based on previous page selection not current p…

### DIFF
--- a/views/beneficial-owner-type.html
+++ b/views/beneficial-owner-type.html
@@ -37,11 +37,13 @@
   {% set boTypesTitle = "Which type of beneficial owner do you want to add?" %}
   {% set boTypes = bos %}
   {% set whatToAdd = "another beneficial owner" %}
+  {% set hiddenTextValue = "beneficial owners" %}
 {% elif beneficial_owners_statement === "NONE_IDENTIFIED" %}
   {% set boTypesLegendText = "Select the type of managing officer you want to add" %}
   {% set boTypesTitle = "Which type of managing officer do you want to add?" %}
   {% set boTypes = mos %}
   {% set whatToAdd = "another managing officer" %}
+  {% set hiddenTextValue = "managing officers" %}
 {% else %}
   {% set boTypesLegendText = "Select the type of beneficial owner or managing officer you want to add" %}
   {% set boTypesTitle = "Which type of beneficial owner or managing officer do you want to add?" %}
@@ -49,6 +51,7 @@
   {% set boTypes = (boTypes.push(mos[0]), boTypes) %}
   {% set boTypes = (boTypes.push(mos[1]), boTypes) %}
   {% set whatToAdd = "another beneficial owner or managing officer" %}
+  {% set hiddenTextValue = "beneficial owners or managing officers" %}
 {% endif %}
 
 {% set hasBeneficialOwners = (beneficial_owners_individual and beneficial_owners_individual.length > 0)
@@ -98,14 +101,6 @@
         }) }}
 
         <button class="govuk-button" data-module="govuk-button" id="add">Add <span class="govuk-visually-hidden"> {{ whatToAdd }} </span></button>
-
-        {% if (hasBeneficialOwners and hasManagingOfficers) %}
-          {% set hiddenTextValue = "beneficial owners or managing officers" %}
-        {% elif (hasBeneficialOwners) %}
-          {% set hiddenTextValue = "beneficial owners" %}
-        {% elif (hasManagingOfficers) %}
-          {% set hiddenTextValue = "managing officers" %}
-        {% endif %}
 
         {% if (hasBeneficialOwners or hasManagingOfficers) %}
           <h2 class="govuk-heading-l govuk-!-margin-0">What <span class="govuk-visually-hidden"> {{ hiddenTextValue }}</span> you have added so far:</h2>


### PR DESCRIPTION
…age content

### JIRA link
https://companieshouse.atlassian.net/browse/ROE-1089


### Change description
Found on the  some identified page:

The hidden text needs to be based entirely on the previous page beneficial owner type selection rather than on what is currently displayed on the page. So for Some beneficial owners identified even if we have added only beneficial owner and not managing officers or vice versa the hidden test should still be "beneficial owners or managing officers"


### Work checklist

- [x] Tests added where applicable
- [x] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
