### PR TITLE
ROE-1128 Match page title and h1 on bo statement and type pages

### DIFF
--- a/views/beneficial-owner-gov.html
+++ b/views/beneficial-owner-gov.html
@@ -1,7 +1,9 @@
 {% extends "layout.html" %}
 
+{% set title = "Tell us about the government or public authority" %}
+
 {% block pageTitle %}
-  Government or public authority beneficial owner - {{ SERVICE_NAME }} - GOV.UK
+  {{ title }} - {{ SERVICE_NAME }} - GOV.UK
 {% endblock %}
 
 {% block backLink %}
@@ -13,7 +15,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <span class="govuk-caption-xl">Beneficial owner</span>
-      <h1 class="govuk-heading-xl govuk-!-margin-0">Tell us about the government or public authority</h1>
+      <h1 class="govuk-heading-xl govuk-!-margin-0">{{ title }}</h1>
       <p class="govuk-caption-l  govuk-!-margin-bottom-5 govuk-!-margin-top-5">You can add more later.</p>
 
       {% include "includes/list/errors.html" %}
@@ -52,7 +54,7 @@
         {% set sanctionsListText = "Is it on the sanctions list?" %}
         {% set sanctionsListHintText = "This means that it is subject to sanctions under the Sanctions and Anti-Money Laundering Act 2018." %}
         {% include "includes/inputs/fields/is-on-sanctions-list-input.html" %}
-        
+
         {{ govukInsetText({
           html: '
             <h2 class="govuk-heading-m">Information shown on the public register</h2>

--- a/views/beneficial-owner-individual.html
+++ b/views/beneficial-owner-individual.html
@@ -1,7 +1,9 @@
 {% extends "layout.html" %}
 
+{% set title = "Tell us about the individual person" %}
+
 {% block pageTitle %}
-  Individual beneficial owner - {{ SERVICE_NAME }} - GOV.UK
+  {{ title }} - {{ SERVICE_NAME }} - GOV.UK
 {% endblock %}
 
 {% block backLink %}

--- a/views/beneficial-owner-other.html
+++ b/views/beneficial-owner-other.html
@@ -1,7 +1,9 @@
 {% extends "layout.html" %}
 
+{% set title = "Tell us about the other legal entity" %}
+
 {% block pageTitle %}
-  Beneficial owner - {{ SERVICE_NAME }} - GOV.UK
+  {{ title }} - {{ SERVICE_NAME }} - GOV.UK
 {% endblock %}
 
 {% block backLink %}
@@ -13,7 +15,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <span class="govuk-caption-xl">Beneficial owner</span>
-      <h1 class="govuk-heading-xl govuk-!-margin-0">Tell us about the other legal entity</h1>
+      <h1 class="govuk-heading-xl govuk-!-margin-0">{{ title }}</h1>
       <br>
       <p class="govuk-body">You can add more later.</p>
       <br>
@@ -60,7 +62,7 @@
 
         {% set sanctionsListText = "Is it on the sanctions list?" %}
         {% set sanctionsListHintText = "This means that it is subject to sanctions under the Sanctions and Anti-Money Laundering Act 2018." %}
-        {% include "includes/inputs/fields/is-on-sanctions-list-input.html" %}        
+        {% include "includes/inputs/fields/is-on-sanctions-list-input.html" %}
 
         {{ govukInsetText({
           html: '

--- a/views/beneficial-owner-statements.html
+++ b/views/beneficial-owner-statements.html
@@ -1,7 +1,9 @@
 {% extends "layout.html" %}
 
+{% set title = "Have any registrable beneficial owners been identified?" %}
+
 {% block pageTitle %}
-  Have any registrable beneficial owners been identified? - {{ SERVICE_NAME }} - GOV.UK
+  {{ title }} - {{ SERVICE_NAME }} - GOV.UK
 {% endblock %}
 
 {% block backLink %}
@@ -13,7 +15,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-      <h1 class="govuk-heading-xl">Have any registrable beneficial owners been identified?</h1>
+      <h1 class="govuk-heading-xl">{{ title }}</h1>
 
       {{ govukDetails({
         summaryText: "What is a registrable beneficial owner?",

--- a/views/beneficial-owner-statements.html
+++ b/views/beneficial-owner-statements.html
@@ -1,7 +1,7 @@
 {% extends "layout.html" %}
 
 {% block pageTitle %}
-  Beneficial owner statements - {{ SERVICE_NAME }} - GOV.UK
+  Have any registrable beneficial owners been identified? - {{ SERVICE_NAME }} - GOV.UK
 {% endblock %}
 
 {% block backLink %}

--- a/views/beneficial-owner-type.html
+++ b/views/beneficial-owner-type.html
@@ -1,13 +1,5 @@
 {% extends "layout.html" %}
 
-{% block pageTitle %}
-  Who is registering - {{ SERVICE_NAME }} - GOV.UK
-{% endblock %}
-
-{% block backLink %}
-  {% include "includes/back-link.html" %}
-{% endblock %}
-
 {% set bos = [{
     value: "individualOwner",
     text: "Individual beneficial owner"
@@ -38,7 +30,7 @@
   {% set boTypes = bos %}
   {% set whatToAdd = "another beneficial owner" %}
   {% set hiddenTextValue = "beneficial owners" %}
-{% elif beneficial_owners_statement === "NONE_IDENTIFIED" %}
+  {% elif beneficial_owners_statement === "NONE_IDENTIFIED" %}
   {% set boTypesLegendText = "Select the type of managing officer you want to add" %}
   {% set boTypesTitle = "Which type of managing officer do you want to add?" %}
   {% set boTypes = mos %}
@@ -55,11 +47,19 @@
 {% endif %}
 
 {% set hasBeneficialOwners = (beneficial_owners_individual and beneficial_owners_individual.length > 0)
-  or (beneficial_owners_corporate and beneficial_owners_corporate.length > 0)
-  or (beneficial_owners_government_or_public_authority and beneficial_owners_government_or_public_authority.length > 0) %}
+or (beneficial_owners_corporate and beneficial_owners_corporate.length > 0)
+or (beneficial_owners_government_or_public_authority and beneficial_owners_government_or_public_authority.length > 0) %}
 
 {% set hasManagingOfficers = (managing_officers_individual and managing_officers_individual.length > 0)
-  or (managing_officers_corporate and managing_officers_corporate.length > 0) %}
+or (managing_officers_corporate and managing_officers_corporate.length > 0) %}
+
+{% block pageTitle %}
+  {{ boTypesTitle }} - {{ SERVICE_NAME }} - GOV.UK
+{% endblock %}
+
+{% block backLink %}
+  {% include "includes/back-link.html" %}
+{% endblock %}
 
 {% block content %}
 

--- a/views/beneficial-owner-type.html
+++ b/views/beneficial-owner-type.html
@@ -30,7 +30,7 @@
   {% set boTypes = bos %}
   {% set whatToAdd = "another beneficial owner" %}
   {% set hiddenTextValue = "beneficial owners" %}
-  {% elif beneficial_owners_statement === "NONE_IDENTIFIED" %}
+{% elif beneficial_owners_statement === "NONE_IDENTIFIED" %}
   {% set boTypesLegendText = "Select the type of managing officer you want to add" %}
   {% set boTypesTitle = "Which type of managing officer do you want to add?" %}
   {% set boTypes = mos %}

--- a/views/includes/heading/bo-and-mo-individuals-heading.html
+++ b/views/includes/heading/bo-and-mo-individuals-heading.html
@@ -1,2 +1,2 @@
-<h1 class="govuk-heading-xl govuk-!-margin-0">Tell us about the individual person</h1>
+<h1 class="govuk-heading-xl govuk-!-margin-0">{{ title }}</h1>
 <br> <p class="govuk-body">You can add more later.</p> <br>

--- a/views/managing-officer-corporate.html
+++ b/views/managing-officer-corporate.html
@@ -1,7 +1,9 @@
 {% extends "layout.html" %}
 
+{% set title = "Tell us about the corporate managing officer" %}
+
 {% block pageTitle %}
-  Corporate managing officer - {{ SERVICE_NAME }} - GOV.UK
+  {{ title }} - {{ SERVICE_NAME }} - GOV.UK
 {% endblock %}
 
 {% block backLink %}
@@ -14,9 +16,9 @@
   <div class="govuk-grid-column-two-thirds">
 
     <span class="govuk-caption-xl">Managing officer</span>
-    <h1 class="govuk-heading-xl govuk-!-margin-0">Tell us about the corporate managing officer</h1>
+    <h1 class="govuk-heading-xl govuk-!-margin-0">{{ title }}</h1>
     <br> <p class="govuk-body">You can add more later.</p> <br>
-    
+
     {% include "includes/list/errors.html" %}
 
     <form class="form" method="post">

--- a/views/managing-officer.html
+++ b/views/managing-officer.html
@@ -1,7 +1,9 @@
 {% extends "layout.html" %}
 
+{% set title = "Tell us about the individual person" %}
+
 {% block pageTitle %}
-  Managing officer - {{ SERVICE_NAME }} - GOV.UK
+  {{ title }} - {{ SERVICE_NAME }} - GOV.UK
 {% endblock %}
 
 {% block backLink %}

--- a/views/sold-land-filter.html
+++ b/views/sold-land-filter.html
@@ -1,8 +1,9 @@
 {% extends "layout.html" %}
 
+{% set title = "Has the entity disposed of UK property or land since 28 February 2022?" %}
+
 {% block pageTitle %}
-Has the entity disposed of UK property or land since 28 February 2022?
- - {{ SERVICE_NAME }} - GOV.UK
+  {{ title }} - {{ SERVICE_NAME }} - GOV.UK
 {% endblock %}
 
 {% block backLink %}
@@ -26,7 +27,7 @@ Has the entity disposed of UK property or land since 28 February 2022?
           name: "has_sold_land",
           fieldset: {
             legend: {
-              text: "Has the entity disposed of UK property or land since 28 February 2022?",
+              text: title,
               isPageHeading: true,
               classes: "govuk-fieldset__legend--xl"
             }

--- a/views/sold-land-filter.html
+++ b/views/sold-land-filter.html
@@ -1,9 +1,8 @@
 {% extends "layout.html" %}
 
-{% set title = "Has the entity disposed of UK property or land since 28 February 2022?" %}
-
 {% block pageTitle %}
-  {{ title }} - {{ SERVICE_NAME }} - GOV.UK
+Has the entity disposed of UK property or land since 28 February 2022?
+ - {{ SERVICE_NAME }} - GOV.UK
 {% endblock %}
 
 {% block backLink %}
@@ -27,7 +26,7 @@
           name: "has_sold_land",
           fieldset: {
             legend: {
-              text: title,
+              text: "Has the entity disposed of UK property or land since 28 February 2022?",
               isPageHeading: true,
               classes: "govuk-fieldset__legend--xl"
             }


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/ROE-1128


### Change description
The title shown in the tab has been changed to match the h1 headings on 7 pages: the two radio button pages and all the possible bo and mo information input pages.


### Work checklist

- [x] Tests added where applicable
- [x] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
