### PR TITLE
Roe 1105 remove full stop from email error

### DIFF
--- a/src/validation/error.messages.ts
+++ b/src/validation/error.messages.ts
@@ -1,7 +1,7 @@
 export enum ErrorMessages {
   ENTITY_NAME = "Enter the name of the overseas entity",
   MANAGING_OFFICER_CORPORATE_NAME = "Enter the corporate managing officer’s name",
-  EMAIL = "Enter an email address.",
+  EMAIL = "Enter an email address",
   LEGAL_FORM = "Enter the legal form",
   LAW_GOVERNED = "Enter the governing law",
   FULL_NAME = "Enter a full name",

--- a/test/controllers/due.diligence.controller.spec.ts
+++ b/test/controllers/due.diligence.controller.spec.ts
@@ -558,7 +558,6 @@ describe("DUE_DILIGENCE controller", () => {
       expect(resp.status).toEqual(200);
       expect(resp.text).toContain(ErrorMessages.NAME_INVALID_CHARACTERS);
       expect(resp.text).toContain(ErrorMessages.EMAIL_INVALID_FORMAT);
-      expect(resp.text).not.toContainEqual(ErrorMessages.EMAIL);
       expect(resp.text).not.toContain(ErrorMessages.MAX_EMAIL_LENGTH);
     });
 

--- a/test/controllers/due.diligence.controller.spec.ts
+++ b/test/controllers/due.diligence.controller.spec.ts
@@ -558,7 +558,7 @@ describe("DUE_DILIGENCE controller", () => {
       expect(resp.status).toEqual(200);
       expect(resp.text).toContain(ErrorMessages.NAME_INVALID_CHARACTERS);
       expect(resp.text).toContain(ErrorMessages.EMAIL_INVALID_FORMAT);
-      expect(resp.text).not.toContain(ErrorMessages.EMAIL);
+      expect(resp.text).not.toContainEqual(ErrorMessages.EMAIL);
       expect(resp.text).not.toContain(ErrorMessages.MAX_EMAIL_LENGTH);
     });
 

--- a/test/controllers/entity.controller.spec.ts
+++ b/test/controllers/entity.controller.spec.ts
@@ -432,7 +432,6 @@ describe("ENTITY controller", () => {
       expect(resp.text).toContain(ErrorMessages.COUNTY_STATE_PROVINCE_REGION_INVALID_CHARACTERS);
       expect(resp.text).toContain(ErrorMessages.POSTCODE_ZIPCODE_INVALID_CHARACTERS);
       expect(resp.text).toContain(ErrorMessages.EMAIL_INVALID_FORMAT);
-      expect(resp.text).not.toContainEqual(ErrorMessages.EMAIL);
       expect(resp.text).not.toContain(ErrorMessages.MAX_EMAIL_LENGTH);
       expect(resp.text).toContain(ErrorMessages.LEGAL_FORM_INVALID_CHARACTERS);
       expect(resp.text).toContain(ErrorMessages.LAW_GOVERNED_INVALID_CHARACTERS);

--- a/test/controllers/entity.controller.spec.ts
+++ b/test/controllers/entity.controller.spec.ts
@@ -432,7 +432,7 @@ describe("ENTITY controller", () => {
       expect(resp.text).toContain(ErrorMessages.COUNTY_STATE_PROVINCE_REGION_INVALID_CHARACTERS);
       expect(resp.text).toContain(ErrorMessages.POSTCODE_ZIPCODE_INVALID_CHARACTERS);
       expect(resp.text).toContain(ErrorMessages.EMAIL_INVALID_FORMAT);
-      expect(resp.text).not.toContain(ErrorMessages.EMAIL);
+      expect(resp.text).not.toContainEqual(ErrorMessages.EMAIL);
       expect(resp.text).not.toContain(ErrorMessages.MAX_EMAIL_LENGTH);
       expect(resp.text).toContain(ErrorMessages.LEGAL_FORM_INVALID_CHARACTERS);
       expect(resp.text).toContain(ErrorMessages.LAW_GOVERNED_INVALID_CHARACTERS);

--- a/test/controllers/managing.officer.corporate.controller.spec.ts
+++ b/test/controllers/managing.officer.corporate.controller.spec.ts
@@ -346,7 +346,7 @@ describe("MANAGING_OFFICER CORPORATE controller", () => {
       expect(resp.text).toContain(ErrorMessages.POSTCODE_ZIPCODE_INVALID_CHARACTERS);
       expect(resp.text).toContain(ErrorMessages.EMAIL_INVALID_FORMAT);
       expect(resp.text).not.toContain(ErrorMessages.MAX_EMAIL_LENGTH);
-      expect(resp.text).not.toContain(ErrorMessages.EMAIL);
+      expect(resp.text).not.toContainEqual(ErrorMessages.EMAIL);
       expect(resp.text).toContain(ErrorMessages.LEGAL_FORM_INVALID_CHARACTERS);
       expect(resp.text).toContain(ErrorMessages.LAW_GOVERNED_INVALID_CHARACTERS);
       expect(resp.text).toContain(ErrorMessages.PUBLIC_REGISTER_NAME_INVALID_CHARACTERS);

--- a/test/controllers/managing.officer.corporate.controller.spec.ts
+++ b/test/controllers/managing.officer.corporate.controller.spec.ts
@@ -346,7 +346,6 @@ describe("MANAGING_OFFICER CORPORATE controller", () => {
       expect(resp.text).toContain(ErrorMessages.POSTCODE_ZIPCODE_INVALID_CHARACTERS);
       expect(resp.text).toContain(ErrorMessages.EMAIL_INVALID_FORMAT);
       expect(resp.text).not.toContain(ErrorMessages.MAX_EMAIL_LENGTH);
-      expect(resp.text).not.toContainEqual(ErrorMessages.EMAIL);
       expect(resp.text).toContain(ErrorMessages.LEGAL_FORM_INVALID_CHARACTERS);
       expect(resp.text).toContain(ErrorMessages.LAW_GOVERNED_INVALID_CHARACTERS);
       expect(resp.text).toContain(ErrorMessages.PUBLIC_REGISTER_NAME_INVALID_CHARACTERS);

--- a/test/controllers/overseas.entity.due.diligence.controller.spec.ts
+++ b/test/controllers/overseas.entity.due.diligence.controller.spec.ts
@@ -577,7 +577,7 @@ describe("OVERSEAS_ENTITY_DUE_DILIGENCE controller", () => {
       expect(resp.status).toEqual(200);
       expect(resp.text).toContain(ErrorMessages.NAME_INVALID_CHARACTERS);
       expect(resp.text).toContain(ErrorMessages.EMAIL_INVALID_FORMAT);
-      expect(resp.text).not.toContain(ErrorMessages.EMAIL);
+      expect(resp.text).not.toContainEqual(ErrorMessages.EMAIL);
       expect(resp.text).not.toContain(ErrorMessages.MAX_EMAIL_LENGTH);
     });
 

--- a/test/controllers/overseas.entity.due.diligence.controller.spec.ts
+++ b/test/controllers/overseas.entity.due.diligence.controller.spec.ts
@@ -577,7 +577,6 @@ describe("OVERSEAS_ENTITY_DUE_DILIGENCE controller", () => {
       expect(resp.status).toEqual(200);
       expect(resp.text).toContain(ErrorMessages.NAME_INVALID_CHARACTERS);
       expect(resp.text).toContain(ErrorMessages.EMAIL_INVALID_FORMAT);
-      expect(resp.text).not.toContainEqual(ErrorMessages.EMAIL);
       expect(resp.text).not.toContain(ErrorMessages.MAX_EMAIL_LENGTH);
     });
 

--- a/test/controllers/presenter.controller.spec.ts
+++ b/test/controllers/presenter.controller.spec.ts
@@ -136,7 +136,7 @@ describe("PRESENTER controller", () => {
       expect(resp.text).toContain(ErrorMessages.MAX_FULL_NAME_LENGTH);
       expect(resp.text).toContain(ErrorMessages.MAX_EMAIL_LENGTH);
       expect(resp.text).not.toContain(ErrorMessages.EMAIL_INVALID_FORMAT);
-      expect(resp.text).not.toContain(ErrorMessages.EMAIL);
+      expect(resp.text).not.toContainEqual(ErrorMessages.EMAIL);
       expect(resp.text).not.toContain(ErrorMessages.FULL_NAME);
     });
 
@@ -182,7 +182,7 @@ describe("PRESENTER controller", () => {
         .post(PRESENTER_URL)
         .send(presenter);
       expect(resp.status).toEqual(302);
-      expect(resp.text).not.toContain(ErrorMessages.EMAIL);
+      expect(resp.text).not.toContainEqual(ErrorMessages.EMAIL);
       expect(resp.text).not.toContain(ErrorMessages.MAX_EMAIL_LENGTH);
       expect(resp.text).not.toContain(ErrorMessages.EMAIL_INVALID_FORMAT);
     });
@@ -195,7 +195,6 @@ describe("PRESENTER controller", () => {
         .post(PRESENTER_URL)
         .send(presenter);
       expect(resp.status).toEqual(302);
-      expect(resp.text).not.toContain(ErrorMessages.EMAIL);
       expect(resp.text).not.toContain(ErrorMessages.MAX_EMAIL_LENGTH);
       expect(resp.text).not.toContain(ErrorMessages.EMAIL_INVALID_FORMAT);
     });

--- a/test/controllers/presenter.controller.spec.ts
+++ b/test/controllers/presenter.controller.spec.ts
@@ -136,7 +136,6 @@ describe("PRESENTER controller", () => {
       expect(resp.text).toContain(ErrorMessages.MAX_FULL_NAME_LENGTH);
       expect(resp.text).toContain(ErrorMessages.MAX_EMAIL_LENGTH);
       expect(resp.text).not.toContain(ErrorMessages.EMAIL_INVALID_FORMAT);
-      expect(resp.text).not.toContainEqual(ErrorMessages.EMAIL);
       expect(resp.text).not.toContain(ErrorMessages.FULL_NAME);
     });
 
@@ -149,7 +148,6 @@ describe("PRESENTER controller", () => {
       expect(resp.text).toContain(PRESENTER_PAGE_TITLE);
       expect(resp.text).toContain(ErrorMessages.FULL_NAME_INVALID_CHARACTERS);
       expect(resp.text).toContain(ErrorMessages.EMAIL_INVALID_FORMAT);
-      expect(resp.text).not.toContainEqual(ErrorMessages.EMAIL);
       expect(resp.text).not.toContain(ErrorMessages.MAX_EMAIL_LENGTH);
     });
 
@@ -182,7 +180,6 @@ describe("PRESENTER controller", () => {
         .post(PRESENTER_URL)
         .send(presenter);
       expect(resp.status).toEqual(302);
-      expect(resp.text).not.toContainEqual(ErrorMessages.EMAIL);
       expect(resp.text).not.toContain(ErrorMessages.MAX_EMAIL_LENGTH);
       expect(resp.text).not.toContain(ErrorMessages.EMAIL_INVALID_FORMAT);
     });

--- a/test/controllers/presenter.controller.spec.ts
+++ b/test/controllers/presenter.controller.spec.ts
@@ -149,7 +149,7 @@ describe("PRESENTER controller", () => {
       expect(resp.text).toContain(PRESENTER_PAGE_TITLE);
       expect(resp.text).toContain(ErrorMessages.FULL_NAME_INVALID_CHARACTERS);
       expect(resp.text).toContain(ErrorMessages.EMAIL_INVALID_FORMAT);
-      expect(resp.text).not.toContain(ErrorMessages.EMAIL);
+      expect(resp.text).not.toContainEqual(ErrorMessages.EMAIL);
       expect(resp.text).not.toContain(ErrorMessages.MAX_EMAIL_LENGTH);
     });
 


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/ROE-1105


### Change description

Removed full stop and confusing test lines.

### Work checklist

- [x] Tests added where applicable
- [x] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
