### PR TITLE
ROE-1944 - TL - Removing 'Overseas Entity' title caption prefix text from entity page

### DIFF
--- a/test/controllers/entity.controller.spec.ts
+++ b/test/controllers/entity.controller.spec.ts
@@ -91,7 +91,7 @@ describe("ENTITY controller", () => {
       expect(resp.text).toContain(DUE_DILIGENCE_URL);
       expect(resp.text).toContain(SAVE_AND_CONTINUE_BUTTON_TEXT);
       expect(resp.text).not.toContain(PAGE_TITLE_ERROR);
-      expect(resp.text).not.toContain(`Overseas Entity ${OVERSEAS_NAME_MOCK}`);
+      expect(resp.text).not.toContain(OVERSEAS_NAME_MOCK);
     });
 
     test(`renders the ${ENTITY_PAGE} page with ${OVERSEAS_ENTITY_DUE_DILIGENCE_URL} back link`, async () => {
@@ -105,7 +105,7 @@ describe("ENTITY controller", () => {
       expect(resp.text).toContain(SHOW_OTHER_INFORMATION_ON_PUBLIC_REGISTER);
       expect(resp.text).toContain(OVERSEAS_ENTITY_DUE_DILIGENCE_URL);
       expect(resp.text).toContain(SAVE_AND_CONTINUE_BUTTON_TEXT);
-      expect(resp.text).not.toContain(`Overseas Entity ${OVERSEAS_NAME_MOCK}`);
+      expect(resp.text).not.toContain(OVERSEAS_NAME_MOCK);
     });
 
     test(`renders the ${ENTITY_PAGE} page with public register jurisdiction field`, async () => {
@@ -117,7 +117,7 @@ describe("ENTITY controller", () => {
       expect(resp.text).toContain(JURISDICTION_FIELD_LABEL);
       expect(resp.text).toContain(ENTITY_PUBLIC_REGISTER_HINT_TEXT);
       expect(resp.text).toContain(SAVE_AND_CONTINUE_BUTTON_TEXT);
-      expect(resp.text).not.toContain(`Overseas Entity ${OVERSEAS_NAME_MOCK}`);
+      expect(resp.text).not.toContain(OVERSEAS_NAME_MOCK);
     });
 
     test("renders the entity page on GET method with session data populated", async () => {
@@ -129,7 +129,8 @@ describe("ENTITY controller", () => {
       expect(resp.text).toContain(ENTITY_OBJECT_MOCK.legal_form);
       expect(resp.text).toContain(ENTITY_OBJECT_MOCK.email);
       expect(resp.text).toContain(SAVE_AND_CONTINUE_BUTTON_TEXT);
-      expect(resp.text).toContain(`Overseas Entity ${OVERSEAS_NAME_MOCK}`);
+      expect(resp.text).toContain(OVERSEAS_NAME_MOCK);
+      expect(resp.text).not.toContain(`Overseas Entity ${OVERSEAS_NAME_MOCK}`);
     });
 
     test("renders the entity page on GET method with Taiwan as country field", async () => {
@@ -148,7 +149,7 @@ describe("ENTITY controller", () => {
       expect(resp.text).toContain(INCORPORATION_COUNTRY_OPTION_SELECTED);
       expect(resp.text).toContain(UNITED_KINGDOM_COUNTRY_OPTION_SELECTED);
       expect(resp.text).toContain(SAVE_AND_CONTINUE_BUTTON_TEXT);
-      expect(resp.text).toContain(`Overseas Entity ${OVERSEAS_NAME_MOCK}`);
+      expect(resp.text).toContain(OVERSEAS_NAME_MOCK);
     });
 
     test("renders the entity page on GET method without United Kingdom on incorporation country", async () => {
@@ -165,7 +166,7 @@ describe("ENTITY controller", () => {
       expect(resp.text).toContain(ENTITY_PAGE_TITLE);
       expect(resp.text).not.toContain(UNITED_KINGDOM_COUNTRY_OPTION_SELECTED);
       expect(resp.text).toContain(SAVE_AND_CONTINUE_BUTTON_TEXT);
-      expect(resp.text).toContain(`Overseas Entity ${OVERSEAS_NAME_MOCK}`);
+      expect(resp.text).toContain(OVERSEAS_NAME_MOCK);
     });
 
     test("renders the entity page on GET method with the three public register fields", async () => {
@@ -184,7 +185,7 @@ describe("ENTITY controller", () => {
       expect(resp.text).toContain(PUBLIC_REGISTER_JURISDICTION_LABEL);
       expect(resp.text).toContain(REGISTRATION_NUMBER_LABEL);
       expect(resp.text).toContain(SAVE_AND_CONTINUE_BUTTON_TEXT);
-      expect(resp.text).toContain(`Overseas Entity ${OVERSEAS_NAME_MOCK}`);
+      expect(resp.text).toContain(OVERSEAS_NAME_MOCK);
     });
 
     test("catch error when renders the entity page on GET method", async () => {
@@ -360,7 +361,7 @@ describe("ENTITY controller", () => {
       expect(resp.status).toEqual(200);
       expect(resp.text).toContain(PAGE_TITLE_ERROR);
       expect(mockSaveAndContinue).not.toHaveBeenCalled();
-      expect(resp.text).toContain(`Overseas Entity ${OVERSEAS_NAME_MOCK}`);
+      expect(resp.text).toContain(OVERSEAS_NAME_MOCK);
     });
 
     test("renders the current page with public register error messages", async () => {
@@ -377,7 +378,7 @@ describe("ENTITY controller", () => {
       expect(resp.text).toContain(ErrorMessages.PUBLIC_REGISTER_JURISDICTION);
       expect(resp.text).toContain(ErrorMessages.PUBLIC_REGISTER_NUMBER);
       expect(resp.text).toContain(OVERSEAS_ENTITY_DUE_DILIGENCE_URL);
-      expect(resp.text).toContain(`Overseas Entity ${OVERSEAS_NAME_MOCK}`);
+      expect(resp.text).toContain(OVERSEAS_NAME_MOCK);
       expect(mockSaveAndContinue).not.toHaveBeenCalled();
     });
 
@@ -413,7 +414,7 @@ describe("ENTITY controller", () => {
       expect(resp.text).not.toContain(ErrorMessages.PUBLIC_REGISTER_NAME);
       expect(resp.text).not.toContain(ErrorMessages.PUBLIC_REGISTER_JURISDICTION);
       expect(resp.text).not.toContain(ErrorMessages.PUBLIC_REGISTER_NUMBER);
-      expect(resp.text).toContain(`Overseas Entity ${OVERSEAS_NAME_MOCK}`);
+      expect(resp.text).toContain(OVERSEAS_NAME_MOCK);
       expect(mockSaveAndContinue).not.toHaveBeenCalled();
     });
 
@@ -438,7 +439,7 @@ describe("ENTITY controller", () => {
       expect(resp.text).toContain(ErrorMessages.PUBLIC_REGISTER_NAME_INVALID_CHARACTERS);
       expect(resp.text).toContain(ErrorMessages.PUBLIC_REGISTER_JURISDICTION_INVALID_CHARACTERS);
       expect(resp.text).toContain(ErrorMessages.PUBLIC_REGISTER_NUMBER_INVALID_CHARACTERS);
-      expect(resp.text).toContain(`Overseas Entity ${OVERSEAS_NAME_MOCK}`);
+      expect(resp.text).toContain(OVERSEAS_NAME_MOCK);
       expect(mockSaveAndContinue).not.toHaveBeenCalled();
     });
 

--- a/views/entity.html
+++ b/views/entity.html
@@ -16,7 +16,7 @@
 
     {% include "includes/list/errors.html" %}
 
-    <span class="govuk-caption-xl govuk-!-padding-bottom-1">Overseas Entity {{ entityName }}</span>
+    <span class="govuk-caption-xl govuk-!-padding-bottom-1">{{ entityName }}</span>
     <h1 class="govuk-heading-xl">{{ title }}</h1>
 
     {{ govukDetails({


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/ROE-1944


### Change description
Work to remove the 'Overseas Entity' prefix from the heading caption on the entity page


### Work checklist

- [x] Tests added where applicable
- [x] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
