### PR TITLE
ROE-1105 Ensure single email error

### DIFF
--- a/src/validation/custom.validation.ts
+++ b/src/validation/custom.validation.ts
@@ -1,6 +1,6 @@
 // Custom validation utils - For now checking is not empty
 
-import { VALID_CHARACTERS } from "./regex/regex.validation";
+import { VALID_CHARACTERS, VALID_EMAIL_FORMAT } from "./regex/regex.validation";
 import { DateTime } from "luxon";
 import { ErrorMessages } from "./error.messages";
 import { trustType } from "../model";
@@ -294,4 +294,36 @@ const checkCorporatesAddress = (trust: trustType.Trust, addressMaxLength: number
       }
     }
   }
+};
+
+export const validateEmail = (email: string, maxLength: number) => {
+  const isEmailPresent = checkEmailIsPresent(email);
+  if (isEmailPresent) {
+    const isWithinLengthLimit = checkIsWithinLengthLimit(email, maxLength);
+    if (isWithinLengthLimit) {
+      checkCorrectIsFormat(email);
+    }
+  }
+  return true;
+};
+
+const checkEmailIsPresent = (email: string) => {
+  if (email === undefined || email === "") {
+    throw new Error(ErrorMessages.EMAIL);
+  }
+  return true;
+};
+
+const checkIsWithinLengthLimit = (email: string, maxLength: number) => {
+  if (email.length > maxLength) {
+    throw new Error(ErrorMessages.MAX_EMAIL_LENGTH);
+  }
+  return true;
+};
+
+const checkCorrectIsFormat = (email: string) => {
+  if (!email.match(VALID_EMAIL_FORMAT)) {
+    throw new Error(ErrorMessages.EMAIL_INVALID_FORMAT);
+  }
+  return true;
 };

--- a/src/validation/custom.validation.ts
+++ b/src/validation/custom.validation.ts
@@ -297,13 +297,9 @@ const checkCorporatesAddress = (trust: trustType.Trust, addressMaxLength: number
 };
 
 export const validateEmail = (email: string, maxLength: number) => {
-  const isEmailPresent = checkEmailIsPresent(email);
-  if (isEmailPresent) {
-    const isWithinLengthLimit = checkIsWithinLengthLimit(email, maxLength);
-    if (isWithinLengthLimit) {
-      checkCorrectIsFormat(email);
-    }
-  }
+  checkEmailIsPresent(email.trim());
+  checkIsWithinLengthLimit(email.trim(), maxLength);
+  checkCorrectIsFormat(email.trim());
   return true;
 };
 

--- a/src/validation/custom.validation.ts
+++ b/src/validation/custom.validation.ts
@@ -297,9 +297,10 @@ const checkCorporatesAddress = (trust: trustType.Trust, addressMaxLength: number
 };
 
 export const validateEmail = (email: string, maxLength: number) => {
-  checkEmailIsPresent(email.trim());
-  checkIsWithinLengthLimit(email.trim(), maxLength);
-  checkCorrectIsFormat(email.trim());
+  const emailString = email.trim();
+  checkEmailIsPresent(emailString);
+  checkIsWithinLengthLimit(emailString, maxLength);
+  checkCorrectIsFormat(emailString);
   return true;
 };
 

--- a/src/validation/custom.validation.ts
+++ b/src/validation/custom.validation.ts
@@ -308,19 +308,16 @@ const checkEmailIsPresent = (email: string) => {
   if (email === undefined || email === "") {
     throw new Error(ErrorMessages.EMAIL);
   }
-  return true;
 };
 
 const checkIsWithinLengthLimit = (email: string, maxLength: number) => {
   if (email.length > maxLength) {
     throw new Error(ErrorMessages.MAX_EMAIL_LENGTH);
   }
-  return true;
 };
 
 const checkCorrectIsFormat = (email: string) => {
   if (!email.match(VALID_EMAIL_FORMAT)) {
     throw new Error(ErrorMessages.EMAIL_INVALID_FORMAT);
   }
-  return true;
 };

--- a/src/validation/error.messages.ts
+++ b/src/validation/error.messages.ts
@@ -1,7 +1,7 @@
 export enum ErrorMessages {
   ENTITY_NAME = "Enter the name of the overseas entity",
   MANAGING_OFFICER_CORPORATE_NAME = "Enter the corporate managing officer’s name",
-  EMAIL = "Enter an email address",
+  EMAIL = "Enter an email address.",
   LEGAL_FORM = "Enter the legal form",
   LAW_GOVERNED = "Enter the governing law",
   FULL_NAME = "Enter a full name",

--- a/src/validation/fields/email.validation.ts
+++ b/src/validation/fields/email.validation.ts
@@ -1,17 +1,12 @@
 import { body } from "express-validator";
-import { ErrorMessages } from "../error.messages";
-import { VALID_EMAIL_FORMAT } from "../regex/regex.validation";
+import { validateEmail } from "../custom.validation";
 
 export const email_validations = [
   body("email").trim()
-    .not().isEmpty({ ignore_whitespace: true }).withMessage(ErrorMessages.EMAIL)
-    .isLength({ max: 256 }).withMessage(ErrorMessages.MAX_EMAIL_LENGTH)
-    .matches(VALID_EMAIL_FORMAT).withMessage(ErrorMessages.EMAIL_INVALID_FORMAT)
+    .custom((value, { req }) => validateEmail(req.body["email"], 256))
 ];
 
 export const contact_email_validations = [
   body("contact_email").trim()
-    .not().isEmpty().withMessage(ErrorMessages.EMAIL)
-    .isLength({ max: 250 }).withMessage(ErrorMessages.MAX_EMAIL_LENGTH)
-    .matches(VALID_EMAIL_FORMAT).withMessage(ErrorMessages.EMAIL_INVALID_FORMAT)
+    .custom((value, { req }) => validateEmail(req.body["contact_email"], 250))
 ];

--- a/test/controllers/due.diligence.controller.spec.ts
+++ b/test/controllers/due.diligence.controller.spec.ts
@@ -179,6 +179,8 @@ describe("DUE_DILIGENCE controller", () => {
       expect(resp.text).toContain(ErrorMessages.UK_COUNTRY);
       expect(resp.text).toContain(ErrorMessages.POSTCODE);
       expect(resp.text).toContain(ErrorMessages.EMAIL);
+      expect(resp.text).not.toContain(ErrorMessages.MAX_EMAIL_LENGTH);
+      expect(resp.text).not.toContain(ErrorMessages.EMAIL_INVALID_FORMAT);
       expect(resp.text).toContain(ErrorMessages.SUPERVISORY_NAME);
       expect(resp.text).toContain(ErrorMessages.AGENT_CODE);
       expect(resp.text).toContain(ErrorMessages.PARTNER_NAME);
@@ -209,6 +211,8 @@ describe("DUE_DILIGENCE controller", () => {
       expect(resp.text).toContain(ErrorMessages.MAX_COUNTY_LENGTH);
       expect(resp.text).toContain(ErrorMessages.MAX_POSTCODE_LENGTH);
       expect(resp.text).toContain(ErrorMessages.MAX_EMAIL_LENGTH);
+      expect(resp.text).not.toContain(ErrorMessages.EMAIL);
+      expect(resp.text).not.toContain(ErrorMessages.EMAIL_INVALID_FORMAT);
       expect(resp.text).toContain(ErrorMessages.MAX_AML_NUMBER_LENGTH);
       expect(resp.text).toContain(ErrorMessages.MAX_SUPERVISORY_NAME_LENGTH);
       expect(resp.text).toContain(ErrorMessages.MAX_AGENT_ASSURANCE_CODE_LENGTH);
@@ -389,6 +393,8 @@ describe("DUE_DILIGENCE controller", () => {
         .send(dueDiligenceData);
       expect(resp.status).toEqual(302);
       expect(resp.text).not.toContain(ErrorMessages.EMAIL);
+      expect(resp.text).not.toContain(ErrorMessages.MAX_EMAIL_LENGTH);
+      expect(resp.text).not.toContain(ErrorMessages.EMAIL_INVALID_FORMAT);
       expect(mockSaveAndContinue).toHaveBeenCalled();
     });
 
@@ -407,6 +413,8 @@ describe("DUE_DILIGENCE controller", () => {
         .send(dueDiligenceData);
       expect(resp.status).toEqual(302);
       expect(resp.text).not.toContain(ErrorMessages.EMAIL);
+      expect(resp.text).not.toContain(ErrorMessages.MAX_EMAIL_LENGTH);
+      expect(resp.text).not.toContain(ErrorMessages.EMAIL_INVALID_FORMAT);
       expect(mockSaveAndContinue).toHaveBeenCalled();
     });
 
@@ -425,6 +433,8 @@ describe("DUE_DILIGENCE controller", () => {
         .send(dueDiligenceData);
       expect(resp.status).toEqual(302);
       expect(resp.text).not.toContain(ErrorMessages.EMAIL);
+      expect(resp.text).not.toContain(ErrorMessages.MAX_EMAIL_LENGTH);
+      expect(resp.text).not.toContain(ErrorMessages.EMAIL_INVALID_FORMAT);
       expect(mockSaveAndContinue).toHaveBeenCalled();
     });
 
@@ -548,6 +558,8 @@ describe("DUE_DILIGENCE controller", () => {
       expect(resp.status).toEqual(200);
       expect(resp.text).toContain(ErrorMessages.NAME_INVALID_CHARACTERS);
       expect(resp.text).toContain(ErrorMessages.EMAIL_INVALID_FORMAT);
+      expect(resp.text).not.toContain(ErrorMessages.EMAIL);
+      expect(resp.text).not.toContain(ErrorMessages.MAX_EMAIL_LENGTH);
     });
 
     test(`catch error when renders the ${DUE_DILIGENCE_PAGE} page on POST method`, async () => {

--- a/test/controllers/entity.controller.spec.ts
+++ b/test/controllers/entity.controller.spec.ts
@@ -271,6 +271,8 @@ describe("ENTITY controller", () => {
         .send(entity);
       expect(resp.status).toEqual(302);
       expect(resp.text).not.toContain(ErrorMessages.EMAIL);
+      expect(resp.text).not.toContain(ErrorMessages.MAX_EMAIL_LENGTH);
+      expect(resp.text).not.toContain(ErrorMessages.EMAIL_INVALID_FORMAT);
       expect(mockSaveAndContinue).toHaveBeenCalled();
     });
 
@@ -284,6 +286,8 @@ describe("ENTITY controller", () => {
         .send(entity);
       expect(resp.status).toEqual(302);
       expect(resp.text).not.toContain(ErrorMessages.EMAIL);
+      expect(resp.text).not.toContain(ErrorMessages.MAX_EMAIL_LENGTH);
+      expect(resp.text).not.toContain(ErrorMessages.EMAIL_INVALID_FORMAT);
       expect(mockSaveAndContinue).toHaveBeenCalled();
     });
 
@@ -297,6 +301,8 @@ describe("ENTITY controller", () => {
         .send(entity);
       expect(resp.status).toEqual(302);
       expect(resp.text).not.toContain(ErrorMessages.EMAIL);
+      expect(resp.text).not.toContain(ErrorMessages.MAX_EMAIL_LENGTH);
+      expect(resp.text).not.toContain(ErrorMessages.EMAIL_INVALID_FORMAT);
       expect(mockSaveAndContinue).toHaveBeenCalled();
     });
 
@@ -312,6 +318,8 @@ describe("ENTITY controller", () => {
       expect(resp.text).toContain(ErrorMessages.CITY_OR_TOWN);
       expect(resp.text).toContain(ErrorMessages.SELECT_IF_SERVICE_ADDRESS_SAME_AS_PRINCIPAL_ADDRESS);
       expect(resp.text).toContain(ErrorMessages.EMAIL);
+      expect(resp.text).not.toContain(ErrorMessages.MAX_EMAIL_LENGTH);
+      expect(resp.text).not.toContain(ErrorMessages.EMAIL_INVALID_FORMAT);
       expect(resp.text).toContain(ErrorMessages.LEGAL_FORM);
       expect(resp.text).toContain(ErrorMessages.LAW_GOVERNED);
       expect(resp.text).toContain(ErrorMessages.SELECT_IF_REGISTER_IN_COUNTRY_FORMED_IN);
@@ -388,6 +396,7 @@ describe("ENTITY controller", () => {
       expect(resp.text).toContain(ErrorMessages.MAX_COUNTY_LENGTH);
       expect(resp.text).toContain(ErrorMessages.MAX_POSTCODE_LENGTH);
       expect(resp.text).toContain(ErrorMessages.MAX_EMAIL_LENGTH);
+      expect(resp.text).not.toContain(ErrorMessages.EMAIL);
       expect(resp.text).not.toContain(ErrorMessages.EMAIL_INVALID_FORMAT);
       expect(resp.text).toContain(ErrorMessages.MAX_ENTITY_LEGAL_FORM_LENGTH);
       expect(resp.text).toContain(ErrorMessages.MAX_ENTITY_LAW_GOVERNED_LENGTH);
@@ -423,6 +432,8 @@ describe("ENTITY controller", () => {
       expect(resp.text).toContain(ErrorMessages.COUNTY_STATE_PROVINCE_REGION_INVALID_CHARACTERS);
       expect(resp.text).toContain(ErrorMessages.POSTCODE_ZIPCODE_INVALID_CHARACTERS);
       expect(resp.text).toContain(ErrorMessages.EMAIL_INVALID_FORMAT);
+      expect(resp.text).not.toContain(ErrorMessages.EMAIL);
+      expect(resp.text).not.toContain(ErrorMessages.MAX_EMAIL_LENGTH);
       expect(resp.text).toContain(ErrorMessages.LEGAL_FORM_INVALID_CHARACTERS);
       expect(resp.text).toContain(ErrorMessages.LAW_GOVERNED_INVALID_CHARACTERS);
       expect(resp.text).toContain(ErrorMessages.PUBLIC_REGISTER_NAME_INVALID_CHARACTERS);

--- a/test/controllers/managing.officer.corporate.controller.spec.ts
+++ b/test/controllers/managing.officer.corporate.controller.spec.ts
@@ -196,6 +196,8 @@ describe("MANAGING_OFFICER CORPORATE controller", () => {
         .send(managingOfficerCorporate);
       expect(resp.status).toEqual(302);
       expect(resp.text).not.toContain(ErrorMessages.EMAIL);
+      expect(resp.text).not.toContain(ErrorMessages.MAX_EMAIL_LENGTH);
+      expect(resp.text).not.toContain(ErrorMessages.EMAIL_INVALID_FORMAT);
       expect(mockSaveAndContinue).toHaveBeenCalled();
     });
 
@@ -210,6 +212,8 @@ describe("MANAGING_OFFICER CORPORATE controller", () => {
         .send(managingOfficerCorporate);
       expect(resp.status).toEqual(302);
       expect(resp.text).not.toContain(ErrorMessages.EMAIL);
+      expect(resp.text).not.toContain(ErrorMessages.MAX_EMAIL_LENGTH);
+      expect(resp.text).not.toContain(ErrorMessages.EMAIL_INVALID_FORMAT);
       expect(mockSaveAndContinue).toHaveBeenCalled();
     });
 
@@ -224,6 +228,8 @@ describe("MANAGING_OFFICER CORPORATE controller", () => {
         .send(managingOfficerCorporate);
       expect(resp.status).toEqual(302);
       expect(resp.text).not.toContain(ErrorMessages.EMAIL);
+      expect(resp.text).not.toContain(ErrorMessages.MAX_EMAIL_LENGTH);
+      expect(resp.text).not.toContain(ErrorMessages.EMAIL_INVALID_FORMAT);
       expect(mockSaveAndContinue).toHaveBeenCalled();
     });
 
@@ -260,6 +266,8 @@ describe("MANAGING_OFFICER CORPORATE controller", () => {
       expect(resp.text).toContain(ErrorMessages.ROLE_AND_RESPONSIBILITIES_CORPORATE);
       expect(resp.text).toContain(ErrorMessages.FULL_NAME);
       expect(resp.text).toContain(ErrorMessages.EMAIL);
+      expect(resp.text).not.toContain(ErrorMessages.MAX_EMAIL_LENGTH);
+      expect(resp.text).not.toContain(ErrorMessages.EMAIL_INVALID_FORMAT);
       expect(resp.text).toContain(BENEFICIAL_OWNER_TYPE_URL);
       expect(mockSaveAndContinue).not.toHaveBeenCalled();
     });
@@ -306,6 +314,8 @@ describe("MANAGING_OFFICER CORPORATE controller", () => {
       expect(resp.text).toContain(ErrorMessages.MAX_ROLE_LENGTH);
       expect(resp.text).toContain(ErrorMessages.MAX_FULL_NAME_LENGTH);
       expect(resp.text).toContain(ErrorMessages.MAX_EMAIL_LENGTH);
+      expect(resp.text).not.toContain(ErrorMessages.EMAIL);
+      expect(resp.text).not.toContain(ErrorMessages.EMAIL_INVALID_FORMAT);
       expect(resp.text).not.toContain(ErrorMessages.MANAGING_OFFICER_CORPORATE_NAME);
       expect(resp.text).not.toContain(ErrorMessages.PROPERTY_NAME_OR_NUMBER);
       expect(resp.text).not.toContain(ErrorMessages.ADDRESS_LINE1);
@@ -335,6 +345,8 @@ describe("MANAGING_OFFICER CORPORATE controller", () => {
       expect(resp.text).toContain(ErrorMessages.COUNTY_STATE_PROVINCE_REGION_INVALID_CHARACTERS);
       expect(resp.text).toContain(ErrorMessages.POSTCODE_ZIPCODE_INVALID_CHARACTERS);
       expect(resp.text).toContain(ErrorMessages.EMAIL_INVALID_FORMAT);
+      expect(resp.text).not.toContain(ErrorMessages.MAX_EMAIL_LENGTH);
+      expect(resp.text).not.toContain(ErrorMessages.EMAIL);
       expect(resp.text).toContain(ErrorMessages.LEGAL_FORM_INVALID_CHARACTERS);
       expect(resp.text).toContain(ErrorMessages.LAW_GOVERNED_INVALID_CHARACTERS);
       expect(resp.text).toContain(ErrorMessages.PUBLIC_REGISTER_NAME_INVALID_CHARACTERS);

--- a/test/controllers/overseas.entity.due.diligence.controller.spec.ts
+++ b/test/controllers/overseas.entity.due.diligence.controller.spec.ts
@@ -151,6 +151,9 @@ describe("OVERSEAS_ENTITY_DUE_DILIGENCE controller", () => {
       expect(resp.status).toEqual(302);
       expect(resp.text).toContain(`${FOUND_REDIRECT_TO} ${ENTITY_URL}`);
       expect(mockSaveAndContinue).toHaveBeenCalledTimes(1);
+      expect(resp.text).not.toContain(ErrorMessages.EMAIL);
+      expect(resp.text).not.toContain(ErrorMessages.MAX_EMAIL_LENGTH);
+      expect(resp.text).not.toContain(ErrorMessages.EMAIL_INVALID_FORMAT);
 
       // Additionally check that email address is trimmed before it's saved in the session
       const data: ApplicationDataType = mockPrepareData.mock.calls[0][0];
@@ -172,6 +175,8 @@ describe("OVERSEAS_ENTITY_DUE_DILIGENCE controller", () => {
         .send(dueDiligenceMock);
       expect(resp.status).toEqual(302);
       expect(resp.text).not.toContain(ErrorMessages.EMAIL);
+      expect(resp.text).not.toContain(ErrorMessages.MAX_EMAIL_LENGTH);
+      expect(resp.text).not.toContain(ErrorMessages.EMAIL_INVALID_FORMAT);
       expect(mockSaveAndContinue).toHaveBeenCalled();
     });
 
@@ -190,6 +195,8 @@ describe("OVERSEAS_ENTITY_DUE_DILIGENCE controller", () => {
         .send(dueDiligenceMock);
       expect(resp.status).toEqual(302);
       expect(resp.text).not.toContain(ErrorMessages.EMAIL);
+      expect(resp.text).not.toContain(ErrorMessages.MAX_EMAIL_LENGTH);
+      expect(resp.text).not.toContain(ErrorMessages.EMAIL_INVALID_FORMAT);
       expect(mockSaveAndContinue).toHaveBeenCalled();
     });
 
@@ -208,6 +215,8 @@ describe("OVERSEAS_ENTITY_DUE_DILIGENCE controller", () => {
         .send(dueDiligenceMock);
       expect(resp.status).toEqual(302);
       expect(resp.text).not.toContain(ErrorMessages.EMAIL);
+      expect(resp.text).not.toContain(ErrorMessages.MAX_EMAIL_LENGTH);
+      expect(resp.text).not.toContain(ErrorMessages.EMAIL_INVALID_FORMAT);
       expect(mockSaveAndContinue).toHaveBeenCalled();
     });
 
@@ -242,6 +251,8 @@ describe("OVERSEAS_ENTITY_DUE_DILIGENCE controller", () => {
       expect(resp.text).toContain(ErrorMessages.UK_COUNTRY);
       expect(resp.text).toContain(ErrorMessages.POSTCODE);
       expect(resp.text).toContain(ErrorMessages.EMAIL);
+      expect(resp.text).not.toContain(ErrorMessages.MAX_EMAIL_LENGTH);
+      expect(resp.text).not.toContain(ErrorMessages.EMAIL_INVALID_FORMAT);
       expect(resp.text).not.toContain(ErrorMessages.SUPERVISORY_NAME);
       expect(resp.text).not.toContain(ErrorMessages.PARTNER_NAME);
       expect(resp.text).not.toContain(ErrorMessages.ENTER_DATE);
@@ -271,6 +282,8 @@ describe("OVERSEAS_ENTITY_DUE_DILIGENCE controller", () => {
       expect(resp.text).toContain(ErrorMessages.MAX_COUNTY_LENGTH);
       expect(resp.text).toContain(ErrorMessages.MAX_POSTCODE_LENGTH);
       expect(resp.text).toContain(ErrorMessages.MAX_EMAIL_LENGTH);
+      expect(resp.text).not.toContain(ErrorMessages.EMAIL);
+      expect(resp.text).not.toContain(ErrorMessages.EMAIL_INVALID_FORMAT);
       expect(resp.text).toContain(ErrorMessages.MAX_AML_NUMBER_LENGTH);
       expect(resp.text).toContain(ErrorMessages.MAX_SUPERVISORY_NAME_LENGTH);
       expect(resp.text).toContain(ErrorMessages.MAX_PARTNER_NAME_LENGTH);
@@ -564,6 +577,8 @@ describe("OVERSEAS_ENTITY_DUE_DILIGENCE controller", () => {
       expect(resp.status).toEqual(200);
       expect(resp.text).toContain(ErrorMessages.NAME_INVALID_CHARACTERS);
       expect(resp.text).toContain(ErrorMessages.EMAIL_INVALID_FORMAT);
+      expect(resp.text).not.toContain(ErrorMessages.EMAIL);
+      expect(resp.text).not.toContain(ErrorMessages.MAX_EMAIL_LENGTH);
     });
 
   });

--- a/test/controllers/presenter.controller.spec.ts
+++ b/test/controllers/presenter.controller.spec.ts
@@ -114,6 +114,8 @@ describe("PRESENTER controller", () => {
       expect(resp.text).toContain(PRESENTER_PAGE_TITLE);
       expect(resp.text).toContain(ErrorMessages.FULL_NAME);
       expect(resp.text).toContain(ErrorMessages.EMAIL);
+      expect(resp.text).not.toContain(ErrorMessages.MAX_EMAIL_LENGTH);
+      expect(resp.text).not.toContain(ErrorMessages.EMAIL_INVALID_FORMAT);
       expect(resp.text).toContain(LANDING_URL);
       expect(mockSaveAndContinue).not.toHaveBeenCalled();
     });
@@ -132,8 +134,9 @@ describe("PRESENTER controller", () => {
       expect(resp.status).toEqual(200);
       expect(resp.text).toContain(PRESENTER_PAGE_TITLE);
       expect(resp.text).toContain(ErrorMessages.MAX_FULL_NAME_LENGTH);
-      expect(resp.text).not.toContain(ErrorMessages.EMAIL_INVALID_FORMAT);
       expect(resp.text).toContain(ErrorMessages.MAX_EMAIL_LENGTH);
+      expect(resp.text).not.toContain(ErrorMessages.EMAIL_INVALID_FORMAT);
+      expect(resp.text).not.toContain(ErrorMessages.EMAIL);
       expect(resp.text).not.toContain(ErrorMessages.FULL_NAME);
     });
 
@@ -146,6 +149,8 @@ describe("PRESENTER controller", () => {
       expect(resp.text).toContain(PRESENTER_PAGE_TITLE);
       expect(resp.text).toContain(ErrorMessages.FULL_NAME_INVALID_CHARACTERS);
       expect(resp.text).toContain(ErrorMessages.EMAIL_INVALID_FORMAT);
+      expect(resp.text).not.toContain(ErrorMessages.EMAIL);
+      expect(resp.text).not.toContain(ErrorMessages.MAX_EMAIL_LENGTH);
     });
 
     test("renders the next page and no errors are reported if email has leading and trailing spaces", async () => {
@@ -178,6 +183,8 @@ describe("PRESENTER controller", () => {
         .send(presenter);
       expect(resp.status).toEqual(302);
       expect(resp.text).not.toContain(ErrorMessages.EMAIL);
+      expect(resp.text).not.toContain(ErrorMessages.MAX_EMAIL_LENGTH);
+      expect(resp.text).not.toContain(ErrorMessages.EMAIL_INVALID_FORMAT);
     });
 
     test("Test email is valid with long email name and address", async () => {
@@ -189,6 +196,8 @@ describe("PRESENTER controller", () => {
         .send(presenter);
       expect(resp.status).toEqual(302);
       expect(resp.text).not.toContain(ErrorMessages.EMAIL);
+      expect(resp.text).not.toContain(ErrorMessages.MAX_EMAIL_LENGTH);
+      expect(resp.text).not.toContain(ErrorMessages.EMAIL_INVALID_FORMAT);
     });
 
     test("Test email is valid with very long email name and address", async () => {
@@ -200,6 +209,8 @@ describe("PRESENTER controller", () => {
         .send(presenter);
       expect(resp.status).toEqual(302);
       expect(resp.text).not.toContain(ErrorMessages.EMAIL);
+      expect(resp.text).not.toContain(ErrorMessages.MAX_EMAIL_LENGTH);
+      expect(resp.text).not.toContain(ErrorMessages.EMAIL_INVALID_FORMAT);
     });
   });
 });


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/ROE-1105


### Change description

As with the date fields we want to display only one relevant mail error message at a time

### Work checklist

- [x] Tests added where applicable
- [x] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
