### PR TITLE
ROE-1724 Remove duplicated register error message at top of page

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -14,6 +14,7 @@ import router from "./routes";
 import errorHandler from "./controllers/error.controller";
 import { createChangeLinkConfig, createSummaryListLink } from "./utils/change.link";
 import { countryFilter } from "./utils/country.filter";
+import { ErrorMessages } from "./validation/error.messages";
 
 const app = express();
 
@@ -34,6 +35,7 @@ const nunjucksEnv = nunjucks.configure([
 nunjucksEnv.addGlobal("CDN_HOST", config.CDN_HOST);
 nunjucksEnv.addGlobal("SERVICE_NAME", config.SERVICE_NAME);
 nunjucksEnv.addGlobal("OE_CONFIGS", config);
+nunjucksEnv.addGlobal("ERROR_MESSAGES", ErrorMessages);
 nunjucksEnv.addGlobal("COUNTRY_FILTER", countryFilter );
 nunjucksEnv.addGlobal("CREATE_CHANGE_LINK", createChangeLinkConfig);
 nunjucksEnv.addGlobal("SUMMARY_LIST_LINK", createSummaryListLink);

--- a/src/validation/beneficial.owner.type.validation.submission.ts
+++ b/src/validation/beneficial.owner.type.validation.submission.ts
@@ -3,5 +3,5 @@ import { checkBeneficialOwnersSubmission } from "./custom.validation";
 
 export const beneficialOwnersTypeSubmission = [
   body("beneficial_owner_type")
-    .custom((value, { req }) =>  checkBeneficialOwnersSubmission(req))
+    .custom((value, { req }) => checkBeneficialOwnersSubmission(req))
 ];

--- a/src/validation/custom.validation.ts
+++ b/src/validation/custom.validation.ts
@@ -234,7 +234,7 @@ export const checkSecondNationality = (nationality: string = "", secondNationali
   return true;
 };
 
-export const checkPublicRegisterJurisdiction = (public_register_name: string = "", public_register_jurisdiction: string = "") => {
+export const checkPublicRegisterJurisdictionLength = (public_register_name: string = "", public_register_jurisdiction: string = "") => {
 
   if (public_register_name && public_register_jurisdiction && `${public_register_name}${CONCATENATED_VALUES_SEPARATOR}${public_register_jurisdiction}`.length > 160) {
     throw new Error(ErrorMessages.MAX_ENTITY_PUBLIC_REGISTER_NAME_AND_JURISDICTION_LENGTH);

--- a/src/validation/fields/public-register.validation.ts
+++ b/src/validation/fields/public-register.validation.ts
@@ -15,8 +15,7 @@ export const entity_public_register_validations = [
     .custom((_, { req }) => checkPublicRegisterJurisdiction(req.body["public_register_name"], req.body["public_register_jurisdiction"])),
   body("public_register_jurisdiction")
     .custom((value, { req }) => checkFieldIfRadioButtonSelected(req.body.is_on_register_in_country_formed_in === '1', ErrorMessages.PUBLIC_REGISTER_JURISDICTION, value) )
-    .custom((value, { req }) => checkInvalidCharactersIfRadioButtonSelected(req.body.is_on_register_in_country_formed_in === '1', ErrorMessages.PUBLIC_REGISTER_JURISDICTION_INVALID_CHARACTERS, value) )
-    .custom((_, { req }) => checkPublicRegisterJurisdiction(req.body["public_register_name"], req.body["public_register_jurisdiction"])),
+    .custom((value, { req }) => checkInvalidCharactersIfRadioButtonSelected(req.body.is_on_register_in_country_formed_in === '1', ErrorMessages.PUBLIC_REGISTER_JURISDICTION_INVALID_CHARACTERS, value) ),
   body("registration_number")
     .custom((value, { req }) => checkFieldIfRadioButtonSelected(req.body.is_on_register_in_country_formed_in === '1', ErrorMessages.PUBLIC_REGISTER_NUMBER, value) )
     .custom((value, { req }) => checkMaxFieldIfRadioButtonSelected(req.body.is_on_register_in_country_formed_in === '1', ErrorMessages.MAX_ENTITY_PUBLIC_REGISTER_NUMBER_LENGTH, 32, value) )

--- a/src/validation/fields/public-register.validation.ts
+++ b/src/validation/fields/public-register.validation.ts
@@ -4,17 +4,19 @@ import {
   checkFieldIfRadioButtonSelected,
   checkInvalidCharactersIfRadioButtonSelected,
   checkMaxFieldIfRadioButtonSelected,
-  checkPublicRegisterJurisdiction
+  checkPublicRegisterJurisdictionLength
 } from "../custom.validation";
 import { ErrorMessages } from "../error.messages";
 
 export const entity_public_register_validations = [
   body("public_register_name")
     .custom((value, { req }) => checkFieldIfRadioButtonSelected(req.body.is_on_register_in_country_formed_in === '1', ErrorMessages.PUBLIC_REGISTER_NAME, value) )
-    .custom((value, { req }) => checkInvalidCharactersIfRadioButtonSelected(req.body.is_on_register_in_country_formed_in === '1', ErrorMessages.PUBLIC_REGISTER_NAME_INVALID_CHARACTERS, value) )
-    .custom((_, { req }) => checkPublicRegisterJurisdiction(req.body["public_register_name"], req.body["public_register_jurisdiction"])),
+    .custom((_, { req }) => checkPublicRegisterJurisdictionLength(req.body["public_register_name"], req.body["public_register_jurisdiction"]))
+    .bail()
+    .custom((value, { req }) => checkInvalidCharactersIfRadioButtonSelected(req.body.is_on_register_in_country_formed_in === '1', ErrorMessages.PUBLIC_REGISTER_NAME_INVALID_CHARACTERS, value) ),
   body("public_register_jurisdiction")
     .custom((value, { req }) => checkFieldIfRadioButtonSelected(req.body.is_on_register_in_country_formed_in === '1', ErrorMessages.PUBLIC_REGISTER_JURISDICTION, value) )
+    .if(body("public_register_name").custom((_, { req }) => checkPublicRegisterJurisdictionLength(req.body["public_register_name"], req.body["public_register_jurisdiction"])))
     .custom((value, { req }) => checkInvalidCharactersIfRadioButtonSelected(req.body.is_on_register_in_country_formed_in === '1', ErrorMessages.PUBLIC_REGISTER_JURISDICTION_INVALID_CHARACTERS, value) ),
   body("registration_number")
     .custom((value, { req }) => checkFieldIfRadioButtonSelected(req.body.is_on_register_in_country_formed_in === '1', ErrorMessages.PUBLIC_REGISTER_NUMBER, value) )

--- a/test/controllers/entity.controller.spec.ts
+++ b/test/controllers/entity.controller.spec.ts
@@ -337,7 +337,9 @@ describe("ENTITY controller", () => {
         .send(ENTITY_WITH_MAX_LENGTH_FIELDS_MOCK);
 
       expect(resp.status).toEqual(200);
-      expect(resp.text).toContain(ErrorMessages.MAX_ENTITY_PUBLIC_REGISTER_NAME_AND_JURISDICTION_LENGTH);
+      expect(resp.text).toContain("<a href=\"#public_register_name\">Name of register and jurisdiction must be 159 characters or less in total</a>");
+      expect(resp.text).toContain("  <p id=\"public_register_name-error\" class=\"govuk-error-message\">\n    <span class=\"govuk-visually-hidden\">Error:</span> Name of register and jurisdiction must be 159 characters or less in total\n  </p>");
+      expect(resp.text).toContain("  <p id=\"public_register_jurisdiction-error\" class=\"govuk-error-message\">\n    <span class=\"govuk-visually-hidden\">Error:</span> Name of register and jurisdiction must be 159 characters or less in total\n  </p>");
     });
 
     test("redirect to the next page when public register name and jurisdiction is just on maxlength", async () => {

--- a/views/includes/inputs/fields/public-register-jurisdiction-input.html
+++ b/views/includes/inputs/fields/public-register-jurisdiction-input.html
@@ -1,5 +1,5 @@
 {% if errors %}
-  {% if errors.public_register_name.text == 'Name of register and jurisdiction must be 159 characters or less in total'  %}
+  {% if errors.public_register_name.text == ERROR_MESSAGES.MAX_ENTITY_PUBLIC_REGISTER_NAME_AND_JURISDICTION_LENGTH  %}
     {% set errorMsg = errors.public_register_name %}
   {% else %}
     {% set errorMsg = errors.public_register_jurisdiction %}

--- a/views/includes/inputs/fields/public-register-jurisdiction-input.html
+++ b/views/includes/inputs/fields/public-register-jurisdiction-input.html
@@ -1,12 +1,19 @@
+{% if errors %}
+  {% if errors.public_register_name.text == 'Name of register and jurisdiction must be 159 characters or less in total'  %}
+    {% set errorMsg = errors.public_register_name %}
+  {% else %}
+    {% set errorMsg = errors.public_register_jurisdiction %}
+  {% endif %}
+{% endif %}
 {{ govukInput({
-  errorMessage: errors.public_register_jurisdiction if errors,
+  errorMessage: errorMsg if errors,
   id: "public_register_jurisdiction",
   name: "public_register_jurisdiction",
   value: public_register_jurisdiction,
-    hint: {
-      text: "For example, Jersey."
-    },
-    label: {
-     text: "Jurisdiction"
+  hint: {
+    text: "For example, Jersey."
+  },
+  label: {
+    text: "Jurisdiction"
   }
 }) }}


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/ROE-1724

### Change description

Removed length error from public register jurisdiction field validation
Added condition to allow name field validation to be used inline with jurisdiction; this allows there to be a single messages at the top and an inline message on both the name and jurisdiction fields.

### Work checklist

- [x] Tests added where applicable
- [x] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
