### PR TITLE
Roe 1618 display trusts beneficial owners on 'check your answers' page

### DIFF
--- a/src/model/beneficial.owner.other.model.ts
+++ b/src/model/beneficial.owner.other.model.ts
@@ -20,7 +20,8 @@ export const BeneficialOwnerOtherKeys: string[] = [
   "beneficial_owner_nature_of_control_types",
   "trustees_nature_of_control_types",
   "non_legal_firm_members_nature_of_control_types",
-  "is_on_sanctions_list"
+  "is_on_sanctions_list",
+  "trust_ids"
 ];
 
 export interface BeneficialOwnerOther {

--- a/src/model/beneficial.owner.other.model.ts
+++ b/src/model/beneficial.owner.other.model.ts
@@ -21,7 +21,7 @@ export const BeneficialOwnerOtherKeys: string[] = [
   "trustees_nature_of_control_types",
   "non_legal_firm_members_nature_of_control_types",
   "is_on_sanctions_list",
-  "trust_ids"
+  "trust_ids",
 ];
 
 export interface BeneficialOwnerOther {

--- a/views/includes/check-your-answers/trusts.html
+++ b/views/includes/check-your-answers/trusts.html
@@ -48,7 +48,7 @@
           items: [ CREATE_CHANGE_LINK(
             OE_CONFIGS.BENEFICIAL_OWNER_OTHER_URL + "/" + appData.beneficial_owners_corporate[0].id + OE_CONFIGS.NAME,
             "Trust " + trust.trust_name + " -  Beneficial Owner",
-            "change-trust-created-date-button"
+            "change-beneficial-owner-button"
           ) ]
         }
       }

--- a/views/includes/check-your-answers/trusts.html
+++ b/views/includes/check-your-answers/trusts.html
@@ -44,6 +44,12 @@
         },
         value: {
           html: trustBeneficialOwnersHtml
+        },  actions: {
+          items: [ CREATE_CHANGE_LINK(
+            OE_CONFIGS.BENEFICIAL_OWNER_OTHER_URL + "/" + appData.beneficial_owners_corporate[0].id + OE_CONFIGS.NAME,
+            "Trust " + trust.trust_name + " -  Beneficial Owner",
+            "change-trust-created-date-button"
+          ) ]
         }
       }
     ]

--- a/views/includes/check-your-answers/trusts.html
+++ b/views/includes/check-your-answers/trusts.html
@@ -6,6 +6,8 @@
 {% endset %}
 {% if pageParams.isTrustFeatureEnabled %}
   {% set trustCreationDate = dateMacros.formatDate(trust.creation_date_day, trust.creation_date_month, trust.creation_date_year) %}
+  {% set boLink = (OE_CONFIGS.BENEFICIAL_OWNER_OTHER_URL + "/" + appData.beneficial_owners_corporate[0].id + OE_CONFIGS.NAME) if appData.beneficial_owners_corporate[0].id
+  else (OE_CONFIGS.BENEFICIAL_OWNER_INDIVIDUAL_URL + "/" + appData.beneficial_owners_individual[0].id + OE_CONFIGS.FIRST_NAME) %}
   {{ govukSummaryList({
     rows: [
       {
@@ -46,7 +48,7 @@
           html: trustBeneficialOwnersHtml
         },  actions: {
           items: [ CREATE_CHANGE_LINK(
-            OE_CONFIGS.BENEFICIAL_OWNER_OTHER_URL + "/" + appData.beneficial_owners_corporate[0].id + OE_CONFIGS.NAME if appData.beneficial_owners_corporate[0].id else appData.beneficial_owners_individual[0].id + OE_CONFIGS.FIRSTNAME,
+            boLink ,
             "Trust " + trust.trust_name + " -  Beneficial Owner",
             "change-beneficial-owner-button"
           ) ]

--- a/views/includes/check-your-answers/trusts.html
+++ b/views/includes/check-your-answers/trusts.html
@@ -46,9 +46,10 @@
         },
         value: {
           html: trustBeneficialOwnersHtml
-        },  actions: {
+        },  
+        actions: {
           items: [ CREATE_CHANGE_LINK(
-            boLink ,
+            boLink,
             "Trust " + trust.trust_name + " -  Beneficial Owner",
             "change-beneficial-owner-button"
           ) ]

--- a/views/includes/check-your-answers/trusts.html
+++ b/views/includes/check-your-answers/trusts.html
@@ -46,7 +46,7 @@
           html: trustBeneficialOwnersHtml
         },  actions: {
           items: [ CREATE_CHANGE_LINK(
-            OE_CONFIGS.BENEFICIAL_OWNER_OTHER_URL + "/" + appData.beneficial_owners_corporate[0].id + OE_CONFIGS.NAME,
+            OE_CONFIGS.BENEFICIAL_OWNER_OTHER_URL + "/" + appData.beneficial_owners_corporate[0].id + OE_CONFIGS.NAME if appData.beneficial_owners_corporate[0].id else appData.beneficial_owners_individual[0].id + OE_CONFIGS.FIRSTNAME,
             "Trust " + trust.trust_name + " -  Beneficial Owner",
             "change-beneficial-owner-button"
           ) ]


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/jira/software/c/projects/ROE/boards/494?modal=detail&selectedIssue=ROE-1618&sprint=2686

### Change description

Change Link Added

### Work checklist

- [x] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
Fix: Display BOs on the check your answer page with Action anchor
```
