### PR TITLE
ROE-1725 Add jurisdiction field to only the entity page

### DIFF
--- a/views/beneficial-owner-other.html
+++ b/views/beneficial-owner-other.html
@@ -37,7 +37,7 @@
 
         {% set registerInCountryFormedText = "Is the other legal entity already on a public register in the country it was formed in?" %}
         {% set registrationNumberText = "Entity's registration number" %}
-        {% include "includes/inputs/fields/is-on-register-in-country-formed-input.html" %}
+        {% include "includes/inputs/fields/is-on-register-in-country-formed-input-no-jurisdiction-field.html" %}
 
         {% set dateText = "When did it become a beneficial owner for the overseas entity?" %}
         {% include "includes/inputs/date/start-date-input.html" %}

--- a/views/includes/inputs/fields/is-on-register-in-country-formed-input-no-jurisdiction-field.html
+++ b/views/includes/inputs/fields/is-on-register-in-country-formed-input-no-jurisdiction-field.html
@@ -1,0 +1,46 @@
+{% set entityPublicRegisterHtml %}
+  {{ govukInput({
+    errorMessage: errors.public_register_name if errors,
+    id: "public_register_name",
+    name: "public_register_name",
+    value: public_register_name,
+    hint: {
+      text: "Include its jurisdiction. For example, Hong Kong or State of Delaware."
+    },
+    label: {
+      text: "Name of register"
+    }
+  }) }}
+
+ {% include "includes/inputs/fields/registration-number-input.html" %}
+{% endset -%}
+
+
+{{ govukRadios({
+  errorMessage: errors.is_on_register_in_country_formed_in if errors,
+  classes: "govuk-radios",
+  idPrefix: "is_on_register_in_country_formed_in",
+  name: "is_on_register_in_country_formed_in",
+  fieldset: {
+    legend: {
+      text: registerInCountryFormedText,
+      isPageHeading: false,
+      classes: "govuk-fieldset__legend--m"
+    }
+  },
+  items: [
+  {
+      value: 1,
+      text: "Yes",
+      conditional: {
+        html: entityPublicRegisterHtml
+      },
+      checked: is_on_register_in_country_formed_in == 1
+    },
+    {
+      value: 0,
+      text: "No",
+      checked: is_on_register_in_country_formed_in == 0
+    }
+  ]
+}) }}

--- a/views/managing-officer-corporate.html
+++ b/views/managing-officer-corporate.html
@@ -35,7 +35,7 @@
 
       {% set registerInCountryFormedText = "Is the corporate managing officer already on a public register in the country it was formed?" %}
       {% set registrationNumberText = "Corporate managing officer's registration number" %}
-      {% include "includes/inputs/fields/is-on-register-in-country-formed-input.html" %}
+      {% include "includes/inputs/fields/is-on-register-in-country-formed-input-no-jurisdiction-field.html" %}
 
       {{ govukTextarea({
       errorMessage: errors.role_and_responsibilities if errors,


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/ROE-1725


### Change description

Introduced separate public register component templates so the extra field on the entity page can be kept separate.

### Work checklist

- [x] Tests added where applicable
- [x] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
