### PR TITLE
ROE-1374 County for due diligence blocks should be optional

### DIFF
--- a/src/validation/fields/address.validation.ts
+++ b/src/validation/fields/address.validation.ts
@@ -127,7 +127,6 @@ export const identity_address_validations = [
     .isLength({ max: 50 }).withMessage(ErrorMessages.MAX_CITY_OR_TOWN_LENGTH)
     .matches(VALID_CHARACTERS).withMessage(ErrorMessages.CITY_OR_TOWN_INVALID_CHARACTERS),
   body("identity_address_county")
-    .not().isEmpty({ ignore_whitespace: true }).withMessage(ErrorMessages.COUNTY)
     .isLength({ max: 50 }).withMessage(ErrorMessages.MAX_COUNTY_LENGTH)
     .matches(VALID_CHARACTERS).withMessage(ErrorMessages.COUNTY_STATE_PROVINCE_REGION_INVALID_CHARACTERS),
   body("identity_address_country")

--- a/test/controllers/due.diligence.controller.spec.ts
+++ b/test/controllers/due.diligence.controller.spec.ts
@@ -129,7 +129,7 @@ describe("DUE_DILIGENCE controller", () => {
       expect(resp.text).not.toContain(ErrorMessages.PROPERTY_NAME_OR_NUMBER);
       expect(resp.text).toContain(ErrorMessages.ADDRESS_LINE1);
       expect(resp.text).toContain(ErrorMessages.CITY_OR_TOWN);
-      expect(resp.text).toContain(ErrorMessages.COUNTY);
+      expect(resp.text).not.toContain(ErrorMessages.COUNTY);
       expect(resp.text).toContain(ErrorMessages.UK_COUNTRY);
       expect(resp.text).toContain(ErrorMessages.POSTCODE);
       expect(resp.text).toContain(ErrorMessages.EMAIL);

--- a/test/controllers/overseas.entity.due.diligence.controller.spec.ts
+++ b/test/controllers/overseas.entity.due.diligence.controller.spec.ts
@@ -139,7 +139,7 @@ describe("OVERSEAS_ENTITY_DUE_DILIGENCE controller", () => {
       expect(resp.text).not.toContain(ErrorMessages.PROPERTY_NAME_OR_NUMBER);
       expect(resp.text).toContain(ErrorMessages.ADDRESS_LINE1);
       expect(resp.text).toContain(ErrorMessages.CITY_OR_TOWN);
-      expect(resp.text).toContain(ErrorMessages.COUNTY);
+      expect(resp.text).not.toContain(ErrorMessages.COUNTY);
       expect(resp.text).toContain(ErrorMessages.UK_COUNTRY);
       expect(resp.text).toContain(ErrorMessages.POSTCODE);
       expect(resp.text).toContain(ErrorMessages.EMAIL);


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/ROE-1374

### Change description

Due diligence and overseas entity due diligence county field must be optional, so removed the not empty validation requirement.

### Work checklist

- [x] Tests added where applicable
- [x] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
