### PR TITLE
Feature/roe 1738 display trust le on trust involved

### DIFF
--- a/src/controllers/trust.involved.controller.ts
+++ b/src/controllers/trust.involved.controller.ts
@@ -17,6 +17,11 @@ const TRUST_INVOLVED_TEXTS = {
     [BeneficialOwnerTypeChoice.individual]: 'Individual beneficial owner',
     [BeneficialOwnerTypeChoice.otherLegal]: 'Other legal beneficial owner',
   },
+  trusteeTypeTitle: {
+    [TrusteeType.HISTORICAL]: 'Former beneficial owner',
+    [TrusteeType.INDIVIDUAL]: 'Indiviudal',
+    [TrusteeType.LEGAL_ENTITY]: 'Legal entity',
+  },
 };
 
 type TrustInvolvedPageProperties = {
@@ -27,6 +32,7 @@ type TrustInvolvedPageProperties = {
   },
   pageData: {
     beneficialOwnerTypeTitle: Record<string, string>;
+    trusteeTypeTitle: Record<string, string>;
     trusteeType: typeof TrusteeType;
     checkYourAnswersUrl: string;
     beneficialOwnerUrlDetach: string;
@@ -55,6 +61,7 @@ const getPageProperties = (
       trustData: mapCommonTrustDataToPage(appData, trustId),
       ...mapTrustWhoIsInvolvedToPage(appData, trustId),
       beneficialOwnerTypeTitle: TRUST_INVOLVED_TEXTS.boTypeTitle,
+      trusteeTypeTitle: TRUST_INVOLVED_TEXTS.trusteeTypeTitle,
       trusteeType: TrusteeType,
       checkYourAnswersUrl: config.CHECK_YOUR_ANSWERS_URL,
       beneficialOwnerUrlDetach: `${config.TRUST_ENTRY_URL}/${trustId}${config.TRUST_BENEFICIAL_OWNER_DETACH_URL}`,

--- a/src/model/trust.page.model.ts
+++ b/src/model/trust.page.model.ts
@@ -1,4 +1,5 @@
 import { BeneficialOwnerTypeChoice } from './beneficial.owner.type.model';
+import { TrusteeType } from './trustee.type.model';
 import { RoleWithinTrustType } from './role.within.trust.type.model';
 
 type TrustDetailsForm = {
@@ -14,11 +15,12 @@ type TrustDetailsForm = {
 type TrustBeneficialOwnerListItem = {
   id: string;
   name: string;
-  type: BeneficialOwnerTypeChoice,
+  type: BeneficialOwnerTypeChoice;
 };
 
 type TrustWhoIsInvolved = {
   boInTrust: TrustBeneficialOwnerListItem[];
+  trustees: TrusteeItem[];
 };
 
 type TrustWhoIsInvolvedForm = {
@@ -112,6 +114,12 @@ public_register_jurisdiction?: string
 registration_number?: string
 };
 
+type TrusteeItem = {
+    id?: string;
+    name: string;
+    trusteeItemType: TrusteeType;
+};
+
 export {
   TrustDetailsForm,
   TrustBeneficialOwnerListItem,
@@ -120,5 +128,6 @@ export {
   TrustHistoricalBeneficialOwnerForm,
   CommonTrustData,
   TrustLegalEntityForm,
-  IndividualTrusteesFormCommon
+  IndividualTrusteesFormCommon,
+  TrusteeItem,
 };

--- a/src/utils/trust/legal.entity.beneficial.owner.mapper.ts
+++ b/src/utils/trust/legal.entity.beneficial.owner.mapper.ts
@@ -1,6 +1,7 @@
 import { v4 as uuidv4 } from "uuid";
 import * as Trust from "../../model/trust.model";
 import * as Page from "../../model/trust.page.model";
+import { TrusteeType } from '../../model/trustee.type.model';
 
 const mapLegalEntityToSession = (
   formData: Page.TrustLegalEntityForm
@@ -37,9 +38,25 @@ const mapLegalEntityToSession = (
     identification_registration_number: formData.registration_number,
   };
 };
+
+const mapLegalEntityItemToPage = (
+  legalEntity: Trust.TrustCorporate,
+): Page.TrusteeItem => {
+  return {
+    id: legalEntity.id,
+    name: legalEntity.name,
+    trusteeItemType: TrusteeType.LEGAL_ENTITY,
+  };
+};
+
 //  other
 const generateId = (): string => {
   return uuidv4();
 };
 
-export { mapLegalEntityToSession, generateId };
+
+export {
+  mapLegalEntityToSession,
+  mapLegalEntityItemToPage,
+  generateId,
+};

--- a/src/utils/trust/who.is.involved.mapper.ts
+++ b/src/utils/trust/who.is.involved.mapper.ts
@@ -1,6 +1,7 @@
 import { TrustWhoIsInvolved } from '../../model/trust.page.model';
-import { getTrustBoIndividuals, getTrustBoOthers } from '../../utils/trusts';
+import { getTrustBoIndividuals, getTrustBoOthers, getLegalEntityBosInTrust, getTrustByIdFromApp } from '../../utils/trusts';
 import * as mapperBeneficialOwner from '../../utils/trust/beneficial.owner.mapper';
+import * as trustLegalEntityMapper from '../../utils/trust/legal.entity.beneficial.owner.mapper';
 import { ApplicationData } from '.../../model';
 
 const mapTrustWhoIsInvolvedToPage = (
@@ -14,8 +15,16 @@ const mapTrustWhoIsInvolvedToPage = (
       .map(mapperBeneficialOwner.mapBoOtherToPage),
   ];
 
+  const trust = getTrustByIdFromApp(appData, trustId);
+
+  const trustees = [
+    ...getLegalEntityBosInTrust(trust)
+      .map(trustLegalEntityMapper.mapLegalEntityItemToPage)
+  ];
+
   return {
     boInTrust,
+    trustees,
   };
 };
 

--- a/src/utils/trusts.ts
+++ b/src/utils/trusts.ts
@@ -158,6 +158,13 @@ const saveHistoricalBoInTrust = (
   return trust;
 };
 
+const getLegalEntityBosInTrust = (
+  trust: Trust,
+): TrustCorporate[] => {
+
+  return trust.CORPORATES ?? [];
+};
+
 const saveLegalEntityBoInTrust = (
   trust: Trust,
   legalEntityData: TrustCorporate,
@@ -195,6 +202,7 @@ export {
   addTrustToBeneficialOwner,
   removeTrustFromBeneficialOwner,
   saveHistoricalBoInTrust,
+  getLegalEntityBosInTrust,
   saveLegalEntityBoInTrust,
   saveIndividualTrusteeInTrust,
 };

--- a/test/utils/trust/legal.entity.beneficial.owner.mapper.spec.ts
+++ b/test/utils/trust/legal.entity.beneficial.owner.mapper.spec.ts
@@ -3,8 +3,11 @@ jest.mock('uuid');
 import { beforeEach, describe, expect, jest, test } from "@jest/globals";
 import * as uuid from 'uuid';
 import * as Page from '../../../src/model/trust.page.model';
+import * as Trust from '../../../src/model/trust.model';
+import { TrusteeType } from "../../../src/model/trustee.type.model";
 import {
   generateId,
+  mapLegalEntityItemToPage,
   mapLegalEntityToSession,
 } from '../../../src/utils/trust/legal.entity.beneficial.owner.mapper';
 
@@ -14,7 +17,7 @@ describe('Trust Legal Entity Beneficial Owner Page Mapper Service', () => {
   });
 
   describe('Test session mapper methods', () => {
-    describe('Test trust legal entity form to sesson mapping', () => {
+    describe('Test trust legal entity form to session mapping', () => {
       const mockFormData = {
         legalEntityId: "9999",
         legalEntityName: "My Legal Entity",
@@ -77,13 +80,57 @@ describe('Trust Legal Entity Beneficial Owner Page Mapper Service', () => {
           identification_registration_number: mockFormData.registration_number,
         });
       });
+
+      test('test generateId', () => {
+        const expectNewId = '9999';
+        jest.spyOn(uuid, 'v4').mockReturnValue(expectNewId);
+
+        expect(generateId()).toBe(expectNewId);
+      });
     });
-  });
 
-  test('test generateId', () => {
-    const expectNewId = '9999';
-    jest.spyOn(uuid, 'v4').mockReturnValue(expectNewId);
+    describe('Test trust legal session to page mapping', () => {
 
-    expect(generateId()).toBe(expectNewId);
+      const mockSessionData = {
+        id: "9998",
+        name: "My Legal Entity in Session",
+        type: "Interest Person",
+        date_became_interested_person_day: "01",
+        date_became_interested_person_month: "01",
+        date_became_interested_person_year: "2020",
+        ro_address_premises: "99",
+        ro_address_line1: "Reg Office First Line",
+        ro_address_line2: "Reg Office Second Line",
+        ro_address_locality: "Reg Office Town",
+        ro_address_region: "Reg Office County",
+        ro_address_country: "Reg Office Country",
+        ro_address_postal_code: "Reg Office Postcode",
+        ro_address_care_of: "",
+        ro_address_po_box: "",
+        sa_address_premises: "100",
+        sa_address_line1: "Serv First Line",
+        sa_address_line2: "Serv Second Line",
+        sa_address_locality: "Serv Town",
+        sa_address_region: "Serv County",
+        sa_address_country: "Serv Country",
+        sa_address_postal_code: "Serv Postcode",
+        sa_address_care_of: "",
+        sa_address_po_box: "",
+        identification_legal_form: "Legal Form",
+        identification_legal_authority: "Governing Law",
+        identification_place_registered: "Reg Name",
+        identification_country_registration: "Reg Jurisdiction",
+        identification_registration_number: "9002",
+      };
+      test("Map legal entity trustee session data to page trustee item", () => {
+        expect(
+          mapLegalEntityItemToPage(mockSessionData as Trust.TrustCorporate)
+        ).toEqual({
+          id: mockSessionData.id,
+          name: mockSessionData.name,
+          trusteeItemType: TrusteeType.LEGAL_ENTITY,
+        });
+      });
+    });
   });
 });

--- a/test/utils/trust/who.is.involved.mapper.spec.ts
+++ b/test/utils/trust/who.is.involved.mapper.spec.ts
@@ -1,10 +1,12 @@
 jest.mock('../../../src/utils/trusts');
 jest.mock('../../../src/utils/trust/beneficial.owner.mapper');
+jest.mock('../../../src/utils/trust/legal.entity.beneficial.owner.mapper');
 
 import { beforeEach, describe, expect, jest, test } from "@jest/globals";
 import { mapTrustWhoIsInvolvedToPage } from "../../../src/utils/trust/who.is.involved.mapper";
-import { getTrustBoIndividuals, getTrustBoOthers } from '../../../src/utils/trusts';
+import { getTrustBoIndividuals, getTrustBoOthers, getTrustByIdFromApp, getLegalEntityBosInTrust } from '../../../src/utils/trusts';
 import { mapBoIndividualToPage, mapBoOtherToPage } from "../../../src/utils/trust/beneficial.owner.mapper";
+import { mapLegalEntityItemToPage } from "../../../src/utils/trust/legal.entity.beneficial.owner.mapper";
 import { TrustKey } from '../../../src/model/trust.model';
 
 describe('Trust Involved Mapper to Page Service', () => {
@@ -33,12 +35,18 @@ describe('Trust Involved Mapper to Page Service', () => {
       (getTrustBoIndividuals as jest.Mock).mockReturnValue(mockBoIndividuals);
       const mockBoOthers = [{}];
       (getTrustBoOthers as jest.Mock).mockReturnValue(mockBoOthers);
+      const mocklegalEntities = [{}];
+      (getLegalEntityBosInTrust as jest.Mock).mockReturnValue(mocklegalEntities);
 
       const expectBoIndividualResult = 'dummyBoIndividualMappingResult';
       (mapBoIndividualToPage as jest.Mock).mockReturnValue(expectBoIndividualResult);
 
       const expectBoOtherResult = 'dummyBoOtherMappingResult';
       (mapBoOtherToPage as jest.Mock).mockReturnValue(expectBoOtherResult);
+
+      (getTrustByIdFromApp as jest.Mock).mockReturnValue(mockTrust1);
+      const expectlegalEntityResult = 'dummylegalEntityResult';
+      (mapLegalEntityItemToPage as jest.Mock).mockReturnValue(expectlegalEntityResult);
 
       const actual = mapTrustWhoIsInvolvedToPage(mockAppData, mockTrust1.trust_id);
 
@@ -48,10 +56,14 @@ describe('Trust Involved Mapper to Page Service', () => {
           expectBoIndividualResult,
           expectBoOtherResult,
         ],
+        trustees: [
+          expectlegalEntityResult,
+        ]
       });
 
       expect(getTrustBoIndividuals).toBeCalledWith(mockAppData, mockTrust1.trust_id);
       expect(getTrustBoOthers).toBeCalledWith(mockAppData, mockTrust1.trust_id);
+      expect(getLegalEntityBosInTrust).toBeCalledWith(mockTrust1);
     });
   });
 });

--- a/views/trust-involved.html
+++ b/views/trust-involved.html
@@ -44,6 +44,23 @@
         ) %}
       {% endfor %}
 
+      {% set trustees = [] %}
+      {% for trustee in pageData.trustees %}
+        {% set type = pageData.trusteeTypeTitle[trustee.trusteeItemType] %}
+        {% set trustees = (
+          trustees.push({
+            key: {
+              text: type
+            },
+            value: {
+              text: trustee.name
+            }
+          }),
+          trustees
+        ) %}
+      {% endfor %}
+
+
       {% if boItems | length %}
         <h1 class="govuk-heading-m">
           What <span class="govuk-visually-hidden">individuals or entities</span>
@@ -51,6 +68,9 @@
         </h1>
         {{ govukSummaryList({
           rows: boItems
+        }) }}
+        {{ govukSummaryList({
+          rows: trustees
         }) }}
       {% endif %}
 


### PR DESCRIPTION
### JIRA link

[ROE-1738](https://companieshouse.atlassian.net/browse/ROE-1738)

### Change description

Display legal entity trustees that have been entered on the "tell us about a legal entity page" on the trust involved page. 

- Add new page model for trusteeItem which should be usable for other trustee type(individual and historical.)
- Create mapper to page method for legal entity trustee
- Update html to display trustees
- Add trusteeTypeTitles in TrustInvolved controller which will be used to display correct trustee title
- Add relevant unit tests


### Work checklist

- [X] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.


[ROE-1738]: https://companieshouse.atlassian.net/browse/ROE-1738?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ