### PR TITLE
ROE-1167 adding id and moving label for hidden inputs

### DIFF
--- a/views/beneficial-owner-delete-warning.html
+++ b/views/beneficial-owner-delete-warning.html
@@ -61,13 +61,14 @@
 
         <!-- Hidden input, needed to submit the beneficial owners statement -->
         {{ govukInput({
-          value: beneficial_owners_statement,
-          name: "beneficial_owners_statement",
-          classes: "govuk-visually-hidden",
           label: {
             text: "Hidden input, needed to submit the beneficial owners statement",
             classes: "govuk-visually-hidden"
-          }
+          },
+          id: "beneficial_owners_statement",
+          value: beneficial_owners_statement,
+          name: "beneficial_owners_statement",
+          classes: "govuk-visually-hidden"
         }) }}
 
         {% include "includes/continue-button.html" %}

--- a/views/beneficial-owner-type.html
+++ b/views/beneficial-owner-type.html
@@ -129,13 +129,14 @@ or (managing_officers_corporate and managing_officers_corporate.length > 0) %}
 
         <!-- Hidden input, needed to submit the beneficial owners statement -->
         {{ govukInput({
-          value: beneficial_owners_statement,
-          name: "beneficial_owners_statement",
-          classes: "govuk-visually-hidden",
           label: {
             text: "Hidden input, needed to submit the beneficial owners statement",
             classes: "govuk-visually-hidden"
-          }
+          },
+          id: "beneficial_owners_statement",
+          value: beneficial_owners_statement,
+          name: "beneficial_owners_statement",
+          classes: "govuk-visually-hidden"
         }) }}
 
       </form>


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/ROE-1167


### Change description
Moved the input around and added an id which was causing the label to not correspond correctly with the input when translated into HTML

### Work checklist

- [ ] Tests added where applicable
- [x] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
