### PR TITLE
ROE-1123 adding matomo tracking to change links

### DIFF
--- a/src/utils/change.link.ts
+++ b/src/utils/change.link.ts
@@ -1,10 +1,13 @@
 import { FEATURE_FLAG_ENABLE_CHANGE_LINKS_02082022 } from "../config";
 import { isActiveFeature } from "./feature.flag";
 
-export const createChangeLinkConfig = (href: string, text: string) => {
+export const createChangeLinkConfig = (href: string, text: string, dataEventId: string) => {
   return (isActiveFeature(FEATURE_FLAG_ENABLE_CHANGE_LINKS_02082022)) ? {
     href,
     text: 'Change',
+    attributes: {
+      'data-event-id': dataEventId
+    },
     visuallyHiddenText: text
   } : "";
 };

--- a/test/__mocks__/text.mock.ts
+++ b/test/__mocks__/text.mock.ts
@@ -82,3 +82,4 @@ export const AGENT_REGISTERING = "The UK agent";
 export const SOMEONE_ELSE_REGISTERING = "Someone from the overseas entity";
 export const CHANGE_LINK = "Change";
 export const CHANGE_LINK_NAME_PRESENTER = "Full name - who can we contact about this application";
+export const DATA_EVENT_ID = "data-event-id";

--- a/test/utils/change.link.spec.ts
+++ b/test/utils/change.link.spec.ts
@@ -2,7 +2,7 @@ jest.mock("../../src/utils/feature.flag" );
 
 import { describe, expect, test, jest } from '@jest/globals';
 
-import { CHANGE_LINK, CHANGE_LINK_NAME_PRESENTER } from '../__mocks__/text.mock';
+import { CHANGE_LINK, CHANGE_LINK_NAME_PRESENTER, DATA_EVENT_ID } from '../__mocks__/text.mock';
 import { PRESENTER_CHANGE_FULL_NAME } from '../../src/config';
 import { createChangeLinkConfig } from '../../src/utils/change.link';
 import { isActiveFeature } from "../../src/utils/feature.flag";
@@ -13,15 +13,16 @@ mockIsActiveFeature.mockImplementation( () => true );
 describe('createChangeLinkConfig test suite', () => {
 
   test('should check if the object returned is correct, and contains the change link configs', () => {
-    const testChangeLinkConfig = createChangeLinkConfig(PRESENTER_CHANGE_FULL_NAME, CHANGE_LINK_NAME_PRESENTER) as any;
+    const testChangeLinkConfig = createChangeLinkConfig(PRESENTER_CHANGE_FULL_NAME, CHANGE_LINK_NAME_PRESENTER, DATA_EVENT_ID) as any;
     expect(testChangeLinkConfig.text).toEqual(CHANGE_LINK);
     expect(testChangeLinkConfig.href).toEqual(PRESENTER_CHANGE_FULL_NAME);
     expect(testChangeLinkConfig.visuallyHiddenText).toEqual(CHANGE_LINK_NAME_PRESENTER);
+    expect(testChangeLinkConfig.attributes['data-event-id']).toEqual(DATA_EVENT_ID);
   });
 
   test('should return an empty string when change links feature flag is false', () => {
     mockIsActiveFeature.mockReturnValueOnce(false);
-    const testChangeLinkConfig = createChangeLinkConfig(PRESENTER_CHANGE_FULL_NAME, CHANGE_LINK_NAME_PRESENTER);
+    const testChangeLinkConfig = createChangeLinkConfig(PRESENTER_CHANGE_FULL_NAME, CHANGE_LINK_NAME_PRESENTER, DATA_EVENT_ID);
     expect(testChangeLinkConfig).toEqual("");
   });
 

--- a/views/includes/check-your-answers/beneficial-owner-gov.html
+++ b/views/includes/check-your-answers/beneficial-owner-gov.html
@@ -51,7 +51,8 @@
         actions: {
           items: [ CREATE_CHANGE_LINK(
             OE_CONFIGS.BENEFICIAL_OWNER_GOV_URL + "/" + bog.id + OE_CONFIGS.NAME,
-            "Government or public authority beneficial owner " + bog.name + " - name"
+            "Government or public authority beneficial owner " + bog.name + " - name",
+            "change-government-or-public-authority-beneficial-owner-name-button"
           ) ]
         }
       },
@@ -65,7 +66,8 @@
         actions: {
           items: [ CREATE_CHANGE_LINK(
             OE_CONFIGS.BENEFICIAL_OWNER_GOV_URL + "/" + bog.id + OE_CONFIGS.CHANGE_PRINCIPAL_ADDRESS,
-            "Government or public authority beneficial owner " + bog.name + " - principal or registered office address"
+            "Government or public authority beneficial owner " + bog.name + " - principal or registered office address",
+            "change-government-or-public-authority-beneficial-owner-principal-address-button"
           ) ]
         }
       },
@@ -79,7 +81,8 @@
         actions: {
           items: [ CREATE_CHANGE_LINK(
             OE_CONFIGS.BENEFICIAL_OWNER_GOV_URL + "/" + bog.id + bogChangeServiceAddressHtml,
-            "Government or public authority beneficial owner " + bog.name + " - correspondence address"
+            "Government or public authority beneficial owner " + bog.name + " - correspondence address",
+            "change-government-or-public-authority-beneficial-owner-correspondence-address-button"
           ) ]
         }
       },
@@ -93,7 +96,8 @@
         actions: {
           items: [ CREATE_CHANGE_LINK(
             OE_CONFIGS.BENEFICIAL_OWNER_GOV_URL + "/" + bog.id + OE_CONFIGS.LEGAL_FORM,
-            "Government or public authority beneficial owner " + bog.name + " - legal form"
+            "Government or public authority beneficial owner " + bog.name + " - legal form",
+            "change-government-or-public-authority-beneficial-owner-legal-form-button"
           ) ]
         }
       },
@@ -107,7 +111,8 @@
         actions: {
           items: [ CREATE_CHANGE_LINK(
             OE_CONFIGS.BENEFICIAL_OWNER_GOV_URL + "/" + bog.id + OE_CONFIGS.LAW_GOVERNED,
-            "Government or public authority beneficial owner " + bog.name + " - governing law"
+            "Government or public authority beneficial owner " + bog.name + " - governing law",
+            "change-government-or-public-authority-beneficial-owner-law-governed-button"
           ) ]
         }
       },
@@ -121,7 +126,8 @@
         actions: {
           items: [ CREATE_CHANGE_LINK(
             OE_CONFIGS.BENEFICIAL_OWNER_GOV_URL + "/" + bog.id + OE_CONFIGS.START_DATE,
-            "Government or public authority beneficial owner " + bog.name + " - date it became a beneficial owner"
+            "Government or public authority beneficial owner " + bog.name + " - date it became a beneficial owner",
+            "change-government-or-public-authority-beneficial-owner-start-date-button"
           ) ]
         }
       },
@@ -135,7 +141,8 @@
         actions: {
           items: [ CREATE_CHANGE_LINK(
             OE_CONFIGS.BENEFICIAL_OWNER_GOV_URL + "/" + bog.id + OE_CONFIGS.NOC_TYPES,
-            "Government or public authority beneficial owner " + bog.name + " - nature of control"
+            "Government or public authority beneficial owner " + bog.name + " - nature of control",
+            "change-government-or-public-authority-beneficial-owner-nature-of-control-button"
           ) ]
         }
       },
@@ -149,10 +156,10 @@
         actions: {
           items: [ CREATE_CHANGE_LINK(
             OE_CONFIGS.BENEFICIAL_OWNER_GOV_URL + "/" + bog.id + OE_CONFIGS.IS_ON_SANCTIONS_LIST,
-            "Government or public authority beneficial owner " + bog.name + " - is it on the sanctions list?"
+            "Government or public authority beneficial owner " + bog.name + " - is it on the sanctions list?",
+            "change-government-or-public-authority-beneficial-owner-sanctions-list-button"
           ) ]
         }
       }
     ]
 }) }}
-  

--- a/views/includes/check-your-answers/beneficial-owner-individual.html
+++ b/views/includes/check-your-answers/beneficial-owner-individual.html
@@ -59,7 +59,8 @@
       actions: {
         items: [ CREATE_CHANGE_LINK(
           OE_CONFIGS.BENEFICIAL_OWNER_INDIVIDUAL_URL + "/" + boi.id + OE_CONFIGS.FIRST_NAME,
-          "Individual beneficial owner " + boi.first_name + " - first name"
+          "Individual beneficial owner " + boi.first_name + " - first name",
+          "change-individual-beneficial-owner-first-name-button"
         ) ]
       }
     },
@@ -73,7 +74,8 @@
       actions: {
         items: [ CREATE_CHANGE_LINK(
           OE_CONFIGS.BENEFICIAL_OWNER_INDIVIDUAL_URL + "/" + boi.id + OE_CONFIGS.LAST_NAME,
-          "Individual beneficial owner " + boi.first_name + " - last name"
+          "Individual beneficial owner " + boi.first_name + " - last name",
+          "change-individual-beneficial-owner-last-name-button"
         ) ]
       }
     },
@@ -87,7 +89,8 @@
       actions: {
         items: [ CREATE_CHANGE_LINK(
           OE_CONFIGS.BENEFICIAL_OWNER_INDIVIDUAL_URL + "/" + boi.id + OE_CONFIGS.DATE_OF_BIRTH,
-          "Individual beneficial owner " + boi.first_name + " - date of birth"
+          "Individual beneficial owner " + boi.first_name + " - date of birth",
+          "change-individual-beneficial-owner-date-of-birth-name-button"
         ) ]
       }
     },
@@ -101,7 +104,8 @@
       actions: {
         items: [ CREATE_CHANGE_LINK(
           OE_CONFIGS.BENEFICIAL_OWNER_INDIVIDUAL_URL + "/" + boi.id + OE_CONFIGS.NATIONALITY,
-          "Individual beneficial owner " + boi.first_name + " - nationality"
+          "Individual beneficial owner " + boi.first_name + " - nationality",
+          "change-individual-beneficial-owner-nationality-button"
         ) ]
       }
     },
@@ -115,7 +119,8 @@
       actions: {
         items: [ CREATE_CHANGE_LINK(
           OE_CONFIGS.BENEFICIAL_OWNER_INDIVIDUAL_URL + "/" + boi.id + OE_CONFIGS.CHANGE_RESIDENTIAL_ADDRESS,
-          "Individual beneficial owner " + boi.first_name + " - home address"
+          "Individual beneficial owner " + boi.first_name + " - home address",
+          "change-individual-beneficial-owner-residential-address-button"
         ) ]
       }
     },
@@ -129,7 +134,8 @@
       actions: {
         items: [ CREATE_CHANGE_LINK(
           OE_CONFIGS.BENEFICIAL_OWNER_INDIVIDUAL_URL + "/" + boi.id + boiChangeServiceAddressHtml,
-          "Individual beneficial owner " + boi.first_name + " - correspondence address"
+          "Individual beneficial owner " + boi.first_name + " - correspondence address",
+          "change-individual-beneficial-owner-correspondence-address-button"
         ) ]
       }
     },
@@ -143,7 +149,8 @@
       actions: {
         items: [ CREATE_CHANGE_LINK(
           OE_CONFIGS.BENEFICIAL_OWNER_INDIVIDUAL_URL + "/" + boi.id + OE_CONFIGS.START_DATE,
-          "Individual beneficial owner " + boi.first_name + " - date they became a beneficial owner"
+          "Individual beneficial owner " + boi.first_name + " - date they became a beneficial owner",
+          "change-individual-beneficial-owner-start-date-button"
         ) ]
       }
     },
@@ -157,7 +164,8 @@
       actions: {
         items: [ CREATE_CHANGE_LINK(
           OE_CONFIGS.BENEFICIAL_OWNER_INDIVIDUAL_URL + "/" + boi.id + OE_CONFIGS.NOC_TYPES,
-          "Individual beneficial owner " + boi.first_name + " - nature of control"
+          "Individual beneficial owner " + boi.first_name + " - nature of control",
+          "change-individual-beneficial-owner-nature-of-control-button"
         ) ]
       }
     },
@@ -171,7 +179,8 @@
       actions: {
         items: [ CREATE_CHANGE_LINK(
           OE_CONFIGS.BENEFICIAL_OWNER_INDIVIDUAL_URL + "/" + boi.id + OE_CONFIGS.IS_ON_SANCTIONS_LIST,
-          "Individual beneficial owner " + boi.first_name + " - are they on the sanctions list?"
+          "Individual beneficial owner " + boi.first_name + " - are they on the sanctions list?",
+          "change-individual-beneficial-owner-sanctions-list-button"
         ) ]
       }
     }

--- a/views/includes/check-your-answers/beneficial-owner-other.html
+++ b/views/includes/check-your-answers/beneficial-owner-other.html
@@ -67,7 +67,8 @@
         actions: {
           items: [ CREATE_CHANGE_LINK(
             OE_CONFIGS.BENEFICIAL_OWNER_OTHER_URL + "/" + boc.id + OE_CONFIGS.NAME,
-            "Corporate beneficial owner " + boc.name + " - name"
+            "Corporate beneficial owner " + boc.name + " - name",
+            "change-corporate-beneficial-owner-name-button"
           ) ]
         }
       },
@@ -81,7 +82,8 @@
         actions: {
           items: [ CREATE_CHANGE_LINK(
             OE_CONFIGS.BENEFICIAL_OWNER_OTHER_URL + "/" + boc.id + OE_CONFIGS.CHANGE_PRINCIPAL_ADDRESS,
-            "Corporate beneficial owner " + boc.name + " - principal or registered office address"
+            "Corporate beneficial owner " + boc.name + " - principal or registered office address",
+            "change-corporate-beneficial-owner-principal-address-button"
           ) ]
         }
       },
@@ -95,7 +97,8 @@
         actions: {
           items: [ CREATE_CHANGE_LINK(
             OE_CONFIGS.BENEFICIAL_OWNER_OTHER_URL + "/" + boc.id + bocChangeServiceAddressHtml,
-            "Corporate beneficial owner " + boc.name + " - correspondence address"
+            "Corporate beneficial owner " + boc.name + " - correspondence address",
+            "change-corporate-beneficial-owner-service-address-button"
           ) ]
         }
       },
@@ -109,7 +112,8 @@
         actions: {
           items: [ CREATE_CHANGE_LINK(
             OE_CONFIGS.BENEFICIAL_OWNER_OTHER_URL + "/" + boc.id + OE_CONFIGS.LEGAL_FORM,
-            "Corporate beneficial owner " + boc.name + " - legal form"
+            "Corporate beneficial owner " + boc.name + " - legal form",
+            "change-corporate-beneficial-owner-legal-form-button"
           ) ]
         }
       },
@@ -123,7 +127,8 @@
         actions: {
           items: [ CREATE_CHANGE_LINK(
             OE_CONFIGS.BENEFICIAL_OWNER_OTHER_URL + "/" + boc.id + OE_CONFIGS.LAW_GOVERNED,
-            "Corporate beneficial owner " + boc.name + " - governing law"
+            "Corporate beneficial owner " + boc.name + " - governing law",
+            "change-corporate-beneficial-owner-law-governed-button"
           ) ]
         }
       },
@@ -137,7 +142,8 @@
         actions: {
           items: [ CREATE_CHANGE_LINK(
             OE_CONFIGS.BENEFICIAL_OWNER_OTHER_URL + "/" + boc.id + bocChangePublicRegister,
-            "Corporate beneficial owner " + boc.name + " - public register"
+            "Corporate beneficial owner " + boc.name + " - public register",
+            "change-corporate-beneficial-owner-public-register-button"
           ) ]
         }
       },
@@ -151,7 +157,8 @@
         actions: {
           items: [ CREATE_CHANGE_LINK(
             OE_CONFIGS.BENEFICIAL_OWNER_OTHER_URL + "/" + boc.id + OE_CONFIGS.START_DATE,
-            "Corporate beneficial owner " + boc.name + " - date it became a beneficial owner"
+            "Corporate beneficial owner " + boc.name + " - date it became a beneficial owner",
+            "change-corporate-beneficial-owner-start-date-button"
           ) ]
         }
       },
@@ -165,7 +172,8 @@
         actions: {
           items: [ CREATE_CHANGE_LINK(
             OE_CONFIGS.BENEFICIAL_OWNER_OTHER_URL + "/" + boc.id + OE_CONFIGS.NOC_TYPES,
-            "Corporate beneficial owner " + boc.name + " - nature of control"
+            "Corporate beneficial owner " + boc.name + " - nature of control",
+            "change-corporate-beneficial-owner-nature-of-control-button"
           ) ]
         }
       },
@@ -179,10 +187,10 @@
         actions: {
           items: [ CREATE_CHANGE_LINK(
             OE_CONFIGS.BENEFICIAL_OWNER_OTHER_URL + "/" + boc.id + OE_CONFIGS.IS_ON_SANCTIONS_LIST,
-            "Corporate beneficial owner " + boc.name + " - is it on the sanctions list?"
+            "Corporate beneficial owner " + boc.name + " - is it on the sanctions list?",
+            "change-corporate-beneficial-owner-sanctions-list-button"
           ) ]
         }
       }
     ]
 }) }}
-  

--- a/views/includes/check-your-answers/beneficial-owner-statements.html
+++ b/views/includes/check-your-answers/beneficial-owner-statements.html
@@ -22,7 +22,8 @@
         actions: {
           items: [ CREATE_CHANGE_LINK(
             OE_CONFIGS.BENEFICIAL_OWNER_STATEMENTS_URL,
-            statementText
+            statementText,
+            "change-beneficial-owner-statement-button"
           ) ]
         }
       }

--- a/views/includes/check-your-answers/entity.html
+++ b/views/includes/check-your-answers/entity.html
@@ -34,7 +34,8 @@
         actions: {
           items: [ CREATE_CHANGE_LINK(
             OE_CONFIGS.ENTITY_CHANGE_NAME,
-            "Name of the overseas entity"
+            "Name of the overseas entity",
+            "change-entity-name-button"
           ) ]
         }
       },
@@ -48,7 +49,8 @@
         actions: {
           items: [CREATE_CHANGE_LINK(
             OE_CONFIGS.ENTITY_CHANGE_COUNTRY,
-            "Country it was formed in"
+            "Country it was formed in",
+            "change-entity-incorporation-country-button"
           ) ]
         }
       },
@@ -62,7 +64,8 @@
         actions: {
           items: [CREATE_CHANGE_LINK(
             OE_CONFIGS.ENTITY_CHANGE_PRINCIPAL_ADDRESS,
-            "Principal or registered office address"
+            "Principal or registered office address",
+            "change-entity-principal-address-button"
           ) ]
         }
       },
@@ -76,7 +79,8 @@
         actions: {
           items: [CREATE_CHANGE_LINK(
             OE_CONFIGS.ENTITY_CHANGE_CORRESPONDENCE_ADDRESS,
-            "Correspondence address"
+            "Correspondence address",
+            "change-entity-correspondence-address-button"
           ) ]
         }
       },
@@ -90,7 +94,8 @@
         actions: {
           items: [CREATE_CHANGE_LINK(
             OE_CONFIGS.ENTITY_CHANGE_EMAIL,
-            "Email address at the overseas entity should we send communications to"
+            "Email address at the overseas entity should we send communications to",
+            "change-entity-email-button"
           ) ]
         }
       },
@@ -104,7 +109,8 @@
         actions: {
           items: [CREATE_CHANGE_LINK(
             OE_CONFIGS.ENTITY_CHANGE_LEGAL_FORM,
-            "Legal form"
+            "Legal form",
+            "change-entity-legal-form-button"
           ) ]
         }
       },
@@ -118,7 +124,8 @@
         actions: {
           items: [CREATE_CHANGE_LINK(
             OE_CONFIGS.ENTITY_CHANGE_GOVERNING_LAW,
-            "Governing law"
+            "Governing law",
+            "change-entity-governing-law-button"
           ) ]
         }
       },
@@ -132,7 +139,8 @@
         actions: {
           items: [CREATE_CHANGE_LINK(
             OE_CONFIGS.ENTITY_CHANGE_PUBLIC_REGISTER,
-            "Already on a public register in the country it was formed in"
+            "Already on a public register in the country it was formed in",
+            "change-entity-public-register-button"
           )]
         }
       }

--- a/views/includes/check-your-answers/identity-checks.html
+++ b/views/includes/check-your-answers/identity-checks.html
@@ -12,7 +12,8 @@
     actions: {
       items: [ CREATE_CHANGE_LINK(
         OE_CONFIGS.DUE_DILIGENCE_CHANGE_AGENT_CODE,
-        "Agent’s authentication code"
+        "Agent’s authentication code",
+        "change-agent-authentication-code-button"
       ) ]
     }
   } %}
@@ -63,7 +64,8 @@
         actions: {
           items: [ CREATE_CHANGE_LINK(
             OE_CONFIGS.DUE_DILIGENCE_CHANGE_WHO,
-            "Who is completing this registration"
+            "Who is completing this registration",
+            "change-identity-check-name-button"
           ) ]
         }
       },
@@ -77,7 +79,8 @@
         actions: {
           items: [ CREATE_CHANGE_LINK(
             dateChangeLink,
-            "Date the identity checks were completed"
+            "Date the identity checks were completed",
+            "change-identity-check-date-button"
           ) ]
         }
       },
@@ -91,7 +94,8 @@
         actions: {
           items: [ CREATE_CHANGE_LINK(
             nameChangeLink,
-            "Name of agent"
+            "Name of agent",
+            "change-identity-check-agent-name-button"
           ) ]
         }
       },
@@ -105,7 +109,8 @@
         actions: {
           items: [ CREATE_CHANGE_LINK(
             addressChangeLink,
-            "Address of agent"
+            "Address of agent",
+            "change-identity-check-agent-correspondence-address-button"
           ) ]
         }
       },
@@ -119,7 +124,8 @@
         actions: {
           items: [ CREATE_CHANGE_LINK(
             emailChangeLink,
-            "Email address of agent"
+            "Email address of agent",
+            "change-identity-check-agent-email-button"
           ) ]
         }
       },
@@ -133,7 +139,8 @@
         actions: {
           items: [ CREATE_CHANGE_LINK(
             supervisoryChangeLink,
-            "Name of the supervisory body"
+            "Name of the supervisory body",
+            "change-identity-check-supervisory-body-name-button"
           ) ]
         }
       },
@@ -147,7 +154,8 @@
         actions: {
           items: [ CREATE_CHANGE_LINK(
             amlChangeLink,
-            "Anti Money Laundering (AML) registration number of the agent"
+            "Anti Money Laundering (AML) registration number of the agent",
+            "change-identity-check-anti-money-laundering-number-button"
           ) ]
         }
       },
@@ -162,7 +170,8 @@
         actions: {
           items: [ CREATE_CHANGE_LINK(
             partnerChangeLink,
-            "Name of partner"
+            "Name of partner",
+            "change-identity-check-partner-name-button"
           ) ]
         }
       }

--- a/views/includes/check-your-answers/managing-officer-corporate.html
+++ b/views/includes/check-your-answers/managing-officer-corporate.html
@@ -40,7 +40,8 @@
         actions: {
           items: [CREATE_CHANGE_LINK(
             OE_CONFIGS.MANAGING_OFFICER_CORPORATE_URL + "/" + moc.id + OE_CONFIGS.NAME,
-            "Corporate managing officer " + moc.name + " - name"
+            "Corporate managing officer " + moc.name + " - name",
+            "change-corporate-managing-officer-name-button"
           ) ]
         }
       },
@@ -54,7 +55,8 @@
         actions: {
           items: [CREATE_CHANGE_LINK(
             OE_CONFIGS.MANAGING_OFFICER_CORPORATE_URL + "/" + moc.id + OE_CONFIGS.CHANGE_PRINCIPAL_ADDRESS,
-            "Corporate managing officer " + moc.name + " - principal or registered office address"
+            "Corporate managing officer " + moc.name + " - principal or registered office address",
+            "change-corporate-managing-officer-principal-address-button"
           ) ]
         }
       },
@@ -68,7 +70,8 @@
         actions: {
           items: [CREATE_CHANGE_LINK(
             OE_CONFIGS.MANAGING_OFFICER_CORPORATE_URL + "/" + moc.id + mocChangeServiceAddressHtml,
-            "Corporate managing officer " + moc.name + " - correspondence address"
+            "Corporate managing officer " + moc.name + " - correspondence address",
+            "change-corporate-managing-officer-correspondence-address-button"
           ) ]
         }
       },
@@ -82,7 +85,8 @@
         actions: {
           items: [CREATE_CHANGE_LINK(
             OE_CONFIGS.MANAGING_OFFICER_CORPORATE_URL + "/" + moc.id + OE_CONFIGS.LEGAL_FORM,
-            "Corporate managing officer " + moc.name + " - legal form"
+            "Corporate managing officer " + moc.name + " - legal form",
+            "change-corporate-managing-officer-legal-form-button"
           ) ]
         }
       },
@@ -96,7 +100,8 @@
         actions: {
           items: [CREATE_CHANGE_LINK(
             OE_CONFIGS.MANAGING_OFFICER_CORPORATE_URL + "/" + moc.id + OE_CONFIGS.LAW_GOVERNED,
-            "Corporate managing officer " + moc.name + " - governing law"
+            "Corporate managing officer " + moc.name + " - governing law",
+            "change-corporate-managing-officer-law-governed-button"
           ) ]
         }
       },
@@ -110,7 +115,8 @@
         actions: {
           items: [CREATE_CHANGE_LINK(
             OE_CONFIGS.MANAGING_OFFICER_CORPORATE_URL + "/" + moc.id + mocChangePublicregisterNameHtml,
-            "Corporate managing officer " + moc.name + " - on a public register in the country it was formed in"
+            "Corporate managing officer " + moc.name + " - on a public register in the country it was formed in",
+            "change-corporate-managing-officer-public-register-button"
           ) ]
         }
       },
@@ -124,7 +130,8 @@
         actions: {
           items: [CREATE_CHANGE_LINK(
             OE_CONFIGS.MANAGING_OFFICER_CORPORATE_URL + "/" + moc.id + OE_CONFIGS.ROLE_AND_RESPONSIBILITIES,
-            "Corporate managing officer " + moc.name + " - role and responsibilities"
+            "Corporate managing officer " + moc.name + " - role and responsibilities",
+            "change-corporate-managing-officer-role-and-responsibilities-button"
           ) ]
         }
       },
@@ -138,7 +145,8 @@
         actions: {
           items: [CREATE_CHANGE_LINK(
             OE_CONFIGS.MANAGING_OFFICER_CORPORATE_URL + "/" + moc.id + OE_CONFIGS.CONTACT_FULL_NAME,
-            "Corporate managing officer " + moc.name + " - contact full name"
+            "Corporate managing officer " + moc.name + " - contact full name",
+            "change-corporate-managing-officer-contact-name-button"
           ) ]
         }
       },
@@ -152,7 +160,8 @@
         actions: {
           items: [CREATE_CHANGE_LINK(
             OE_CONFIGS.MANAGING_OFFICER_CORPORATE_URL + "/" + moc.id + OE_CONFIGS.CONTACT_EMAIL,
-            "Corporate managing officer " + moc.name + " - contact email"
+            "Corporate managing officer " + moc.name + " - contact email",
+            "change-corporate-managing-officer-contact-email-button"
           ) ]
         }
       }

--- a/views/includes/check-your-answers/managing-officer-individual.html
+++ b/views/includes/check-your-answers/managing-officer-individual.html
@@ -40,7 +40,8 @@
         actions: {
           items: [CREATE_CHANGE_LINK(
             OE_CONFIGS.MANAGING_OFFICER_URL + "/" + moi.id + OE_CONFIGS.FIRST_NAME,
-            "Individual managing officer " + moi.first_name + " " + moi.last_name + " - first name"
+            "Individual managing officer " + moi.first_name + " " + moi.last_name + " - first name",
+            "change-individual-managing-officer-first-name-button"
           ) ]
         }
       },
@@ -54,7 +55,8 @@
         actions: {
           items: [CREATE_CHANGE_LINK(
             OE_CONFIGS.MANAGING_OFFICER_URL + "/" + moi.id + OE_CONFIGS.LAST_NAME,
-            "Individual managing officer " + moi.first_name + " " + moi.last_name + " - last name"
+            "Individual managing officer " + moi.first_name + " " + moi.last_name + " - last name",
+            "change-individual-managing-officer-last-name-button"
           ) ]
         }
       },
@@ -68,7 +70,8 @@
         actions: {
           items: [CREATE_CHANGE_LINK(
             OE_CONFIGS.MANAGING_OFFICER_URL + "/" + moi.id + moiChangeFormerNamesHtml,
-            "Individual managing officer " + moi.first_name + " " + moi.last_name + " - former names"
+            "Individual managing officer " + moi.first_name + " " + moi.last_name + " - former names",
+            "change-individual-managing-officer-former-names-button"
           ) ]
         }
       },
@@ -82,7 +85,8 @@
         actions: {
           items: [CREATE_CHANGE_LINK(
             OE_CONFIGS.MANAGING_OFFICER_URL + "/" + moi.id + OE_CONFIGS.DATE_OF_BIRTH,
-            "Individual managing officer " + moi.first_name + " " + moi.last_name + " - date of birth"
+            "Individual managing officer " + moi.first_name + " " + moi.last_name + " - date of birth",
+            "change-individual-managing-officer-date-of-birth-button"
           ) ]
         }
       },
@@ -96,7 +100,8 @@
         actions: {
           items: [CREATE_CHANGE_LINK(
             OE_CONFIGS.MANAGING_OFFICER_URL + "/" + moi.id + OE_CONFIGS.NATIONALITY,
-            "Individual managing officer " + moi.first_name + " " + moi.last_name + " - nationality"
+            "Individual managing officer " + moi.first_name + " " + moi.last_name + " - nationality",
+            "change-individual-managing-officer-nationality-button"
           ) ]
         }
       },
@@ -110,7 +115,8 @@
         actions: {
           items: [CREATE_CHANGE_LINK(
             OE_CONFIGS.MANAGING_OFFICER_URL + "/" + moi.id + OE_CONFIGS.CHANGE_RESIDENTIAL_ADDRESS,
-            "Individual managing officer " + moi.first_name + " " + moi.last_name + " - home address"
+            "Individual managing officer " + moi.first_name + " " + moi.last_name + " - home address",
+            "change-individual-managing-officer-residential-address-button"
           ) ]
         }
       },
@@ -124,7 +130,8 @@
         actions: {
           items: [CREATE_CHANGE_LINK(
             OE_CONFIGS.MANAGING_OFFICER_URL + "/" + moi.id + moiChangeServiceAddressHtml,
-            "Individual managing officer " + moi.first_name + " " + moi.last_name + " - correspondence address"
+            "Individual managing officer " + moi.first_name + " " + moi.last_name + " - correspondence address",
+            "change-individual-managing-officer-correspondence-address-button"
           ) ]
         }
       },
@@ -138,7 +145,8 @@
         actions: {
           items: [CREATE_CHANGE_LINK(
             OE_CONFIGS.MANAGING_OFFICER_URL + "/" + moi.id + OE_CONFIGS.OCCUPATION,
-            "Individual managing officer " + moi.first_name + " " + moi.last_name + " - occupation"
+            "Individual managing officer " + moi.first_name + " " + moi.last_name + " - occupation",
+            "change-individual-managing-officer-occupation-button"
           ) ]
         }
       },
@@ -152,7 +160,8 @@
         actions: {
           items: [CREATE_CHANGE_LINK(
             OE_CONFIGS.MANAGING_OFFICER_URL + "/" + moi.id + OE_CONFIGS.ROLE_AND_RESPONSIBILITIES,
-            "Individual managing officer " + moi.first_name + " " + moi.last_name + " - role and responsibilities"
+            "Individual managing officer " + moi.first_name + " " + moi.last_name + " - role and responsibilities",
+            "change-individual-managing-officer-role-and-responsibilities-button"
           ) ]
         }
       }

--- a/views/includes/check-your-answers/presenter.html
+++ b/views/includes/check-your-answers/presenter.html
@@ -13,7 +13,8 @@
         actions: {
           items: [ CREATE_CHANGE_LINK(
             OE_CONFIGS.PRESENTER_CHANGE_FULL_NAME,
-            "Full name - who can we contact about this application"
+            "Full name - who can we contact about this application",
+            "change-presenter-name-button"
           ) ]
         }
       },
@@ -27,7 +28,8 @@
         actions: {
           items: [ CREATE_CHANGE_LINK(
             OE_CONFIGS.PRESENTER_CHANGE_EMAIL,
-            "Email address - who can we contact about this application"
+            "Email address - who can we contact about this application",
+            "change-presenter-email-button"
           ) ]
         }
       }


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/ROE-1123


### Change description
Added an option to the CREATE_CHANGE_LINK function to allow a data-event-id attribute to be added for matomo tracking. Then added data for this new parameter to each CREATE_CHANGE_LINK call.


### Work checklist

- [ ] Tests added where applicable
- [x] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
