### PR TITLE
ROE-1240 Focus field problem depends on field errors being kept separate

### DIFF
--- a/src/validation/beneficial.owner.gov.validation.ts
+++ b/src/validation/beneficial.owner.gov.validation.ts
@@ -3,7 +3,8 @@ import { body } from "express-validator";
 import { ErrorMessages } from "./error.messages";
 import { principal_address_validations, principal_service_address_validations } from "./fields/address.validation";
 import { VALID_CHARACTERS } from "./regex/regex.validation";
-import { checkAtLeastOneFieldHasValue, checkMandatoryDate } from "./custom.validation";
+import { checkAtLeastOneFieldHasValue } from "./custom.validation";
+import { start_date_validations } from "./fields/date.validation";
 
 export const beneficialOwnerGov = [
   body("name")
@@ -34,6 +35,5 @@ export const beneficialOwnerGov = [
   body("is_on_sanctions_list")
     .not().isEmpty().withMessage(ErrorMessages.SELECT_IF_ON_SANCTIONS_LIST),
 
-  body("start_date")
-    .custom((value, { req }) => checkMandatoryDate(req.body["start_date-day"], req.body["start_date-month"], req.body["start_date-year"])),
+  ...start_date_validations,
 ];

--- a/src/validation/beneficial.owner.individual.validation.ts
+++ b/src/validation/beneficial.owner.individual.validation.ts
@@ -8,7 +8,7 @@ import {
 } from "./fields/address.validation";
 import { nature_of_control_validations } from "./fields/nature-of-control.validation";
 import { second_nationality_validations } from "./fields/second-nationality.validation";
-import { checkDateOfBirth, checkMandatoryDate } from "./custom.validation";
+import { date_of_birth_validations, start_date_validations } from "./fields/date.validation";
 
 export const beneficialOwnerIndividual = [
   body("first_name")
@@ -31,14 +31,12 @@ export const beneficialOwnerIndividual = [
   body("is_service_address_same_as_usual_residential_address")
     .not().isEmpty().withMessage(ErrorMessages.SELECT_IF_SERVICE_ADDRESS_SAME_AS_USER_RESIDENTIAL_ADDRESS),
 
-  body("start_date")
-    .custom((value, { req }) => checkMandatoryDate(req.body["start_date-day"], req.body["start_date-month"], req.body["start_date-year"])),
+  ...start_date_validations,
 
   ...usual_residential_address_validations,
   ...usual_residential_service_address_validations,
 
-  body("date_of_birth")
-    .custom((value, { req }) => checkDateOfBirth(req.body["date_of_birth-day"], req.body["date_of_birth-month"], req.body["date_of_birth-year"])),
+  ...date_of_birth_validations,
 
   ...nature_of_control_validations
 ];

--- a/src/validation/beneficial.owner.other.validation.ts
+++ b/src/validation/beneficial.owner.other.validation.ts
@@ -5,7 +5,7 @@ import { VALID_CHARACTERS } from "./regex/regex.validation";
 import { principal_address_validations, principal_service_address_validations } from "./fields/address.validation";
 import { public_register_validations } from "./fields/public-register.validation";
 import { nature_of_control_validations } from "./fields/nature-of-control.validation";
-import { checkMandatoryDate } from "./custom.validation";
+import { start_date_validations } from "./fields/date.validation";
 
 export const beneficialOwnerOther = [
   body("name")
@@ -35,8 +35,7 @@ export const beneficialOwnerOther = [
 
   ...public_register_validations,
 
-  body("start_date")
-    .custom((value, { req }) => checkMandatoryDate(req.body["start_date-day"], req.body["start_date-month"], req.body["start_date-year"])),
+  ...start_date_validations,
 
   ...nature_of_control_validations,
 

--- a/src/validation/custom.validation.ts
+++ b/src/validation/custom.validation.ts
@@ -93,14 +93,23 @@ export const checkOptionalDate = (dayStr: string = "", monthStr: string = "", ye
 };
 
 export const checkIdentityDate = (dayStr: string = "", monthStr: string = "", yearStr: string = "") => {
-  const isMandatoryDateValid = checkMandatoryDate(dayStr, monthStr, yearStr);
-  if (isMandatoryDateValid) {
-    checkDateIsWithinLast3Months(ErrorMessages.IDENTITY_CHECK_DATE_NOT_WITHIN_PAST_3_MONTHS, dayStr, monthStr, yearStr);
+  const isDatePresent = checkDateIsNotCompletelyEmpty(ErrorMessages.ENTER_DATE, dayStr, monthStr, yearStr);
+  if (isDatePresent) {
+    const areAllDateFieldsPresent = checkAllDateFieldsArePresent(dayStr, monthStr, yearStr);
+    if (areAllDateFieldsPresent) {
+      const isDateValid = checkDateValueIsValid(ErrorMessages.INVALID_DATE, dayStr, monthStr, yearStr);
+      if (isDateValid) {
+        const isDatePastOrToday = checkDateIsInPastOrToday(ErrorMessages.DATE_NOT_IN_PAST_OR_TODAY, dayStr, monthStr, yearStr);
+        if (isDatePastOrToday) {
+          checkDateIsWithinLast3Months(ErrorMessages.IDENTITY_CHECK_DATE_NOT_WITHIN_PAST_3_MONTHS, dayStr, monthStr, yearStr);
+        }
+      }
+    }
   }
   return true;
 };
 
-export const checkMandatoryDate = (dayStr: string = "", monthStr: string = "", yearStr: string = "") => {
+export const checkStartDate = (dayStr: string = "", monthStr: string = "", yearStr: string = "") => {
   const isDatePresent = checkDateIsNotCompletelyEmpty(ErrorMessages.ENTER_DATE, dayStr, monthStr, yearStr);
   if (isDatePresent) {
     const areAllDateFieldsPresent = checkAllDateFieldsArePresent(dayStr, monthStr, yearStr);
@@ -114,13 +123,34 @@ export const checkMandatoryDate = (dayStr: string = "", monthStr: string = "", y
   return true;
 };
 
-export const checkAllDateFieldsArePresent = (dayStr: string = "", monthStr: string = "", yearStr: string = "") => {
+export const checkDateFieldDay = (dayStr: string = "", monthStr: string = "", yearStr: string = "") => {
   if (dayStr === "" && monthStr !== "" && yearStr !== "") {
     throw new Error(ErrorMessages.DAY);
-  } else if (monthStr === "" && dayStr !== "" && yearStr !== "") {
+  }
+  return true;
+};
+
+export const checkDateFieldMonth = (dayStr: string = "", monthStr: string = "", yearStr: string = "") => {
+  if (monthStr === "" && dayStr !== "" && yearStr !== "") {
     throw new Error(ErrorMessages.MONTH);
-  } else if (yearStr === "" && dayStr !== "" && monthStr !== "") {
+  }
+  return true;
+};
+
+export const checkDateFieldYear = (dayStr: string = "", monthStr: string = "", yearStr: string = "") => {
+  if (yearStr === "" && dayStr !== "" && monthStr !== "") {
     throw new Error(ErrorMessages.YEAR);
+  }
+  return true;
+};
+
+export const checkAllDateFieldsArePresent = (dayStr: string = "", monthStr: string = "", yearStr: string = "") => {
+  if (dayStr === "" && monthStr !== "" && yearStr !== "") {
+    return false;
+  } else if (monthStr === "" && dayStr !== "" && yearStr !== "") {
+    return false;
+  } else if (yearStr === "" && dayStr !== "" && monthStr !== "") {
+    return false;
   } else if ((dayStr === "" && monthStr === "") || (dayStr === "" && yearStr === "") || (monthStr === "" && yearStr === "")) {
     throw new Error(ErrorMessages.INVALID_DATE);
   }
@@ -141,13 +171,35 @@ export const checkDateOfBirth = (dayStr: string = "", monthStr: string = "", yea
   return true;
 };
 
-export const checkDateOfBirthFieldsArePresent = (dayStr: string = "", monthStr: string = "", yearStr: string = "") => {
+export const checkDateOfBirthFieldDay = (dayStr: string = "", monthStr: string = "", yearStr: string = "") => {
   if (dayStr === "" && monthStr !== "" && yearStr !== "") {
     throw new Error(ErrorMessages.DAY_OF_BIRTH);
-  } else if (monthStr === "" && dayStr !== "" && yearStr !== "") {
+  }
+  return true;
+};
+
+export const checkDateOfBirthFieldMonth = (dayStr: string = "", monthStr: string = "", yearStr: string = "") => {
+  if (monthStr === "" && dayStr !== "" && yearStr !== "") {
     throw new Error(ErrorMessages.MONTH_OF_BIRTH);
-  } else if (yearStr === "" && dayStr !== "" && monthStr !== "") {
+  }
+  return true;
+};
+
+export const checkDateOfBirthFieldYear = (dayStr: string = "", monthStr: string = "", yearStr: string = "") => {
+  if (yearStr === "" && dayStr !== "" && monthStr !== "") {
     throw new Error(ErrorMessages.YEAR_OF_BIRTH);
+  }
+  return true;
+};
+
+
+export const checkDateOfBirthFieldsArePresent = (dayStr: string = "", monthStr: string = "", yearStr: string = "") => {
+  if (dayStr === "" && monthStr !== "" && yearStr !== "") {
+    return false;
+  } else if (monthStr === "" && dayStr !== "" && yearStr !== "") {
+    return false;
+  } else if (yearStr === "" && dayStr !== "" && monthStr !== "") {
+    return false;
   } else if ((dayStr === "" && monthStr === "") || (dayStr === "" && yearStr === "") || (monthStr === "" && yearStr === "")) {
     throw new Error(ErrorMessages.INVALID_DATE_OF_BIRTH);
   }

--- a/src/validation/due.diligence.validation.ts
+++ b/src/validation/due.diligence.validation.ts
@@ -4,12 +4,11 @@ import { ErrorMessages } from "./error.messages";
 import { identity_address_validations } from "./fields/address.validation";
 import { VALID_CHARACTERS } from "./regex/regex.validation";
 import { email_validations } from "./fields/email.validation";
-import { checkIdentityDate } from "./custom.validation";
+import { identity_check_date_validations } from "./fields/date.validation";
 
 export const dueDiligence = [
 
-  body("identity_date")
-    .custom((value, { req }) => checkIdentityDate(req.body["identity_date-day"], req.body["identity_date-month"], req.body["identity_date-year"])),
+  ...identity_check_date_validations,
 
   body("name")
     .not().isEmpty({ ignore_whitespace: true }).withMessage(ErrorMessages.DUE_DILIGENCE_NAME)

--- a/src/validation/fields/date.validation.ts
+++ b/src/validation/fields/date.validation.ts
@@ -1,0 +1,38 @@
+import { body } from "express-validator";
+import {
+  checkDateFieldDay,
+  checkDateFieldMonth,
+  checkDateFieldYear, checkDateOfBirth, checkDateOfBirthFieldDay, checkDateOfBirthFieldMonth, checkDateOfBirthFieldYear,
+  checkIdentityDate,
+  checkStartDate
+} from "../custom.validation";
+
+export const start_date_validations = [
+  body("start_date-day").custom((value, { req }) => checkDateFieldDay(req.body["start_date-day"], req.body["start_date-month"], req.body["start_date-year"])),
+  body("start_date-month").custom((value, { req }) => checkDateFieldMonth(req.body["start_date-day"], req.body["start_date-month"], req.body["start_date-year"])),
+  body("start_date-year").custom((value, { req }) => checkDateFieldYear(req.body["start_date-day"], req.body["start_date-month"], req.body["start_date-year"])),
+  body("start_date")
+    .custom((value, { req }) => checkStartDate(req.body["start_date-day"], req.body["start_date-month"], req.body["start_date-year"])),
+];
+
+export const date_of_birth_validations = [
+  body("date_of_birth-day")
+    .custom((value, { req }) => checkDateOfBirthFieldDay(req.body["date_of_birth-day"], req.body["date_of_birth-month"], req.body["date_of_birth-year"])),
+  body("date_of_birth-month")
+    .custom((value, { req }) => checkDateOfBirthFieldMonth(req.body["date_of_birth-day"], req.body["date_of_birth-month"], req.body["date_of_birth-year"])),
+  body("date_of_birth-year")
+    .custom((value, { req }) => checkDateOfBirthFieldYear(req.body["date_of_birth-day"], req.body["date_of_birth-month"], req.body["date_of_birth-year"])),
+  body("date_of_birth")
+    .custom((value, { req }) => checkDateOfBirth(req.body["date_of_birth-day"], req.body["date_of_birth-month"], req.body["date_of_birth-year"])),
+];
+
+export const identity_check_date_validations = [
+  body("identity_date-day")
+    .custom((value, { req }) => checkDateFieldDay(req.body["identity_date-day"], req.body["identity_date-month"], req.body["identity_date-year"])),
+  body("identity_date-month")
+    .custom((value, { req }) => checkDateFieldMonth(req.body["identity_date-day"], req.body["identity_date-month"], req.body["identity_date-year"])),
+  body("identity_date-year")
+    .custom((value, { req }) => checkDateFieldYear(req.body["identity_date-day"], req.body["identity_date-month"], req.body["identity_date-year"])),
+  body("identity_date")
+    .custom((value, { req }) => checkIdentityDate(req.body["identity_date-day"], req.body["identity_date-month"], req.body["identity_date-year"])),
+];

--- a/src/validation/managing.officer.validation.ts
+++ b/src/validation/managing.officer.validation.ts
@@ -1,7 +1,6 @@
 import { body } from "express-validator";
 
 import {
-  checkDateOfBirth,
   checkFieldIfRadioButtonSelected,
   checkInvalidCharactersIfRadioButtonSelected,
   checkMaxFieldIfRadioButtonSelected
@@ -10,6 +9,7 @@ import { ErrorMessages } from "./error.messages";
 import { usual_residential_service_address_validations, usual_residential_address_validations } from "./fields/address.validation";
 import { second_nationality_validations } from "./fields/second-nationality.validation";
 import { VALID_CHARACTERS, VALID_CHARACTERS_FOR_TEXT_BOX } from "./regex/regex.validation";
+import { date_of_birth_validations } from "./fields/date.validation";
 
 export const managingOfficerIndividual = [
   body("first_name").not().isEmpty({ ignore_whitespace: true })
@@ -23,8 +23,8 @@ export const managingOfficerIndividual = [
     .custom((value, { req }) => checkFieldIfRadioButtonSelected(req.body.has_former_names === '1', ErrorMessages.FORMER_NAME, value))
     .custom((value, { req }) => checkMaxFieldIfRadioButtonSelected(req.body.has_former_names === '1', ErrorMessages.MAX_FORMER_NAME_LENGTH, 260, value))
     .custom((value, { req }) => checkInvalidCharactersIfRadioButtonSelected(req.body.has_former_names === '1', ErrorMessages.FORMER_NAMES_INVALID_CHARACTERS, value)),
-  body("date_of_birth")
-    .custom((value, { req }) => checkDateOfBirth(req.body["date_of_birth-day"], req.body["date_of_birth-month"], req.body["date_of_birth-year"])),
+
+  ...date_of_birth_validations,
 
   body("nationality")
     .not().isEmpty({ ignore_whitespace: true }).withMessage(ErrorMessages.NATIONALITY)

--- a/src/validation/overseas.entity.due.diligence.validation.ts
+++ b/src/validation/overseas.entity.due.diligence.validation.ts
@@ -3,11 +3,17 @@ import { body } from "express-validator";
 import { ErrorMessages } from "./error.messages";
 import { identity_address_validations } from "./fields/address.validation";
 import { VALID_CHARACTERS } from "./regex/regex.validation";
-import { checkOptionalDate } from "./custom.validation";
+import { checkDateFieldDay, checkDateFieldMonth, checkDateFieldYear, checkOptionalDate } from "./custom.validation";
 import { email_validations } from "./fields/email.validation";
 
 export const overseasEntityDueDiligence = [
 
+  body("identity_date-day")
+    .custom((value, { req }) => checkDateFieldDay(req.body["identity_date-day"], req.body["identity_date-month"], req.body["identity_date-year"])),
+  body("identity_date-month")
+    .custom((value, { req }) => checkDateFieldMonth(req.body["identity_date-day"], req.body["identity_date-month"], req.body["identity_date-year"])),
+  body("identity_date-year")
+    .custom((value, { req }) => checkDateFieldYear(req.body["identity_date-day"], req.body["identity_date-month"], req.body["identity_date-year"])),
   body("identity_date")
     .custom((value, { req }) => checkOptionalDate(req.body["identity_date-day"], req.body["identity_date-month"], req.body["identity_date-year"])),
 

--- a/test/controllers/due.diligence.controller.spec.ts
+++ b/test/controllers/due.diligence.controller.spec.ts
@@ -282,7 +282,6 @@ describe("DUE_DILIGENCE controller", () => {
       expect(resp.text).not.toContain(ErrorMessages.IDENTITY_CHECK_DATE_NOT_WITHIN_PAST_3_MONTHS);
       expect(mockSaveAndContinue).not.toHaveBeenCalled();
     });
-
     test(`renders the ${DUE_DILIGENCE_PAGE} page with only DAY error when identity date day is empty`, async () => {
       const dueDiligenceData = { ...DUE_DILIGENCE_REQ_BODY_OBJECT_MOCK_FOR_IDENTITY_DATE };
       dueDiligenceData["identity_date-month"] = "11";


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/ROE-1240

### Change description

This addresses the loss of focus, that is to say clicking the error and it taking us directly to the dd mm yyyy field when an error is thrown against one one of them.

Had to ensure that each of the the date fields are dealt with separately to get the focus back and yet still ensure only one error is displayed in order to do this the checks have to be performed twice first on each field separately then a second time when we check for other errors so that a second error is not thrown when a single empty field is detected


### Work checklist

- [x] Tests added where applicable
- [x] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
