### PR TITLE
ROE-1971 - TL - Adding payment failed redirect screen

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -78,6 +78,7 @@ export const WHO_IS_MAKING_FILING_PAGE = "who-is-making-filing";
 export const OVERSEAS_NAME_PAGE = "overseas-name";
 export const SIGN_OUT_PAGE = "sign-out";
 export const STARTING_NEW_PAGE = "starting-new";
+export const PAYMENT_FAILED_PAGE = "payment-failed";
 
 export const TRUST_DETAILS_PAGE = "trust-details";
 export const TRUST_INVOLVED_PAGE = "trust-involved";
@@ -123,6 +124,7 @@ export const ACCESSIBILITY_STATEMENT_URL = REGISTER_AN_OVERSEAS_ENTITY_URL + ACC
 export const SIGN_OUT_URL = REGISTER_AN_OVERSEAS_ENTITY_URL + SIGN_OUT_PAGE;
 export const OVERSEAS_NAME_URL = REGISTER_AN_OVERSEAS_ENTITY_URL + OVERSEAS_NAME_PAGE;
 export const STARTING_NEW_URL = REGISTER_AN_OVERSEAS_ENTITY_URL + STARTING_NEW_PAGE;
+export const PAYMENT_FAILED_URL = REGISTER_AN_OVERSEAS_ENTITY_URL + PAYMENT_FAILED_PAGE;
 
 export const ACCOUNTS_SIGN_OUT_URL = `${ACCOUNT_URL}/signout`;
 export const REMOVE = "/remove";

--- a/src/controllers/index.ts
+++ b/src/controllers/index.ts
@@ -33,6 +33,8 @@ export * as trustIndividualbeneficialOwner from "./trust.individual.beneficial.o
 export * as trustLegalEntitybeneficialOwner from "./trust.legal.entity.beneficial.owner.controller";
 export * as trustInterrupt from "./trust.interrupt.controller";
 export * as overseasName from "./overseas.name.controller";
+export * as paymentFailed from "./payment.failed.controller";
+
 // UPDATE controllers
 export * as updateLanding from "./update/update.landing.controller";
 export * as secureUpdateFilter from "./update/secure.update.filter.controller";

--- a/src/controllers/payment.controller.ts
+++ b/src/controllers/payment.controller.ts
@@ -2,10 +2,17 @@ import { NextFunction, Request, Response } from "express";
 import { CreatePaymentRequest } from "@companieshouse/api-sdk-node/dist/services/payment";
 
 import { logger, createAndLogErrorRequest } from "../utils/logger";
-import { CHECK_YOUR_ANSWERS_URL, CONFIRMATION_URL, PAYMENT_PAID } from "../config";
+import {
+  CHECK_YOUR_ANSWERS_URL,
+  CONFIRMATION_URL,
+  FEATURE_FLAG_ENABLE_SAVE_AND_RESUME_17102022,
+  PAYMENT_FAILED_URL,
+  PAYMENT_PAID
+} from "../config";
 import { ApplicationData } from "../model";
 import { getApplicationData } from "../utils/application.data";
 import { OverseasEntityKey, PaymentKey } from "../model/data.types.model";
+import { isActiveFeature } from "../utils/feature.flag";
 
 // The Payment Platform will redirect the user's browser back to the `redirectUri` supplied when the payment session was created,
 // and this controller is dealing with the completion of the payment journey
@@ -34,8 +41,12 @@ export const get = (req: Request, res: Response, next: NextFunction) => {
       logger.debugRequest(req, `Overseas Entity id: ${ appData[OverseasEntityKey] }, Payment status: ${status}, Redirecting to: ${CHECK_YOUR_ANSWERS_URL}`);
 
       // Dealing with failures payment (User cancelled, Insufficient funds, Payment error ...)
-      // Redirect to CHECK_YOUR_ANSWERS. Try again eventually
-      return res.redirect(CHECK_YOUR_ANSWERS_URL);
+      if (isActiveFeature(FEATURE_FLAG_ENABLE_SAVE_AND_RESUME_17102022)) {
+        return res.redirect(PAYMENT_FAILED_URL);
+      } else {
+        // Redirect to CHECK_YOUR_ANSWERS. Try again eventually
+        return res.redirect(CHECK_YOUR_ANSWERS_URL);
+      }
     }
   } catch (error) {
     logger.errorRequest(req, error);

--- a/src/controllers/payment.controller.ts
+++ b/src/controllers/payment.controller.ts
@@ -38,12 +38,13 @@ export const get = (req: Request, res: Response, next: NextFunction) => {
       // Payment Successful, redirect to confirmation page
       return res.redirect(CONFIRMATION_URL);
     } else {
-      logger.debugRequest(req, `Overseas Entity id: ${ appData[OverseasEntityKey] }, Payment status: ${status}, Redirecting to: ${CHECK_YOUR_ANSWERS_URL}`);
 
       // Dealing with failures payment (User cancelled, Insufficient funds, Payment error ...)
       if (isActiveFeature(FEATURE_FLAG_ENABLE_SAVE_AND_RESUME_17102022)) {
+        logger.debugRequest(req, `Overseas Entity id: ${ appData[OverseasEntityKey] }, Payment status: ${status}, Redirecting to: ${PAYMENT_FAILED_URL}`);
         return res.redirect(PAYMENT_FAILED_URL);
       } else {
+        logger.debugRequest(req, `Overseas Entity id: ${ appData[OverseasEntityKey] }, Payment status: ${status}, Redirecting to: ${CHECK_YOUR_ANSWERS_URL}`);
         // Redirect to CHECK_YOUR_ANSWERS. Try again eventually
         return res.redirect(CHECK_YOUR_ANSWERS_URL);
       }

--- a/src/controllers/payment.failed.controller.ts
+++ b/src/controllers/payment.failed.controller.ts
@@ -1,0 +1,12 @@
+import { Request, Response } from "express";
+import * as config from "../config";
+import { logger } from "../utils/logger";
+import { PAYMENT_FAILED_PAGE } from "../config";
+
+export const get = (req: Request, res: Response) => {
+  logger.debugRequest(req, `GET ${PAYMENT_FAILED_PAGE}`);
+
+  return res.render(config.PAYMENT_FAILED_PAGE, {
+    templateName: PAYMENT_FAILED_PAGE
+  });
+};

--- a/src/controllers/payment.failed.controller.ts
+++ b/src/controllers/payment.failed.controller.ts
@@ -1,12 +1,11 @@
 import { Request, Response } from "express";
-import * as config from "../config";
 import { logger } from "../utils/logger";
 import { PAYMENT_FAILED_PAGE } from "../config";
 
 export const get = (req: Request, res: Response) => {
   logger.debugRequest(req, `GET ${PAYMENT_FAILED_PAGE}`);
 
-  return res.render(config.PAYMENT_FAILED_PAGE, {
+  return res.render(PAYMENT_FAILED_PAGE, {
     templateName: PAYMENT_FAILED_PAGE
   });
 };

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -51,7 +51,8 @@ import {
   updateCheckYourAnswers,
   updateDueDiligence,
   updateDueDiligenceOverseasEntity,
-  updateConfirmation
+  updateConfirmation,
+  paymentFailed
 } from "../controllers";
 
 import { serviceAvailabilityMiddleware } from "../middleware/service.availability.middleware";
@@ -226,6 +227,8 @@ router.get(config.CHECK_YOUR_ANSWERS_URL, authentication, navigation.hasBOsOrMOs
 router.post(config.CHECK_YOUR_ANSWERS_URL, authentication, navigation.hasBOsOrMOs, checkYourAnswers.post);
 
 router.get(config.PAYMENT_WITH_TRANSACTION_URL, authentication, payment.get);
+
+router.get(config.PAYMENT_FAILED_URL, authentication, paymentFailed.get);
 
 router.get(config.CONFIRMATION_URL, authentication, navigation.hasBOsOrMOs, confirmation.get);
 

--- a/test/__mocks__/text.mock.ts
+++ b/test/__mocks__/text.mock.ts
@@ -131,6 +131,7 @@ export const NOT_SHOW_INFORMATION_ON_PUBLIC_REGISTER = "We will not show any of 
 export const USE_INFORMATION_NEED_MORE = "We’ll use this if we need more information about the application.";
 export const UPDATE_USE_INFORMATION_NEED_MORE = "We’ll use this if we need more information about the update.";
 export const UK_REGULATED_AGENT = "Someone who works for the UK-regulated agent that carried out verification checks";
+export const PAYMENT_FAILED_PAGE_HEADING = "Payment failed";
 
 export const CHANGE_LINK_INDIVIDUAL_BO = "Individual beneficial owner ";
 export const CHANGE_LINK_INDIVIDUAL_BO_FIRST_NAME = CHANGE_LINK_INDIVIDUAL_BO + "Ivan Drago - first name";

--- a/test/controllers/payment.controller.spec.ts
+++ b/test/controllers/payment.controller.spec.ts
@@ -2,6 +2,8 @@ jest.mock("ioredis");
 jest.mock('../../src/middleware/authentication.middleware');
 jest.mock("../../src/utils/logger");
 jest.mock('../../src/utils/application.data');
+jest.mock('../../src/utils/feature.flag');
+jest.mock('../../src/middleware/service.availability.middleware');
 
 import { NextFunction, Request, Response } from "express";
 import { describe, expect, jest, test, beforeEach } from "@jest/globals";
@@ -9,15 +11,24 @@ import request from "supertest";
 
 import app from "../../src/app";
 import { authentication } from "../../src/middleware/authentication.middleware";
+import { serviceAvailabilityMiddleware } from "../../src/middleware/service.availability.middleware";
 import { getApplicationData } from '../../src/utils/application.data';
 import { createAndLogErrorRequest, logger } from '../../src/utils/logger';
+import { isActiveFeature } from "../../src/utils/feature.flag";
 
 import {
   PAYMENT_DECLINED_WITH_TRANSACTION_URL_AND_QUERY_STRING,
   PAYMENT_OBJECT_MOCK,
   PAYMENT_WITH_TRANSACTION_URL_AND_QUERY_STRING
 } from "../__mocks__/session.mock";
-import { CHECK_YOUR_ANSWERS_URL, CONFIRMATION_PAGE, CONFIRMATION_URL, PAYMENT_PAID } from "../../src/config";
+import {
+  CHECK_YOUR_ANSWERS_URL,
+  CONFIRMATION_PAGE,
+  CONFIRMATION_URL,
+  PAYMENT_FAILED_PAGE,
+  PAYMENT_FAILED_URL,
+  PAYMENT_PAID
+} from "../../src/config";
 import { FOUND_REDIRECT_TO, MESSAGE_ERROR, SERVICE_UNAVAILABLE } from "../__mocks__/text.mock";
 import { PaymentKey } from "../../src/model/data.types.model";
 
@@ -27,6 +38,9 @@ const mockCreateAndLogErrorRequest = createAndLogErrorRequest as jest.Mock;
 const mockGetApplicationData = getApplicationData as jest.Mock;
 const mockAuthenticationMiddleware = authentication as jest.Mock;
 mockAuthenticationMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => next() );
+const mockServiceAvailabilityMiddleware = serviceAvailabilityMiddleware as jest.Mock;
+mockServiceAvailabilityMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => next() );
+const mockIsActiveFeature = isActiveFeature as jest.Mock;
 
 describe("Payment controller", () => {
 
@@ -43,7 +57,7 @@ describe("Payment controller", () => {
     expect(mockCreateAndLogErrorRequest).toHaveBeenCalledTimes(1);
   });
 
-  test(`should redirect to ${CONFIRMATION_PAGE} page, Payment Successfull with status ${PAYMENT_PAID}`, async () => {
+  test(`should redirect to ${CONFIRMATION_PAGE} page, Payment Successful with status ${PAYMENT_PAID}`, async () => {
     mockGetApplicationData.mockReturnValueOnce( { [PaymentKey]: PAYMENT_OBJECT_MOCK } );
     const resp = await request(app).get(PAYMENT_WITH_TRANSACTION_URL_AND_QUERY_STRING);
 
@@ -60,6 +74,18 @@ describe("Payment controller", () => {
 
     expect(resp.status).toEqual(302);
     expect(resp.text).toEqual(`${FOUND_REDIRECT_TO} ${CHECK_YOUR_ANSWERS_URL}`);
+    expect(mockLoggerDebugRequest).toHaveBeenCalledTimes(1);
+    expect(mockLoggerInfoRequest).toHaveBeenCalledTimes(1);
+    expect(mockCreateAndLogErrorRequest).not.toHaveBeenCalled();
+  });
+
+  test(`should redirect to ${PAYMENT_FAILED_PAGE} page, Payment failed somehow and feature flag active`, async () => {
+    mockIsActiveFeature.mockReturnValueOnce(true);
+    mockGetApplicationData.mockReturnValueOnce( { [PaymentKey]: PAYMENT_OBJECT_MOCK } );
+    const resp = await request(app).get(PAYMENT_DECLINED_WITH_TRANSACTION_URL_AND_QUERY_STRING);
+
+    expect(resp.status).toEqual(302);
+    expect(resp.text).toEqual(`${FOUND_REDIRECT_TO} ${PAYMENT_FAILED_URL}`);
     expect(mockLoggerDebugRequest).toHaveBeenCalledTimes(1);
     expect(mockLoggerInfoRequest).toHaveBeenCalledTimes(1);
     expect(mockCreateAndLogErrorRequest).not.toHaveBeenCalled();

--- a/test/controllers/payment.failed.controller.spec.ts
+++ b/test/controllers/payment.failed.controller.spec.ts
@@ -1,0 +1,31 @@
+jest.mock("ioredis");
+jest.mock("../../src/utils/logger");
+jest.mock('../../src/middleware/authentication.middleware');
+
+import { NextFunction, Request, Response } from "express";
+import { expect, jest, test } from "@jest/globals";
+import request from "supertest";
+
+import {
+  PAYMENT_FAILED_PAGE,
+  PAYMENT_FAILED_URL,
+  YOUR_FILINGS_PATH
+} from "../../src/config";
+import app from "../../src/app";
+import { PAYMENT_FAILED_PAGE_HEADING } from "../__mocks__/text.mock";
+
+import { authentication } from "../../src/middleware/authentication.middleware";
+
+const mockAuthenticationMiddleware = authentication as jest.Mock;
+mockAuthenticationMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => next() );
+
+describe("Payment failed controller tests", () => {
+
+  test(`renders the ${PAYMENT_FAILED_PAGE} page`, async () => {
+    const resp = await request(app).get(PAYMENT_FAILED_URL);
+
+    expect(resp.status).toEqual(200);
+    expect(resp.text).toContain(PAYMENT_FAILED_PAGE_HEADING);
+    expect(resp.text).toContain(YOUR_FILINGS_PATH);
+  });
+});

--- a/views/payment-failed.html
+++ b/views/payment-failed.html
@@ -1,0 +1,26 @@
+{% extends "layout.html" %}
+
+{% set title = "Payment failed" %}
+
+{% block pageTitle %}
+  {% include "includes/page-title.html" %}
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l">{{ title }}</h1>
+
+      <p class="govuk-body">Your application has not been submitted because we have not been able to take payment. This could be because:</p>
+
+      <ul class="govuk-list govuk-list--bullet">
+        <li>you cancelled your payment</li>
+        <li>your payment was declined</li>
+        <li>your payment expired</li>
+        <li>there was an error (for example, a technical error)</li>
+      </ul>
+
+      <p class="govuk-body">Your application has been saved in Your Filings. To submit the application, you will need to <a href="{{ OE_CONFIGS.YOUR_FILINGS_PATH }}" class="govuk-link" data-event-id="payment-failed-your-filings-link">find the application in Your Filings</a> and complete payment</p>
+    </div>
+  </div>
+{% endblock %}


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/ROE-1971


### Change description
Work to add a payment failed screen to show when the user cancels or otherwise fails the payment and FEATURE_FLAG_ENABLE_SAVE_AND_RESUME_17102022 is active.


### Work checklist

- [x] Tests added where applicable
- [x] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
