### PR TITLE
ROE-1933-TL-Fix date error highlighting and only fire one date error at a time

### DIFF
--- a/src/validation/beneficial.owner.individual.validation.ts
+++ b/src/validation/beneficial.owner.individual.validation.ts
@@ -20,6 +20,9 @@ export const beneficialOwnerIndividual = [
     .isLength({ max: 160 })
     .withMessage(ErrorMessages.MAX_LAST_NAME_LENGTH)
     .matches(VALID_CHARACTERS).withMessage(ErrorMessages.LAST_NAME_INVALID_CHARACTERS),
+
+  ...date_of_birth_validations,
+
   body("nationality")
     .not().isEmpty({ ignore_whitespace: true }).withMessage(ErrorMessages.NATIONALITY)
     .matches(VALID_CHARACTERS).withMessage(ErrorMessages.NATIONALITY_INVALID_CHARACTERS),
@@ -31,12 +34,10 @@ export const beneficialOwnerIndividual = [
   body("is_service_address_same_as_usual_residential_address")
     .not().isEmpty().withMessage(ErrorMessages.SELECT_IF_SERVICE_ADDRESS_SAME_AS_USER_RESIDENTIAL_ADDRESS),
 
-  ...start_date_validations,
-
   ...usual_residential_address_validations,
   ...usual_residential_service_address_validations,
 
-  ...date_of_birth_validations,
+  ...start_date_validations,
 
   ...nature_of_control_validations
 ];

--- a/src/validation/custom.validation.ts
+++ b/src/validation/custom.validation.ts
@@ -65,12 +65,10 @@ export const checkDateIsWithinLast3Months = (errMsg: string, day: string = "", m
   return true;
 };
 
-export const checkDateValueIsValid = (invalidDateErrMsg: string, yearLengthErrMsg: string, dayStr: string = "", monthStr: string = "", yearStr: string = "") => {
+export const checkDateValueIsValid = (invalidDateErrMsg: string, dayStr: string = "", monthStr: string = "", yearStr: string = "") => {
   const day = parseInt(dayStr), month = parseInt(monthStr), year = parseInt(yearStr);
   if (isNaN(day) || isNaN(month) || isNaN(year) || !DateTime.utc(year, month, day).isValid) {
     throw new Error(invalidDateErrMsg);
-  } else if (yearStr.length !== 4) {
-    throw new Error(yearLengthErrMsg);
   }
 
   return true;
@@ -80,7 +78,7 @@ export const checkOptionalDate = (dayStr: string = "", monthStr: string = "", ye
   if ( dayStr !== "" || monthStr !== "" || yearStr !== "" ) {
     const areDateFieldsPresent = checkAllDateFieldsArePresent(dayStr, monthStr, yearStr);
     if (areDateFieldsPresent) {
-      const isOptionalDateValid = checkDateValueIsValid(ErrorMessages.INVALID_DATE, ErrorMessages.YEAR_LENGTH, dayStr, monthStr, yearStr);
+      const isOptionalDateValid = checkDateValueIsValid(ErrorMessages.INVALID_DATE, dayStr, monthStr, yearStr);
       if (isOptionalDateValid) {
         const isDateInThePast = checkDateIsInPastOrToday(ErrorMessages.DATE_NOT_IN_PAST_OR_TODAY, dayStr, monthStr, yearStr);
         if (isDateInThePast) {
@@ -97,7 +95,7 @@ export const checkIdentityDate = (dayStr: string = "", monthStr: string = "", ye
   if (isDatePresent) {
     const areAllDateFieldsPresent = checkAllDateFieldsArePresent(dayStr, monthStr, yearStr);
     if (areAllDateFieldsPresent) {
-      const isDateValid = checkDateValueIsValid(ErrorMessages.INVALID_DATE, ErrorMessages.YEAR_LENGTH, dayStr, monthStr, yearStr);
+      const isDateValid = checkDateValueIsValid(ErrorMessages.INVALID_DATE, dayStr, monthStr, yearStr);
       if (isDateValid) {
         const isDatePastOrToday = checkDateIsInPastOrToday(ErrorMessages.DATE_NOT_IN_PAST_OR_TODAY, dayStr, monthStr, yearStr);
         if (isDatePastOrToday) {
@@ -114,7 +112,7 @@ export const checkStartDate = (dayStr: string = "", monthStr: string = "", yearS
   if (isDatePresent) {
     const areAllDateFieldsPresent = checkAllDateFieldsArePresent(dayStr, monthStr, yearStr);
     if (areAllDateFieldsPresent) {
-      const isDateValid = checkDateValueIsValid(ErrorMessages.INVALID_DATE, ErrorMessages.YEAR_LENGTH, dayStr, monthStr, yearStr);
+      const isDateValid = checkDateValueIsValid(ErrorMessages.INVALID_DATE, dayStr, monthStr, yearStr);
       if (isDateValid) {
         checkDateIsInPastOrToday(ErrorMessages.DATE_NOT_IN_PAST_OR_TODAY, dayStr, monthStr, yearStr);
       }
@@ -172,7 +170,7 @@ export const checkDateOfBirth = (dayStr: string = "", monthStr: string = "", yea
   if (isDatePresent) {
     const areDateOfBirthFieldsPresent = checkDateOfBirthFieldsArePresent(dayStr, monthStr, yearStr);
     if (areDateOfBirthFieldsPresent) {
-      const isDateValid = checkDateValueIsValid(ErrorMessages.INVALID_DATE_OF_BIRTH, ErrorMessages.DATE_OF_BIRTH_YEAR_LENGTH, dayStr, monthStr, yearStr);
+      const isDateValid = checkDateValueIsValid(ErrorMessages.INVALID_DATE_OF_BIRTH, dayStr, monthStr, yearStr);
       if (isDateValid) {
         checkDateIsInPast(ErrorMessages.DATE_OF_BIRTH_NOT_IN_PAST, dayStr, monthStr, yearStr);
       }

--- a/src/validation/custom.validation.ts
+++ b/src/validation/custom.validation.ts
@@ -74,8 +74,12 @@ export const checkDateValueIsValid = (invalidDateErrMsg: string, dayStr: string 
   return true;
 };
 
+const isYearEitherMissingOrCorrectLength = (yearStr: string = ""): boolean => {
+  return (yearStr.length === 0 || yearStr.length === 4);
+};
+
 export const checkOptionalDate = (dayStr: string = "", monthStr: string = "", yearStr: string = "") => {
-  if (yearStr.length === 0 || yearStr.length === 4) {
+  if (isYearEitherMissingOrCorrectLength(yearStr)) {
     if ( dayStr !== "" || monthStr !== "" || yearStr !== "" ) {
       const areDateFieldsPresent = checkAllDateFieldsArePresent(dayStr, monthStr, yearStr);
       if (areDateFieldsPresent) {
@@ -93,7 +97,8 @@ export const checkOptionalDate = (dayStr: string = "", monthStr: string = "", ye
 };
 
 export const checkIdentityDate = (dayStr: string = "", monthStr: string = "", yearStr: string = "") => {
-  if (yearStr.length === 0 || yearStr.length === 4) {
+  // to prevent more than 1 error reported on the date fields we check if the year is correct length or missing before doing the date check as a whole.
+  if (isYearEitherMissingOrCorrectLength(yearStr)) {
     const isDatePresent = checkDateIsNotCompletelyEmpty(ErrorMessages.ENTER_DATE, dayStr, monthStr, yearStr);
     if (isDatePresent) {
       const areAllDateFieldsPresent = checkAllDateFieldsArePresent(dayStr, monthStr, yearStr);
@@ -112,7 +117,8 @@ export const checkIdentityDate = (dayStr: string = "", monthStr: string = "", ye
 };
 
 export const checkStartDate = (dayStr: string = "", monthStr: string = "", yearStr: string = "") => {
-  if (yearStr.length === 0 || yearStr.length === 4) {
+  // to prevent more than 1 error reported on the date fields we check if the year is correct length or missing before doing the date check as a whole.
+  if (isYearEitherMissingOrCorrectLength(yearStr)) {
     const isDatePresent = checkDateIsNotCompletelyEmpty(ErrorMessages.ENTER_DATE, dayStr, monthStr, yearStr);
     if (isDatePresent) {
       const areAllDateFieldsPresent = checkAllDateFieldsArePresent(dayStr, monthStr, yearStr);
@@ -127,20 +133,16 @@ export const checkStartDate = (dayStr: string = "", monthStr: string = "", yearS
   return true;
 };
 
-export const checkDateFieldDay = (message: string, dayStr: string = "", monthStr: string = "", yearStr: string = "") => {
-  if (yearStr.length === 0 || yearStr.length === 4) {
-    if (dayStr === "" && monthStr !== "" && yearStr !== "") {
-      throw new Error(message);
-    }
+export const checkDateFieldDay = (dayMissingMessage: string, dayStr: string = "", monthStr: string = "", yearStr: string = "") => {
+  if (dayStr === "" && monthStr !== "" && yearStr !== "") {
+    throw new Error(dayMissingMessage);
   }
   return true;
 };
 
-export const checkDateFieldMonth = (message: string, dayStr: string = "", monthStr: string = "", yearStr: string = "") => {
-  if (yearStr.length === 0 || yearStr.length === 4) {
-    if (monthStr === "" && dayStr !== "" && yearStr !== "") {
-      throw new Error(message);
-    }
+export const checkDateFieldMonth = (monthMissingMessage: string, dayStr: string = "", monthStr: string = "", yearStr: string = "") => {
+  if (monthStr === "" && dayStr !== "" && yearStr !== "") {
+    throw new Error(monthMissingMessage);
   }
   return true;
 };
@@ -149,7 +151,7 @@ export const checkDateFieldYear = (yearMissingMessage: string, yearLengthMessage
   if (yearStr === "" && dayStr !== "" && monthStr !== "") {
     throw new Error(yearMissingMessage);
   }
-  if (yearStr.length > 0 && yearStr.length < 4) {
+  if (yearStr.length !== 0 && yearStr.length !== 4) {
     throw new Error(yearLengthMessage);
   }
   return true;
@@ -179,7 +181,8 @@ export const checkMoreThanOneDateFieldIsNotMissing = (dayStr: string = "", month
 };
 
 export const checkDateOfBirth = (dayStr: string = "", monthStr: string = "", yearStr: string = "") => {
-  if (yearStr.length === 0 || yearStr.length === 4) {
+  // to prevent more than 1 error reported on the date fields we check if the year is correct length or missing before doing the date check as a whole.
+  if (isYearEitherMissingOrCorrectLength(yearStr)) {
     const isDatePresent = checkDateIsNotCompletelyEmpty(ErrorMessages.ENTER_DATE_OF_BIRTH, dayStr, monthStr, yearStr);
     if (isDatePresent) {
       const areDateOfBirthFieldsPresent = checkDateOfBirthFieldsArePresent(dayStr, monthStr, yearStr);

--- a/src/validation/custom.validation.ts
+++ b/src/validation/custom.validation.ts
@@ -75,14 +75,16 @@ export const checkDateValueIsValid = (invalidDateErrMsg: string, dayStr: string 
 };
 
 export const checkOptionalDate = (dayStr: string = "", monthStr: string = "", yearStr: string = "") => {
-  if ( dayStr !== "" || monthStr !== "" || yearStr !== "" ) {
-    const areDateFieldsPresent = checkAllDateFieldsArePresent(dayStr, monthStr, yearStr);
-    if (areDateFieldsPresent) {
-      const isOptionalDateValid = checkDateValueIsValid(ErrorMessages.INVALID_DATE, dayStr, monthStr, yearStr);
-      if (isOptionalDateValid) {
-        const isDateInThePast = checkDateIsInPastOrToday(ErrorMessages.DATE_NOT_IN_PAST_OR_TODAY, dayStr, monthStr, yearStr);
-        if (isDateInThePast) {
-          checkDateIsWithinLast3Months(ErrorMessages.IDENTITY_CHECK_DATE_NOT_WITHIN_PAST_3_MONTHS, dayStr, monthStr, yearStr);
+  if (yearStr.length === 0 || yearStr.length === 4) {
+    if ( dayStr !== "" || monthStr !== "" || yearStr !== "" ) {
+      const areDateFieldsPresent = checkAllDateFieldsArePresent(dayStr, monthStr, yearStr);
+      if (areDateFieldsPresent) {
+        const isOptionalDateValid = checkDateValueIsValid(ErrorMessages.INVALID_DATE, dayStr, monthStr, yearStr);
+        if (isOptionalDateValid) {
+          const isDateInThePast = checkDateIsInPastOrToday(ErrorMessages.DATE_NOT_IN_PAST_OR_TODAY, dayStr, monthStr, yearStr);
+          if (isDateInThePast) {
+            checkDateIsWithinLast3Months(ErrorMessages.IDENTITY_CHECK_DATE_NOT_WITHIN_PAST_3_MONTHS, dayStr, monthStr, yearStr);
+          }
         }
       }
     }
@@ -91,15 +93,17 @@ export const checkOptionalDate = (dayStr: string = "", monthStr: string = "", ye
 };
 
 export const checkIdentityDate = (dayStr: string = "", monthStr: string = "", yearStr: string = "") => {
-  const isDatePresent = checkDateIsNotCompletelyEmpty(ErrorMessages.ENTER_DATE, dayStr, monthStr, yearStr);
-  if (isDatePresent) {
-    const areAllDateFieldsPresent = checkAllDateFieldsArePresent(dayStr, monthStr, yearStr);
-    if (areAllDateFieldsPresent) {
-      const isDateValid = checkDateValueIsValid(ErrorMessages.INVALID_DATE, dayStr, monthStr, yearStr);
-      if (isDateValid) {
-        const isDatePastOrToday = checkDateIsInPastOrToday(ErrorMessages.DATE_NOT_IN_PAST_OR_TODAY, dayStr, monthStr, yearStr);
-        if (isDatePastOrToday) {
-          checkDateIsWithinLast3Months(ErrorMessages.IDENTITY_CHECK_DATE_NOT_WITHIN_PAST_3_MONTHS, dayStr, monthStr, yearStr);
+  if (yearStr.length === 0 || yearStr.length === 4) {
+    const isDatePresent = checkDateIsNotCompletelyEmpty(ErrorMessages.ENTER_DATE, dayStr, monthStr, yearStr);
+    if (isDatePresent) {
+      const areAllDateFieldsPresent = checkAllDateFieldsArePresent(dayStr, monthStr, yearStr);
+      if (areAllDateFieldsPresent) {
+        const isDateValid = checkDateValueIsValid(ErrorMessages.INVALID_DATE, dayStr, monthStr, yearStr);
+        if (isDateValid) {
+          const isDatePastOrToday = checkDateIsInPastOrToday(ErrorMessages.DATE_NOT_IN_PAST_OR_TODAY, dayStr, monthStr, yearStr);
+          if (isDatePastOrToday) {
+            checkDateIsWithinLast3Months(ErrorMessages.IDENTITY_CHECK_DATE_NOT_WITHIN_PAST_3_MONTHS, dayStr, monthStr, yearStr);
+          }
         }
       }
     }
@@ -108,13 +112,15 @@ export const checkIdentityDate = (dayStr: string = "", monthStr: string = "", ye
 };
 
 export const checkStartDate = (dayStr: string = "", monthStr: string = "", yearStr: string = "") => {
-  const isDatePresent = checkDateIsNotCompletelyEmpty(ErrorMessages.ENTER_DATE, dayStr, monthStr, yearStr);
-  if (isDatePresent) {
-    const areAllDateFieldsPresent = checkAllDateFieldsArePresent(dayStr, monthStr, yearStr);
-    if (areAllDateFieldsPresent) {
-      const isDateValid = checkDateValueIsValid(ErrorMessages.INVALID_DATE, dayStr, monthStr, yearStr);
-      if (isDateValid) {
-        checkDateIsInPastOrToday(ErrorMessages.DATE_NOT_IN_PAST_OR_TODAY, dayStr, monthStr, yearStr);
+  if (yearStr.length === 0 || yearStr.length === 4) {
+    const isDatePresent = checkDateIsNotCompletelyEmpty(ErrorMessages.ENTER_DATE, dayStr, monthStr, yearStr);
+    if (isDatePresent) {
+      const areAllDateFieldsPresent = checkAllDateFieldsArePresent(dayStr, monthStr, yearStr);
+      if (areAllDateFieldsPresent) {
+        const isDateValid = checkDateValueIsValid(ErrorMessages.INVALID_DATE, dayStr, monthStr, yearStr);
+        if (isDateValid) {
+          checkDateIsInPastOrToday(ErrorMessages.DATE_NOT_IN_PAST_OR_TODAY, dayStr, monthStr, yearStr);
+        }
       }
     }
   }
@@ -122,22 +128,29 @@ export const checkStartDate = (dayStr: string = "", monthStr: string = "", yearS
 };
 
 export const checkDateFieldDay = (message: string, dayStr: string = "", monthStr: string = "", yearStr: string = "") => {
-  if (dayStr === "" && monthStr !== "" && yearStr !== "") {
-    throw new Error(message);
+  if (yearStr.length === 0 || yearStr.length === 4) {
+    if (dayStr === "" && monthStr !== "" && yearStr !== "") {
+      throw new Error(message);
+    }
   }
   return true;
 };
 
 export const checkDateFieldMonth = (message: string, dayStr: string = "", monthStr: string = "", yearStr: string = "") => {
-  if (monthStr === "" && dayStr !== "" && yearStr !== "") {
-    throw new Error(message);
+  if (yearStr.length === 0 || yearStr.length === 4) {
+    if (monthStr === "" && dayStr !== "" && yearStr !== "") {
+      throw new Error(message);
+    }
   }
   return true;
 };
 
-export const checkDateFieldYear = (message: string, dayStr: string = "", monthStr: string = "", yearStr: string = "") => {
+export const checkDateFieldYear = (yearMissingMessage: string, yearLengthMessage: string, dayStr: string = "", monthStr: string = "", yearStr: string = "") => {
   if (yearStr === "" && dayStr !== "" && monthStr !== "") {
-    throw new Error(message);
+    throw new Error(yearMissingMessage);
+  }
+  if (yearStr.length > 0 && yearStr.length < 4) {
+    throw new Error(yearLengthMessage);
   }
   return true;
 };
@@ -166,13 +179,15 @@ export const checkMoreThanOneDateFieldIsNotMissing = (dayStr: string = "", month
 };
 
 export const checkDateOfBirth = (dayStr: string = "", monthStr: string = "", yearStr: string = "") => {
-  const isDatePresent = checkDateIsNotCompletelyEmpty(ErrorMessages.ENTER_DATE_OF_BIRTH, dayStr, monthStr, yearStr);
-  if (isDatePresent) {
-    const areDateOfBirthFieldsPresent = checkDateOfBirthFieldsArePresent(dayStr, monthStr, yearStr);
-    if (areDateOfBirthFieldsPresent) {
-      const isDateValid = checkDateValueIsValid(ErrorMessages.INVALID_DATE_OF_BIRTH, dayStr, monthStr, yearStr);
-      if (isDateValid) {
-        checkDateIsInPast(ErrorMessages.DATE_OF_BIRTH_NOT_IN_PAST, dayStr, monthStr, yearStr);
+  if (yearStr.length === 0 || yearStr.length === 4) {
+    const isDatePresent = checkDateIsNotCompletelyEmpty(ErrorMessages.ENTER_DATE_OF_BIRTH, dayStr, monthStr, yearStr);
+    if (isDatePresent) {
+      const areDateOfBirthFieldsPresent = checkDateOfBirthFieldsArePresent(dayStr, monthStr, yearStr);
+      if (areDateOfBirthFieldsPresent) {
+        const isDateValid = checkDateValueIsValid(ErrorMessages.INVALID_DATE_OF_BIRTH, dayStr, monthStr, yearStr);
+        if (isDateValid) {
+          checkDateIsInPast(ErrorMessages.DATE_OF_BIRTH_NOT_IN_PAST, dayStr, monthStr, yearStr);
+        }
       }
     }
   }

--- a/src/validation/custom.validation.ts
+++ b/src/validation/custom.validation.ts
@@ -79,6 +79,7 @@ const isYearEitherMissingOrCorrectLength = (yearStr: string = ""): boolean => {
 };
 
 export const checkOptionalDate = (dayStr: string = "", monthStr: string = "", yearStr: string = "") => {
+  // to prevent more than 1 error reported on the date fields we check if the year is correct length or missing before doing the date check as a whole.
   if (isYearEitherMissingOrCorrectLength(yearStr)) {
     if ( dayStr !== "" || monthStr !== "" || yearStr !== "" ) {
       const areDateFieldsPresent = checkAllDateFieldsArePresent(dayStr, monthStr, yearStr);

--- a/src/validation/custom.validation.ts
+++ b/src/validation/custom.validation.ts
@@ -152,7 +152,7 @@ export const checkDateFieldYear = (yearMissingMessage: string, yearLengthMessage
   if (yearStr === "" && dayStr !== "" && monthStr !== "") {
     throw new Error(yearMissingMessage);
   }
-  if (yearStr.length !== 0 && yearStr.length !== 4) {
+  if (!isYearEitherMissingOrCorrectLength(yearStr)) {
     throw new Error(yearLengthMessage);
   }
   return true;

--- a/src/validation/due.diligence.validation.ts
+++ b/src/validation/due.diligence.validation.ts
@@ -12,7 +12,9 @@ export const dueDiligence = [
 
   body("name")
     .not().isEmpty({ ignore_whitespace: true }).withMessage(ErrorMessages.DUE_DILIGENCE_NAME)
+    .bail()
     .isLength({ max: 256 }).withMessage(ErrorMessages.MAX_AGENT_NAME_LENGTH)
+    .bail()
     .matches(VALID_CHARACTERS).withMessage(ErrorMessages.NAME_INVALID_CHARACTERS),
 
   ...identity_address_validations,

--- a/src/validation/fields/date.validation.ts
+++ b/src/validation/fields/date.validation.ts
@@ -10,34 +10,34 @@ import {
 import { ErrorMessages } from "../error.messages";
 
 export const start_date_validations = [
-  body("start_date")
+  body("start_date-day")
     .custom((value, { req }) => checkDateFieldDay(ErrorMessages.DAY, req.body["start_date-day"], req.body["start_date-month"], req.body["start_date-year"])),
-  body("start_date")
+  body("start_date-month")
     .custom((value, { req }) => checkDateFieldMonth(ErrorMessages.MONTH, req.body["start_date-day"], req.body["start_date-month"], req.body["start_date-year"])),
-  body("start_date")
-    .custom((value, { req }) => checkDateFieldYear(ErrorMessages.YEAR, req.body["start_date-day"], req.body["start_date-month"], req.body["start_date-year"])),
+  body("start_date-year")
+    .custom((value, { req }) => checkDateFieldYear(ErrorMessages.YEAR, ErrorMessages.YEAR_LENGTH, req.body["start_date-day"], req.body["start_date-month"], req.body["start_date-year"])),
   body("start_date")
     .custom((value, { req }) => checkStartDate(req.body["start_date-day"], req.body["start_date-month"], req.body["start_date-year"])),
 ];
 
 export const date_of_birth_validations = [
-  body("date_of_birth")
+  body("date_of_birth-day")
     .custom((value, { req }) => checkDateFieldDay(ErrorMessages.DAY_OF_BIRTH, req.body["date_of_birth-day"], req.body["date_of_birth-month"], req.body["date_of_birth-year"])),
-  body("date_of_birth")
+  body("date_of_birth-month")
     .custom((value, { req }) => checkDateFieldMonth(ErrorMessages.MONTH_OF_BIRTH, req.body["date_of_birth-day"], req.body["date_of_birth-month"], req.body["date_of_birth-year"])),
-  body("date_of_birth")
-    .custom((value, { req }) => checkDateFieldYear(ErrorMessages.YEAR_OF_BIRTH, req.body["date_of_birth-day"], req.body["date_of_birth-month"], req.body["date_of_birth-year"])),
+  body("date_of_birth-year")
+    .custom((value, { req }) => checkDateFieldYear(ErrorMessages.YEAR_OF_BIRTH, ErrorMessages.DATE_OF_BIRTH_YEAR_LENGTH, req.body["date_of_birth-day"], req.body["date_of_birth-month"], req.body["date_of_birth-year"])),
   body("date_of_birth")
     .custom((value, { req }) => checkDateOfBirth(req.body["date_of_birth-day"], req.body["date_of_birth-month"], req.body["date_of_birth-year"])),
 ];
 
 export const identity_check_date_validations = [
-  body("identity_date")
+  body("identity_date-day")
     .custom((value, { req }) => checkDateFieldDay(ErrorMessages.DAY, req.body["identity_date-day"], req.body["identity_date-month"], req.body["identity_date-year"])),
-  body("identity_date")
+  body("identity_date-month")
     .custom((value, { req }) => checkDateFieldMonth(ErrorMessages.MONTH, req.body["identity_date-day"], req.body["identity_date-month"], req.body["identity_date-year"])),
-  body("identity_date")
-    .custom((value, { req }) => checkDateFieldYear(ErrorMessages.YEAR, req.body["identity_date-day"], req.body["identity_date-month"], req.body["identity_date-year"])),
+  body("identity_date-year")
+    .custom((value, { req }) => checkDateFieldYear(ErrorMessages.YEAR, ErrorMessages.YEAR_LENGTH, req.body["identity_date-day"], req.body["identity_date-month"], req.body["identity_date-year"])),
   body("identity_date")
     .custom((value, { req }) => checkIdentityDate(req.body["identity_date-day"], req.body["identity_date-month"], req.body["identity_date-year"])),
 ];

--- a/src/validation/fields/date.validation.ts
+++ b/src/validation/fields/date.validation.ts
@@ -10,7 +10,7 @@ import {
 import { ErrorMessages } from "../error.messages";
 
 // to prevent more than 1 error reported on the date fields we check if the year is valid before doing some checks.
-// This means that teh year check is checked before some others
+// This means that the year check is checked before some others
 export const start_date_validations = [
   body("start_date-day")
     .if(body("start_date-year").isLength({ min: 4, max: 4 }))
@@ -25,7 +25,7 @@ export const start_date_validations = [
 ];
 
 // to prevent more than 1 error reported on the date fields we check if the year is valid before doing some checks.
-// This means that teh year check is checked before some others
+// This means that the year check is checked before some others
 export const date_of_birth_validations = [
   body("date_of_birth-day")
     .if(body("date_of_birth-year").isLength({ min: 4, max: 4 }))
@@ -40,7 +40,7 @@ export const date_of_birth_validations = [
 ];
 
 // to prevent more than 1 error reported on the date fields we check if the year is valid before doing some checks.
-// This means that teh year check is checked before some others
+// This means that the year check is checked before some others
 export const identity_check_date_validations = [
   body("identity_date-day")
     .if(body("identity_date-year").isLength({ min: 4, max: 4 }))

--- a/src/validation/fields/date.validation.ts
+++ b/src/validation/fields/date.validation.ts
@@ -9,10 +9,14 @@ import {
 } from "../custom.validation";
 import { ErrorMessages } from "../error.messages";
 
+// to prevent more than 1 error reported on the date fields we check if the year is valid before doing some checks.
+// This means that teh year check is checked before some others
 export const start_date_validations = [
   body("start_date-day")
+    .if(body("start_date-year").isLength({ min: 4, max: 4 }))
     .custom((value, { req }) => checkDateFieldDay(ErrorMessages.DAY, req.body["start_date-day"], req.body["start_date-month"], req.body["start_date-year"])),
   body("start_date-month")
+    .if(body("start_date-year").isLength({ min: 4, max: 4 }))
     .custom((value, { req }) => checkDateFieldMonth(ErrorMessages.MONTH, req.body["start_date-day"], req.body["start_date-month"], req.body["start_date-year"])),
   body("start_date-year")
     .custom((value, { req }) => checkDateFieldYear(ErrorMessages.YEAR, ErrorMessages.YEAR_LENGTH, req.body["start_date-day"], req.body["start_date-month"], req.body["start_date-year"])),
@@ -20,10 +24,14 @@ export const start_date_validations = [
     .custom((value, { req }) => checkStartDate(req.body["start_date-day"], req.body["start_date-month"], req.body["start_date-year"])),
 ];
 
+// to prevent more than 1 error reported on the date fields we check if the year is valid before doing some checks.
+// This means that teh year check is checked before some others
 export const date_of_birth_validations = [
   body("date_of_birth-day")
+    .if(body("date_of_birth-year").isLength({ min: 4, max: 4 }))
     .custom((value, { req }) => checkDateFieldDay(ErrorMessages.DAY_OF_BIRTH, req.body["date_of_birth-day"], req.body["date_of_birth-month"], req.body["date_of_birth-year"])),
   body("date_of_birth-month")
+    .if(body("date_of_birth-year").isLength({ min: 4, max: 4 }))
     .custom((value, { req }) => checkDateFieldMonth(ErrorMessages.MONTH_OF_BIRTH, req.body["date_of_birth-day"], req.body["date_of_birth-month"], req.body["date_of_birth-year"])),
   body("date_of_birth-year")
     .custom((value, { req }) => checkDateFieldYear(ErrorMessages.YEAR_OF_BIRTH, ErrorMessages.DATE_OF_BIRTH_YEAR_LENGTH, req.body["date_of_birth-day"], req.body["date_of_birth-month"], req.body["date_of_birth-year"])),
@@ -31,10 +39,14 @@ export const date_of_birth_validations = [
     .custom((value, { req }) => checkDateOfBirth(req.body["date_of_birth-day"], req.body["date_of_birth-month"], req.body["date_of_birth-year"])),
 ];
 
+// to prevent more than 1 error reported on the date fields we check if the year is valid before doing some checks.
+// This means that teh year check is checked before some others
 export const identity_check_date_validations = [
   body("identity_date-day")
+    .if(body("identity_date-year").isLength({ min: 4, max: 4 }))
     .custom((value, { req }) => checkDateFieldDay(ErrorMessages.DAY, req.body["identity_date-day"], req.body["identity_date-month"], req.body["identity_date-year"])),
   body("identity_date-month")
+    .if(body("identity_date-year").isLength({ min: 4, max: 4 }))
     .custom((value, { req }) => checkDateFieldMonth(ErrorMessages.MONTH, req.body["identity_date-day"], req.body["identity_date-month"], req.body["identity_date-year"])),
   body("identity_date-year")
     .custom((value, { req }) => checkDateFieldYear(ErrorMessages.YEAR, ErrorMessages.YEAR_LENGTH, req.body["identity_date-day"], req.body["identity_date-month"], req.body["identity_date-year"])),

--- a/src/validation/overseas.entity.due.diligence.validation.ts
+++ b/src/validation/overseas.entity.due.diligence.validation.ts
@@ -13,13 +13,16 @@ import { email_validations } from "./fields/email.validation";
 
 export const overseasEntityDueDiligence = [
 
-  body("identity_date")
+  body("identity_date-day")
     .custom((value, { req }) => checkDateFieldDay(ErrorMessages.DAY, req.body["identity_date-day"], req.body["identity_date-month"], req.body["identity_date-year"])),
-  body("identity_date")
+  body("identity_date-month")
     .custom((value, { req }) => checkDateFieldMonth(ErrorMessages.MONTH, req.body["identity_date-day"], req.body["identity_date-month"], req.body["identity_date-year"])),
+  body("identity_date-year")
+    .custom((value, { req }) => checkDateFieldYear(ErrorMessages.YEAR, req.body["identity_date-day"], req.body["identity_date-month"], req.body["identity_date-year"]))
+    .bail()
+    .isLength({ min: 4, max: 4 }).withMessage(ErrorMessages.YEAR_LENGTH),
   body("identity_date")
-    .custom((value, { req }) => checkDateFieldYear(ErrorMessages.YEAR, req.body["identity_date-day"], req.body["identity_date-month"], req.body["identity_date-year"])),
-  body("identity_date")
+    .if(body("identity_date-year").isLength({ min: 4, max: 4 }))
     .custom((value, { req }) => checkOptionalDate(req.body["identity_date-day"], req.body["identity_date-month"], req.body["identity_date-year"])),
 
   body("name")

--- a/src/validation/overseas.entity.due.diligence.validation.ts
+++ b/src/validation/overseas.entity.due.diligence.validation.ts
@@ -18,11 +18,8 @@ export const overseasEntityDueDiligence = [
   body("identity_date-month")
     .custom((value, { req }) => checkDateFieldMonth(ErrorMessages.MONTH, req.body["identity_date-day"], req.body["identity_date-month"], req.body["identity_date-year"])),
   body("identity_date-year")
-    .custom((value, { req }) => checkDateFieldYear(ErrorMessages.YEAR, req.body["identity_date-day"], req.body["identity_date-month"], req.body["identity_date-year"]))
-    .bail()
-    .isLength({ min: 4, max: 4 }).withMessage(ErrorMessages.YEAR_LENGTH),
+    .custom((value, { req }) => checkDateFieldYear(ErrorMessages.YEAR, ErrorMessages.YEAR_LENGTH, req.body["identity_date-day"], req.body["identity_date-month"], req.body["identity_date-year"])),
   body("identity_date")
-    .if(body("identity_date-year").isLength({ min: 4, max: 4 }))
     .custom((value, { req }) => checkOptionalDate(req.body["identity_date-day"], req.body["identity_date-month"], req.body["identity_date-year"])),
 
   body("name")

--- a/test/controllers/beneficial.owner.gov.controller.spec.ts
+++ b/test/controllers/beneficial.owner.gov.controller.spec.ts
@@ -444,7 +444,7 @@ describe("BENEFICIAL OWNER GOV controller", () => {
       expect(mockSaveAndContinue).not.toHaveBeenCalled();
     });
 
-    test(`renders the current page ${config.BENEFICIAL_OWNER_GOV_PAGE} with only YEAR_LENGTH error when invalid charcters are used`, async () => {
+    test(`renders the current page ${config.BENEFICIAL_OWNER_GOV_PAGE} with only YEAR_LENGTH error when invalid characters are used`, async () => {
       const beneficialOwnerGov = { ...REQ_BODY_BENEFICIAL_OWNER_GOV_FOR_DATE_VALIDATION };
       beneficialOwnerGov["start_date-day"] =  "a";
       beneficialOwnerGov["start_date-month"] = "b";

--- a/test/controllers/beneficial.owner.gov.controller.spec.ts
+++ b/test/controllers/beneficial.owner.gov.controller.spec.ts
@@ -444,11 +444,11 @@ describe("BENEFICIAL OWNER GOV controller", () => {
       expect(mockSaveAndContinue).not.toHaveBeenCalled();
     });
 
-    test(`renders the current page ${config.BENEFICIAL_OWNER_GOV_PAGE} with only INVALID_DATE error when invalid characters are used`, async () => {
+    test(`renders the current page ${config.BENEFICIAL_OWNER_GOV_PAGE} with only INVALID_DATE error when invalid date is used`, async () => {
       const beneficialOwnerGov = { ...REQ_BODY_BENEFICIAL_OWNER_GOV_FOR_DATE_VALIDATION };
-      beneficialOwnerGov["start_date-day"] =  "a";
-      beneficialOwnerGov["start_date-month"] = "b";
-      beneficialOwnerGov["start_date-year"] = "c";
+      beneficialOwnerGov["start_date-day"] =  "11";
+      beneficialOwnerGov["start_date-month"] = "33";
+      beneficialOwnerGov["start_date-year"] = "2022";
       const resp = await request(app)
         .post(config.BENEFICIAL_OWNER_GOV_URL)
         .send(beneficialOwnerGov);

--- a/test/controllers/beneficial.owner.gov.controller.spec.ts
+++ b/test/controllers/beneficial.owner.gov.controller.spec.ts
@@ -444,6 +444,25 @@ describe("BENEFICIAL OWNER GOV controller", () => {
       expect(mockSaveAndContinue).not.toHaveBeenCalled();
     });
 
+    test(`renders the current page ${config.BENEFICIAL_OWNER_GOV_PAGE} with only YEAR_LENGTH error when invalid charcters are used`, async () => {
+      const beneficialOwnerGov = { ...REQ_BODY_BENEFICIAL_OWNER_GOV_FOR_DATE_VALIDATION };
+      beneficialOwnerGov["start_date-day"] =  "a";
+      beneficialOwnerGov["start_date-month"] = "b";
+      beneficialOwnerGov["start_date-year"] = "c";
+      const resp = await request(app)
+        .post(config.BENEFICIAL_OWNER_GOV_URL)
+        .send(beneficialOwnerGov);
+      expect(resp.status).toEqual(200);
+      expect(resp.text).toContain(BENEFICIAL_OWNER_GOV_PAGE_HEADING);
+      expect(resp.text).not.toContain(ErrorMessages.ENTER_DATE);
+      expect(resp.text).not.toContain(ErrorMessages.DAY);
+      expect(resp.text).not.toContain(ErrorMessages.MONTH);
+      expect(resp.text).not.toContain(ErrorMessages.YEAR);
+      expect(resp.text).toContain(ErrorMessages.YEAR_LENGTH);
+      expect(resp.text).not.toContain(ErrorMessages.DATE_NOT_IN_PAST_OR_TODAY);
+      expect(mockSaveAndContinue).not.toHaveBeenCalled();
+    });
+
     test(`renders the current page ${config.BENEFICIAL_OWNER_GOV_PAGE} with only INVALID_DATE error when invalid date is used`, async () => {
       const beneficialOwnerGov = { ...REQ_BODY_BENEFICIAL_OWNER_GOV_FOR_DATE_VALIDATION };
       beneficialOwnerGov["start_date-day"] =  "11";

--- a/test/controllers/managing.officer.controller.spec.ts
+++ b/test/controllers/managing.officer.controller.spec.ts
@@ -591,6 +591,25 @@ describe("MANAGING_OFFICER controller", () => {
       expect(mockSaveAndContinue).not.toHaveBeenCalled();
     });
 
+    test(`renders the current page ${MANAGING_OFFICER_PAGE} with only INVALID_DATE_OF_BIRTH error when invalid characters are used`, async () => {
+      const managingOfficer = { ...REQ_BODY_MANAGING_OFFICER_FOR_DATE_VALIDATION };
+      managingOfficer["date_of_birth-day"] =  "a";
+      managingOfficer["date_of_birth-month"] = "b";
+      managingOfficer["date_of_birth-year"] = "c";
+      const resp = await request(app)
+        .post(MANAGING_OFFICER_URL)
+        .send(managingOfficer);
+      expect(resp.status).toEqual(200);
+      expect(resp.text).toContain(MANAGING_OFFICER_PAGE_HEADING);
+      expect(resp.text).not.toContain(ErrorMessages.ENTER_DATE_OF_BIRTH);
+      expect(resp.text).not.toContain(ErrorMessages.DAY_OF_BIRTH);
+      expect(resp.text).not.toContain(ErrorMessages.MONTH_OF_BIRTH);
+      expect(resp.text).not.toContain(ErrorMessages.YEAR_OF_BIRTH);
+      expect(resp.text).toContain(ErrorMessages.DATE_OF_BIRTH_YEAR_LENGTH);
+      expect(resp.text).not.toContain(ErrorMessages.DATE_OF_BIRTH_NOT_IN_PAST);
+      expect(mockSaveAndContinue).not.toHaveBeenCalled();
+    });
+
     test(`renders the current page ${MANAGING_OFFICER_PAGE} with only INVALID_DATE_OF_BIRTH error when invalid date is used`, async () => {
       const managingOfficer = { ...REQ_BODY_MANAGING_OFFICER_FOR_DATE_VALIDATION };
       managingOfficer["date_of_birth-day"] =  "35";

--- a/test/controllers/managing.officer.controller.spec.ts
+++ b/test/controllers/managing.officer.controller.spec.ts
@@ -591,11 +591,11 @@ describe("MANAGING_OFFICER controller", () => {
       expect(mockSaveAndContinue).not.toHaveBeenCalled();
     });
 
-    test(`renders the current page ${MANAGING_OFFICER_PAGE} with only INVALID_DATE_OF_BIRTH error when invalid characters are used`, async () => {
+    test(`renders the current page ${MANAGING_OFFICER_PAGE} with only INVALID_DATE_OF_BIRTH error when invalid date is used`, async () => {
       const managingOfficer = { ...REQ_BODY_MANAGING_OFFICER_FOR_DATE_VALIDATION };
-      managingOfficer["date_of_birth-day"] =  "a";
-      managingOfficer["date_of_birth-month"] = "b";
-      managingOfficer["date_of_birth-year"] = "c";
+      managingOfficer["date_of_birth-day"] =  "35";
+      managingOfficer["date_of_birth-month"] = "15";
+      managingOfficer["date_of_birth-year"] = "2022";
       const resp = await request(app)
         .post(MANAGING_OFFICER_URL)
         .send(managingOfficer);

--- a/views/includes/inputs/date/date-of-birth-input.html
+++ b/views/includes/inputs/date/date-of-birth-input.html
@@ -3,11 +3,19 @@
 {% set isDobMonthError = false %}
 {% set isDobYearError = false %}
 
+{# We are constrained by the generic validation handling so have to manipulate the error data in the template rather than the controller #}
+{# We need to loop through the errors returned to pick out the first date_of_birth error #}
+{# to prevent duplicate messages on the same field. #}
+{# We can use its message text and then work out which of the day/month/year fields #}
+{# to mark as 'red' using the error style class #}
+
 {% if errors %}
   {% for key, value in errors %}
 
+    {# only look at first matching error #}
     {% if not dobErrorMessage %}
       {% if "date_of_birth" == key|string %}
+        {# if the matching error is for the whole date field, look at the data to see what has not been populated in the date #}
         {% set dobErrorMessage = value %}
         {% if date_of_birth %}
           {% if not date_of_birth["date_of_birth-day"] %}
@@ -21,6 +29,7 @@
           {% endif %}
         {% endif %}
       {% elif "date_of_birth" in key|string %}
+        {# if the matching error is for a -day,-month,-year field, set the flag to mark that field as in error #}
         {% set dobErrorMessage = value %}
         {% if "-day" in key|string %}
           {% set isDobDayError = true %}

--- a/views/includes/inputs/date/date-of-birth-input.html
+++ b/views/includes/inputs/date/date-of-birth-input.html
@@ -1,5 +1,58 @@
+{% set dobErrorMessage = '' %}
+{% set isDobDayError = false %}
+{% set isDobMonthError = false %}
+{% set isDobYearError = false %}
+
+{% if errors %}
+  {% for key, value in errors %}
+
+    {% if not dobErrorMessage %}
+      {% if "date_of_birth" == key|string %}
+        {% set dobErrorMessage = value %}
+        {% if date_of_birth %}
+          {% if not date_of_birth["date_of_birth-day"] %}
+            {% set isDobDayError = true %}
+          {% endif %}
+          {% if not date_of_birth["date_of_birth-month"] %}
+            {% set isDobMonthError = true %}
+          {% endif %}
+          {% if not date_of_birth["date_of_birth-year"] %}
+            {% set isDobYearError = true %}
+          {% endif %}
+        {% endif %}
+      {% elif "date_of_birth" in key|string %}
+        {% set dobErrorMessage = value %}
+        {% if "-day" in key|string %}
+          {% set isDobDayError = true %}
+        {% elif "-month" in key|string %} 
+          {% set isDobMonthError = true %}
+        {% elif "-year" in key|string %} 
+          {% set isDobYearError = true %}
+        {% endif %}
+      {% endif %}
+    {% endif %}
+  {% endfor %}    
+{% endif %}
+
+
+{% set date_of_birth_classes_year = "govuk-input--width-4 govuk-input" %}
+{% set date_of_birth_classes_month = "govuk-input--width-2 govuk-input" %}
+{% set date_of_birth_classes_day = "govuk-input--width-2 govuk-input" %}
+
+{% if isDobDayError %}
+  {% set date_of_birth_classes_day = date_of_birth_classes_day + "--error" %}
+{% endif %}
+{% if isDobMonthError %}
+  {% set date_of_birth_classes_month = date_of_birth_classes_month + "--error" %}
+{% endif %}
+{% if isDobYearError %}
+  {% set date_of_birth_classes_year = date_of_birth_classes_year + "--error" %}
+{% endif %}
+
+
+
 {{ govukDateInput({
-  errorMessage: errors.date_of_birth if errors,
+  errorMessage: dobErrorMessage,
   id: "date_of_birth",
   namePrefix: "date_of_birth",
   fieldset: {
@@ -14,17 +67,17 @@
   },
   items: [
     {
-      classes: "govuk-input--width-2 govuk-input",
+      classes: date_of_birth_classes_day,
       name: "day",
       value: date_of_birth["date_of_birth-day"] if date_of_birth
     },
     {
-      classes: "govuk-input--width-2 govuk-input",
+      classes: date_of_birth_classes_month,
       name: "month",
       value: date_of_birth["date_of_birth-month"] if date_of_birth
     },
     {
-      classes: "govuk-input--width-4 govuk-input",
+      classes: date_of_birth_classes_year,
       name: "year",
       value: date_of_birth["date_of_birth-year"] if date_of_birth
     }

--- a/views/includes/inputs/date/identity-date-input.html
+++ b/views/includes/inputs/date/identity-date-input.html
@@ -34,18 +34,18 @@
 {% endif %}
 
 
-{% set identity_date_classes_year = "govuk-input--width-4" %}
-{% set identity_date_classes_month = "govuk-input--width-2" %}
-{% set identity_date_classes_day = "govuk-input--width-2" %}
+{% set identity_date_classes_year = "govuk-input--width-4 govuk-input" %}
+{% set identity_date_classes_month = "govuk-input--width-2 govuk-input" %}
+{% set identity_date_classes_day = "govuk-input--width-2 govuk-input" %}
 
 {% if isIdentityDateDayError %}
-  {% set identity_date_classes_day = identity_date_classes_day + " govuk-input--error" %}
+  {% set identity_date_classes_day = identity_date_classes_day + "--error" %}
 {% endif %}
 {% if isIdentityDateMonthError %}
-  {% set identity_date_classes_month = identity_date_classes_month + " govuk-input--error" %}
+  {% set identity_date_classes_month = identity_date_classes_month + "--error" %}
 {% endif %}
 {% if isIdentityDateYearError %}
-  {% set identity_date_classes_year = identity_date_classes_year + " govuk-input--error" %}
+  {% set identity_date_classes_year = identity_date_classes_year + "--error" %}
 {% endif %}
 
 {{ govukDateInput({

--- a/views/includes/inputs/date/identity-date-input.html
+++ b/views/includes/inputs/date/identity-date-input.html
@@ -1,4 +1,4 @@
-{% set errorMess = '' %}
+{% set identityDateErrorMsg = '' %}
 {% set isIdentityDateDayError = false %}
 {% set isIdentityDateMonthError = false %}
 {% set isIdentityDateYearError = false %}
@@ -7,7 +7,7 @@
   {% for key, value in errors %}
 
     {% if "identity_date" == key|string %}
-      {% set errorMess = value %}
+      {% set identityDateErrorMsg = value %}
       {% if identity_date %}
         {% if not identity_date["identity_date-day"] %}
           {% set isIdentityDateDayError = true %}
@@ -19,8 +19,8 @@
           {% set isIdentityDateYearError = true %}
         {% endif %}
       {% endif %}
-    {% elif not errorMess and "identity_date" in key|string %}
-      {% set errorMess = value %}
+    {% elif not identityDateErrorMsg and "identity_date" in key|string %}
+      {% set identityDateErrorMsg = value %}
       {% if "-day" in key|string %}
         {% set isIdentityDateDayError = true %}
       {% elif "-month" in key|string %} 
@@ -49,7 +49,7 @@
 {% endif %}
 
 {{ govukDateInput({
-  errorMessage: errorMess,
+  errorMessage: identityDateErrorMsg,
   id: "identity_date",
   namePrefix: "identity_date",
   fieldset: {

--- a/views/includes/inputs/date/identity-date-input.html
+++ b/views/includes/inputs/date/identity-date-input.html
@@ -1,5 +1,55 @@
+{% set errorMess = '' %}
+{% set isIdentityDateDayError = false %}
+{% set isIdentityDateMonthError = false %}
+{% set isIdentityDateYearError = false %}
+
+{% if errors %}
+  {% for key, value in errors %}
+
+    {% if "identity_date" == key|string %}
+      {% set errorMess = value %}
+      {% if identity_date %}
+        {% if not identity_date["identity_date-day"] %}
+          {% set isIdentityDateDayError = true %}
+        {% endif %}
+        {% if not identity_date["identity_date-month"] %}
+          {% set isIdentityDateMonthError = true %}
+        {% endif %}
+        {% if not identity_date["identity_date-year"] %}
+          {% set isIdentityDateYearError = true %}
+        {% endif %}
+      {% endif %}
+    {% elif not errorMess and "identity_date" in key|string %}
+      {% set errorMess = value %}
+      {% if "-day" in key|string %}
+        {% set isIdentityDateDayError = true %}
+      {% elif "-month" in key|string %} 
+        {% set isIdentityDateMonthError = true %}
+      {% elif "-year" in key|string %} 
+        {% set isIdentityDateYearError = true %}
+      {% endif %}
+
+    {% endif %}
+  {% endfor %}    
+{% endif %}
+
+
+{% set identity_date_classes_year = "govuk-input--width-4" %}
+{% set identity_date_classes_month = "govuk-input--width-2" %}
+{% set identity_date_classes_day = "govuk-input--width-2" %}
+
+{% if isIdentityDateDayError %}
+  {% set identity_date_classes_day = identity_date_classes_day + " govuk-input--error" %}
+{% endif %}
+{% if isIdentityDateMonthError %}
+  {% set identity_date_classes_month = identity_date_classes_month + " govuk-input--error" %}
+{% endif %}
+{% if isIdentityDateYearError %}
+  {% set identity_date_classes_year = identity_date_classes_year + " govuk-input--error" %}
+{% endif %}
+
 {{ govukDateInput({
-  errorMessage: errors.identity_date if errors,
+  errorMessage: errorMess,
   id: "identity_date",
   namePrefix: "identity_date",
   fieldset: {
@@ -14,17 +64,17 @@
   },
   items: [
     {
-      classes: "govuk-input--width-2 govuk-input",
+      classes: identity_date_classes_day,
       name: "day",
       value: identity_date["identity_date-day"] if identity_date
     },
     {
-      classes: "govuk-input--width-2 govuk-input",
+      classes: identity_date_classes_month,
       name: "month",
       value: identity_date["identity_date-month"] if identity_date
     },
     {
-      classes: "govuk-input--width-4 govuk-input",
+      classes: identity_date_classes_year,
       name: "year",
       value: identity_date["identity_date-year"] if identity_date
     }

--- a/views/includes/inputs/date/identity-date-input.html
+++ b/views/includes/inputs/date/identity-date-input.html
@@ -3,32 +3,42 @@
 {% set isIdentityDateMonthError = false %}
 {% set isIdentityDateYearError = false %}
 
+{# We are constrained by the generic validation handling so have to manipulate the error data in the template rather than the controller #}
+{# We need to loop through the errors returned to pick out the first identity_date error #}
+{# to prevent duplicate messages on the same field. #}
+{# We can use its message text and then work out which of the day/month/year fields #}
+{# to mark as 'red' using the error style class #}
+
 {% if errors %}
   {% for key, value in errors %}
 
-    {% if "identity_date" == key|string %}
-      {% set identityDateErrorMsg = value %}
-      {% if identity_date %}
-        {% if not identity_date["identity_date-day"] %}
+    {# only look at first matching error #}
+    {% if not identityDateErrorMsg %}
+      {% if "identity_date" == key|string %}
+        {# if the matching error is for the whole date field, look at the data to see what has not been populated in the date #}
+        {% set identityDateErrorMsg = value %}
+        {% if identity_date %}
+          {% if not identity_date["identity_date-day"] %}
+            {% set isIdentityDateDayError = true %}
+          {% endif %}
+          {% if not identity_date["identity_date-month"] %}
+            {% set isIdentityDateMonthError = true %}
+          {% endif %}
+          {% if not identity_date["identity_date-year"] %}
+            {% set isIdentityDateYearError = true %}
+          {% endif %}
+        {% endif %}
+      {% elif "identity_date" in key|string %}
+        {# if the matching error is for a -day,-month,-year field, set the flag to mark that field as in error #}
+        {% set identityDateErrorMsg = value %}
+        {% if "-day" in key|string %}
           {% set isIdentityDateDayError = true %}
-        {% endif %}
-        {% if not identity_date["identity_date-month"] %}
+        {% elif "-month" in key|string %} 
           {% set isIdentityDateMonthError = true %}
-        {% endif %}
-        {% if not identity_date["identity_date-year"] %}
+        {% elif "-year" in key|string %} 
           {% set isIdentityDateYearError = true %}
         {% endif %}
       {% endif %}
-    {% elif not identityDateErrorMsg and "identity_date" in key|string %}
-      {% set identityDateErrorMsg = value %}
-      {% if "-day" in key|string %}
-        {% set isIdentityDateDayError = true %}
-      {% elif "-month" in key|string %} 
-        {% set isIdentityDateMonthError = true %}
-      {% elif "-year" in key|string %} 
-        {% set isIdentityDateYearError = true %}
-      {% endif %}
-
     {% endif %}
   {% endfor %}    
 {% endif %}

--- a/views/includes/inputs/date/start-date-input.html
+++ b/views/includes/inputs/date/start-date-input.html
@@ -3,11 +3,19 @@
 {% set isStartDateMonthError = false %}
 {% set isStartDateYearError = false %}
 
+{# We are constrained by the generic validation handling so have to manipulate the error data in the template rather than the controller #}
+{# We need to loop through the errors returned to pick out the first start_date error #}
+{# to prevent duplicate messages on the same field. #}
+{# We can use its message text and then work out which of the day/month/year fields #}
+{# to mark as 'red' using the error style class #}
+
 {% if errors %}
   {% for key, value in errors %}
 
+    {# only look at first matching error #}
     {% if not startDateErrorMessage %}
       {% if "start_date" == key|string %}
+        {# if the matching error is for the whole date field, look at the data to see what has not been populated in the date #}
         {% set startDateErrorMessage = value %}
         {% if start_date %}
           {% if not start_date["start_date-day"] %}
@@ -21,6 +29,7 @@
           {% endif %}
         {% endif %}
       {% elif "start_date" in key|string %}
+        {# if the matching error is for a -day,-month,-year field, set the flag to mark that field as in error #}
         {% set startDateErrorMessage = value %}
         {% if "-day" in key|string %}
           {% set isStartDateDayError = true %}

--- a/views/includes/inputs/date/start-date-input.html
+++ b/views/includes/inputs/date/start-date-input.html
@@ -1,5 +1,57 @@
+{% set startDateErrorMessage = '' %}
+{% set isStartDateDayError = false %}
+{% set isStartDateMonthError = false %}
+{% set isStartDateYearError = false %}
+
+{% if errors %}
+  {% for key, value in errors %}
+
+    {% if not startDateErrorMessage %}
+      {% if "start_date" == key|string %}
+        {% set startDateErrorMessage = value %}
+        {% if start_date %}
+          {% if not start_date["start_date-day"] %}
+            {% set isStartDateDayError = true %}
+          {% endif %}
+          {% if not start_date["start_date-month"] %}
+            {% set isStartDateMonthError = true %}
+          {% endif %}
+          {% if not start_date["start_date-year"] %}
+            {% set isStartDateYearError = true %}
+          {% endif %}
+        {% endif %}
+      {% elif "start_date" in key|string %}
+        {% set startDateErrorMessage = value %}
+        {% if "-day" in key|string %}
+          {% set isStartDateDayError = true %}
+        {% elif "-month" in key|string %} 
+          {% set isStartDateMonthError = true %}
+        {% elif "-year" in key|string %} 
+          {% set isStartDateYearError = true %}
+        {% endif %}
+      {% endif %}
+    {% endif %}
+  {% endfor %}    
+{% endif %}
+
+
+{% set start_date_classes_year = "govuk-input--width-4 govuk-input" %}
+{% set start_date_classes_month = "govuk-input--width-2 govuk-input" %}
+{% set start_date_classes_day = "govuk-input--width-2 govuk-input" %}
+
+{% if isStartDateDayError %}
+  {% set start_date_classes_day = start_date_classes_day + "--error" %}
+{% endif %}
+{% if isStartDateMonthError %}
+  {% set start_date_classes_month = start_date_classes_month + "--error" %}
+{% endif %}
+{% if isStartDateYearError %}
+  {% set start_date_classes_year = start_date_classes_year + "--error" %}
+{% endif %}
+
+
 {{ govukDateInput({
-  errorMessage: errors.start_date if errors,
+  errorMessage: startDateErrorMessage,
   id: "start_date",
   namePrefix: "start_date",
   fieldset: {
@@ -14,17 +66,17 @@
   },
   items: [
     {
-      classes: "govuk-input--width-2 govuk-input",
+      classes: start_date_classes_day,
       name: "day",
       value: start_date["start_date-day"] if start_date
     },
     {
-      classes: "govuk-input--width-2 govuk-input",
+      classes: start_date_classes_month,
       name: "month",
       value: start_date["start_date-month"] if start_date
     },
     {
-      classes: "govuk-input--width-4 govuk-input",
+      classes: start_date_classes_year,
       name: "year",
       value: start_date["start_date-year"] if start_date
     }

--- a/views/overseas-entity-due-diligence.html
+++ b/views/overseas-entity-due-diligence.html
@@ -14,6 +14,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
+      <p>{{errors | dump | safe}}</p>
       {% include "includes/list/errors.html" %}
 
       <h1 class="govuk-heading-xl">Tell us about the UK-regulated agent that carried out verification checks</h1>

--- a/views/overseas-entity-due-diligence.html
+++ b/views/overseas-entity-due-diligence.html
@@ -14,7 +14,6 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-      <p>{{errors | dump | safe}}</p>
       {% include "includes/list/errors.html" %}
 
       <h1 class="govuk-heading-xl">Tell us about the UK-regulated agent that carried out verification checks</h1>


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/ROE-1933

### Change description
Added year length checks to the other validation checks to prevent > 1 date error being fired. This means that the date length check is a higher priority than the 'all in one' date check (invalid date etc...)

Had to add a for loop in the template includes to determine what part of the date to highlight red. Works of the field name being present in the errors list. Tried to make it generic but struggled with variable scopes when used as an include. So had to repeat it for each of the 3 date includes.


### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
