### PR TITLE
ROE-1670 adding new email hint text on entity page

### DIFF
--- a/views/entity.html
+++ b/views/entity.html
@@ -54,13 +54,27 @@
           classes: "govuk-label--m",
           isPageHeading: false
         },
-        hint: {
-          text: "We'll use this to send the Overseas Entity ID number, the notice of registration, and any other digital correspondence"
-        },
         id: "email",
         name: "email",
         value: email
       }) }}
+
+      <details class="govuk-details" data-module="govuk-details">
+        <summary class="govuk-details__summary">
+            <span class="govuk-details__summary-text">
+              What we'll use this email address for
+            </span>
+        </summary>
+        <div class="govuk-details__text">
+          <p class="govuk-body">We'll use this to send:</p>
+          <ul class="govuk-list govuk-list--bullet">
+            <li>the Overseas Entity ID</li>
+            <li>the notice of registration</li>
+            <li>any other important information</li>
+          </ul>
+          <p>We’ll also send the Overseas Entity ID to the email you used to sign in.</p>
+        </div>
+      </details>
 
       {% set hintText = "For example, limited company" %}
       {% include "includes/inputs/legal-form-input.html" %}


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/ROE-1670


### Change description
Work to remove the old hint text and replace it with a new govuk details element below the email input on the entity page.


### Work checklist

- [ ] Tests added where applicable
- [x] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
