### PR TITLE
[UAR-215] No validation error for OE number greater than 'OE' + 6 digits

### DIFF
--- a/src/validation/regex/regex.validation.ts
+++ b/src/validation/regex/regex.validation.ts
@@ -7,4 +7,4 @@ export const VALID_CHARACTERS_FOR_TEXT_BOX = /^[-,.:; 0-9A-Z&@$£¥€'"«»''""
 export const VALID_EMAIL_FORMAT = /^.+@.+\..+$/;
 
 // Valid OE number characters
-export const VALID_OE_NUMBER_FORMAT = /OE\d{6}/;
+export const VALID_OE_NUMBER_FORMAT = /^OE\d{6}$/;

--- a/test/controllers/update/overseas.entity.query.controller.spec.ts
+++ b/test/controllers/update/overseas.entity.query.controller.spec.ts
@@ -100,31 +100,17 @@ describe("OVERSEAS ENTITY QUERY controller", () => {
       expect(resp.text).toContain(htmlDecodedString);
     });
 
-    test('renders the OVERSEAS_ENTITY_QUERY_PAGE page with correct error message', async () => {
-      const resp = await request(app)
-        .post(config.OVERSEAS_ENTITY_QUERY_URL)
-        .send({ oe_number: 'OE123' });
-      expect(resp.status).toEqual(200);
-      expect(resp.text).toContain(htmlDecodedString);
-      expect(resp.text).not.toContain(ErrorMessages.OE_QUERY_NUMBER);
-    });
+    const invalid_input_values = ['OE123', 'EO123456', 'OE123456789'];
 
-    test('renders the OVERSEAS_ENTITY_QUERY_PAGE page with correct error message when input contains EO', async () => {
-      const resp = await request(app)
-        .post(config.OVERSEAS_ENTITY_QUERY_URL)
-        .send({ oe_number: 'EO123456' });
-      expect(resp.status).toEqual(200);
-      expect(resp.text).toContain(htmlDecodedString);
-      expect(resp.text).not.toContain(ErrorMessages.OE_QUERY_NUMBER);
-    });
-
-    test('renders the OVERSEAS_ENTITY_QUERY_PAGE page with correct error message when greater than 6 digits', async () => {
-      const resp = await request(app)
-        .post(config.OVERSEAS_ENTITY_QUERY_URL)
-        .send({ oe_number: 'OE123456789' });
-      expect(resp.status).toEqual(200);
-      expect(resp.text).toContain(htmlDecodedString);
-      expect(resp.text).not.toContain(ErrorMessages.OE_QUERY_NUMBER);
-    });
+    test.each(invalid_input_values)(
+      "given %p, renders OVERSEAS_ENTITY_QUERY_PAGE with validator failure", async (input_value) => {
+        const resp = await request(app)
+          .post(config.OVERSEAS_ENTITY_QUERY_URL)
+          .send({ oe_number: input_value });
+        expect(resp.status).toEqual(200);
+        expect(resp.text).toContain(htmlDecodedString);
+        expect(resp.text).not.toContain(ErrorMessages.OE_QUERY_NUMBER);
+      }
+    );
   });
 });

--- a/test/controllers/update/overseas.entity.query.controller.spec.ts
+++ b/test/controllers/update/overseas.entity.query.controller.spec.ts
@@ -117,5 +117,14 @@ describe("OVERSEAS ENTITY QUERY controller", () => {
       expect(resp.text).toContain(htmlDecodedString);
       expect(resp.text).not.toContain(ErrorMessages.OE_QUERY_NUMBER);
     });
+
+    test('renders the OVERSEAS_ENTITY_QUERY_PAGE page with correct error message when greater than 6 digits', async () => {
+      const resp = await request(app)
+        .post(config.OVERSEAS_ENTITY_QUERY_URL)
+        .send({ oe_number: 'OE123456789' });
+      expect(resp.status).toEqual(200);
+      expect(resp.text).toContain(htmlDecodedString);
+      expect(resp.text).not.toContain(ErrorMessages.OE_QUERY_NUMBER);
+    });
   });
 });


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/UAR-215


### Change description

If the user enters 'OE12345678' or anything greater than 6 digits after 'OE' then it passes the page's validator and would continue onto the next controller from UAR-93 (and call the API before triggering the redirect with company profile not found error there).
To avoid unnecessary API calls, validator updated to ensure only 6 digits exist after 'OE'.

### Work checklist

- [x] Tests added where applicable
- [x] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.


[UAR-215]: https://companieshouse.atlassian.net/browse/UAR-215?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[UAR-93]: https://companieshouse.atlassian.net/browse/UAR-93?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ