### PR TITLE
Feature/roe 1731 display former bo on trust involved page

### DIFF
--- a/src/controllers/trust.historical.beneficial.owner.controller.ts
+++ b/src/controllers/trust.historical.beneficial.owner.controller.ts
@@ -1,6 +1,7 @@
 import { NextFunction, Request, Response } from 'express';
 import * as config from '../config';
 import { logger } from '../utils/logger';
+import { TrusteeType } from '../model/trustee.type.model';
 import { getApplicationData, setExtraData } from '../utils/application.data';
 import { getTrustByIdFromApp, saveHistoricalBoInTrust, saveTrustInApp } from '../utils/trusts';
 import { mapBeneficialOwnerToSession } from '../utils/trust/historical.beneficial.owner.mapper';
@@ -21,6 +22,7 @@ type TrustHistoricalBeneficialOwnerProperties = {
   },
   pageData: {
     trustData: CommonTrustData,
+    trusteeType: typeof TrusteeType;
   },
   formData?: PageModel.TrustHistoricalBeneficialOwnerForm,
 };
@@ -39,6 +41,7 @@ const getPageProperties = (
     },
     pageData: {
       trustData: CommonTrustDataMapper.mapCommonTrustDataToPage(getApplicationData(req.session), trustId),
+      trusteeType: TrusteeType,
     },
     formData,
   };

--- a/src/controllers/trust.involved.controller.ts
+++ b/src/controllers/trust.involved.controller.ts
@@ -10,8 +10,8 @@ import { getApplicationData } from '../utils/application.data';
 import { mapCommonTrustDataToPage } from '../utils/trust/common.trust.data.mapper';
 import { mapTrustWhoIsInvolvedToPage } from '../utils/trust/who.is.involved.mapper';
 import { FormattedValidationErrors, formatValidationError } from '../middleware/validation.middleware';
-import { IndividualTrustee } from '../model/trust.model';
-import { getIndividualTrusteesFromTrust } from '../utils/trusts';
+import { IndividualTrustee, TrustHistoricalBeneficialOwner } from '../model/trust.model';
+import { getIndividualTrusteesFromTrust, getFormerTrusteesFromTrust } from '../utils/trusts';
 
 const TRUST_INVOLVED_TEXTS = {
   title: 'Individuals or entities involved in the trust',
@@ -37,6 +37,7 @@ type TrustInvolvedPageProperties = {
     trusteeTypeTitle: Record<string, string>;
     trusteeType: typeof TrusteeType;
     individualTrusteeData: IndividualTrustee[];
+    formerTrusteeData: TrustHistoricalBeneficialOwner[];
     checkYourAnswersUrl: string;
     beneficialOwnerUrlDetach: string;
     trustData: CommonTrustData,
@@ -66,6 +67,7 @@ const getPageProperties = (
       beneficialOwnerTypeTitle: TRUST_INVOLVED_TEXTS.boTypeTitle,
       trusteeTypeTitle: TRUST_INVOLVED_TEXTS.trusteeTypeTitle,
       individualTrusteeData: getIndividualTrusteesFromTrust(appData, trustId),
+      formerTrusteeData: getFormerTrusteesFromTrust(appData, trustId),
       trusteeType: TrusteeType,
       checkYourAnswersUrl: config.CHECK_YOUR_ANSWERS_URL,
       beneficialOwnerUrlDetach: `${config.TRUST_ENTRY_URL}/${trustId}${config.TRUST_BENEFICIAL_OWNER_DETACH_URL}`,
@@ -82,6 +84,8 @@ const get = (
 ): void => {
   try {
     logger.debugRequest(req, `${req.method} ${req.route.path}`);
+
+    logger.debugRequest(req, `${JSON.stringify(req.session)}`);
 
     const pageProps = getPageProperties(req);
 

--- a/src/controllers/trust.involved.controller.ts
+++ b/src/controllers/trust.involved.controller.ts
@@ -85,8 +85,6 @@ const get = (
   try {
     logger.debugRequest(req, `${req.method} ${req.route.path}`);
 
-    logger.debugRequest(req, `${JSON.stringify(req.session)}`);
-
     const pageProps = getPageProperties(req);
 
     return res.render(pageProps.templateName, pageProps);

--- a/src/model/trust.model.ts
+++ b/src/model/trust.model.ts
@@ -3,6 +3,7 @@ import { BeneficialOwnerOther } from '../model/beneficial.owner.other.model';
 import { BeneficialOwnerTypeChoice } from '../model/beneficial.owner.type.model';
 import { yesNoResponse } from './data.types.model';
 import { RoleWithinTrustType } from './role.within.trust.type.model';
+import { TrusteeType } from './trustee.type.model';
 
 export const TrustKey = "trusts";
 
@@ -66,11 +67,11 @@ interface TrustIndividual {
   sa_address_po_box?: string;
 }
 
-export type TrustHistoricalBeneficialOwnerType = BeneficialOwnerTypeChoice.individual | BeneficialOwnerTypeChoice.otherLegal;
+// export type TrustHistoricalBeneficialOwnerType = BeneficialOwnerTypeChoice.individual | BeneficialOwnerTypeChoice.otherLegal;
 
 interface TrustHistoricalBeneficialOwnerCommon {
   id?: string;
-  corporateIndicator: TrustHistoricalBeneficialOwnerType;
+  corporateIndicator: TrusteeType;
   ceased_date_day: string;
   ceased_date_month: string;
   ceased_date_year: string;

--- a/src/model/trust.model.ts
+++ b/src/model/trust.model.ts
@@ -67,8 +67,6 @@ interface TrustIndividual {
   sa_address_po_box?: string;
 }
 
-// export type TrustHistoricalBeneficialOwnerType = BeneficialOwnerTypeChoice.individual | BeneficialOwnerTypeChoice.otherLegal;
-
 interface TrustHistoricalBeneficialOwnerCommon {
   id?: string;
   corporateIndicator: TrusteeType;

--- a/src/model/trust.page.model.ts
+++ b/src/model/trust.page.model.ts
@@ -70,12 +70,12 @@ type IndividualTrusteesFormCommon = {
 };
 
 interface TrustHistoricalBeneficialOwnerFormLegal extends TrustHistoricalBeneficialOwnerFormCommon {
-  type: BeneficialOwnerTypeChoice.otherLegal;
+  type: TrusteeType.LEGAL_ENTITY;
   corporateName: string;
 }
 
 interface TrustHistoricalBeneficialOwnerFormIndividual extends TrustHistoricalBeneficialOwnerFormCommon {
-  type: BeneficialOwnerTypeChoice.individual;
+  type: TrusteeType.INDIVIDUAL;
   firstName: string;
   lastName: string;
 }

--- a/src/utils/trust/historical.beneficial.owner.mapper.ts
+++ b/src/utils/trust/historical.beneficial.owner.mapper.ts
@@ -1,5 +1,5 @@
 import { v4 as uuidv4 } from 'uuid';
-import { BeneficialOwnerTypeChoice } from '../../model/beneficial.owner.type.model';
+import { TrusteeType } from '../../model/trustee.type.model';
 import * as Trust from '../../model/trust.model';
 import * as Page from '../../model/trust.page.model';
 
@@ -8,7 +8,7 @@ const mapBeneficialOwnerToSession = (
 ): Trust.TrustHistoricalBeneficialOwner => {
   const data = {
     id: formData.boId || generateBoId(),
-    corporateIndicator: formData.type as Trust.TrustHistoricalBeneficialOwnerType,
+    corporateIndicator: formData.type as TrusteeType,
     ceased_date_day: formData.startDateDay,
     ceased_date_month: formData.startDateMonth,
     ceased_date_year: formData.startDateYear,
@@ -17,7 +17,7 @@ const mapBeneficialOwnerToSession = (
     notified_date_year: formData.endDateYear,
   };
 
-  if (formData.type === BeneficialOwnerTypeChoice.otherLegal) {
+  if (formData.type === TrusteeType.LEGAL_ENTITY) {
     return {
       ...data,
       corporateName: formData.corporateName,

--- a/src/utils/trusts.ts
+++ b/src/utils/trusts.ts
@@ -147,6 +147,22 @@ const getIndividualTrusteesFromTrust = (
   return individuals;
 };
 
+const getFormerTrusteesFromTrust = (
+  appData: ApplicationData,
+  trustId?: string,
+): TrustHistoricalBeneficialOwner[] => {
+  let formerTrustees: TrustHistoricalBeneficialOwner[] = [];
+  if (trustId) {
+    formerTrustees = appData[TrustKey]?.find(trust =>
+      trust?.trust_id === trustId)?.HISTORICAL_BO as TrustHistoricalBeneficialOwner[];
+  } else {
+    appData[TrustKey]?.map(trust => trust.HISTORICAL_BO?.map(formerTrustee => {
+      formerTrustees.push(formerTrustee as TrustHistoricalBeneficialOwner);
+    }));
+  }
+  return formerTrustees;
+};
+
 const addTrustToBeneficialOwner = (
   beneficialOwner: TrustBeneficialOwner,
   trustId: string,
@@ -222,6 +238,7 @@ export {
   getTrustBoIndividuals,
   getTrustBoOthers,
   getIndividualTrusteesFromTrust,
+  getFormerTrusteesFromTrust,
   addTrustToBeneficialOwner,
   removeTrustFromBeneficialOwner,
   saveHistoricalBoInTrust,

--- a/test/controllers/trusts.involved.controller.spec.ts
+++ b/test/controllers/trusts.involved.controller.spec.ts
@@ -11,6 +11,8 @@ jest.mock('../../src/validation/trust.involved.validation', () => ({
 }));
 jest.mock('../../src/utils/trust/common.trust.data.mapper');
 jest.mock('../../src/utils/trust/who.is.involved.mapper');
+jest.mock('../../src/utils/trust/who.is.involved.mapper');
+jest.mock('../../src/utils/trusts');
 
 import { constants } from 'http2';
 import { beforeEach, describe, expect, jest, test } from '@jest/globals';
@@ -39,6 +41,7 @@ import { TrusteeType } from '../../src/model/trustee.type.model';
 import { getApplicationData } from '../../src/utils/application.data';
 import { mapCommonTrustDataToPage } from '../../src/utils/trust/common.trust.data.mapper';
 import { mapTrustWhoIsInvolvedToPage } from '../../src/utils/trust/who.is.involved.mapper';
+import { getFormerTrusteesFromTrust, getIndividualTrusteesFromTrust } from '../../src/utils/trusts';
 
 describe('Trust Involved controller', () => {
   const mockGetApplicationData = getApplicationData as jest.Mock;
@@ -85,6 +88,18 @@ describe('Trust Involved controller', () => {
       };
       (mapTrustWhoIsInvolvedToPage as any as jest.Mock).mockReturnValue(mockInvolvedData);
 
+      const indiviudalTrusteeData = {
+        name: "indiviudalTrustee"
+      };
+
+      (getIndividualTrusteesFromTrust as any as jest.Mock).mockReturnValue(indiviudalTrusteeData);
+
+      const formerTrusteeData = {
+        name: "formerTrustee"
+      };
+
+      (getFormerTrusteesFromTrust as any as jest.Mock).mockReturnValue(formerTrusteeData);
+
       get(mockReq, mockRes, mockNext);
 
       expect(mockRes.redirect).not.toBeCalled();
@@ -95,6 +110,12 @@ describe('Trust Involved controller', () => {
       expect(mapTrustWhoIsInvolvedToPage).toBeCalledTimes(1);
       expect(mapTrustWhoIsInvolvedToPage).toBeCalledWith(mockAppData, trustId);
 
+      expect(getIndividualTrusteesFromTrust).toBeCalledTimes(1);
+      expect(getIndividualTrusteesFromTrust).toBeCalledWith(mockAppData, trustId);
+
+      expect(getFormerTrusteesFromTrust).toBeCalledTimes(1);
+      expect(getFormerTrusteesFromTrust).toBeCalledWith(mockAppData, trustId);
+
       expect(mockRes.render).toBeCalledTimes(1);
       expect(mockRes.render).toBeCalledWith(
         TRUST_INVOLVED_PAGE,
@@ -102,6 +123,8 @@ describe('Trust Involved controller', () => {
           pageData: expect.objectContaining({
             trustData: mockTrustData,
             ...mockInvolvedData,
+            individualTrusteeData: indiviudalTrusteeData,
+            formerTrusteeData: formerTrusteeData,
           }),
         }),
       );

--- a/test/utils/trust.spec.ts
+++ b/test/utils/trust.spec.ts
@@ -11,6 +11,7 @@ import {
   saveTrustInApp,
   saveLegalEntityBoInTrust,
   getIndividualTrusteesFromTrust,
+  getFormerTrusteesFromTrust,
 } from '../../src/utils/trusts';
 import { ApplicationData } from '../../src/model';
 import { NatureOfControlType } from '../../src/model/data.types.model';
@@ -315,6 +316,34 @@ describe('Trust Utils method tests', () => {
       } as ApplicationData;
 
       const result = getIndividualTrusteesFromTrust(appData);
+      expect(result.length).toEqual(6);
+      expect(result).toEqual([{}, {}, {}, {}, {}, {}]);
+    });
+
+    test("test getFormerTrusteesFromTrust with application data and trust id", () => {
+      const test_trust_id = '353';
+      const appData = {
+        [TrustKey]: [{
+          'trust_id': test_trust_id,
+          'HISTORICAL_BO': [{}, {}, {}] as TrustHistoricalBeneficialOwner[],
+        }]
+      } as ApplicationData;
+
+      const result = getFormerTrusteesFromTrust(appData, test_trust_id);
+      expect(result.length).toEqual(3);
+      expect(result).toEqual([{}, {}, {}]);
+    });
+
+    test("test getFormerTrusteesFromTrust with application data and no trust id", () => {
+      const appData = {
+        [TrustKey]: [{
+          'HISTORICAL_BO': [{}, {}, {}] as TrustHistoricalBeneficialOwner[],
+        }, {
+          'HISTORICAL_BO': [{}, {}, {}] as TrustHistoricalBeneficialOwner[],
+        }]
+      } as ApplicationData;
+
+      const result = getFormerTrusteesFromTrust(appData);
       expect(result.length).toEqual(6);
       expect(result).toEqual([{}, {}, {}, {}, {}, {}]);
     });

--- a/test/utils/trust/historical.beneficial.owner.mapper.spec.ts
+++ b/test/utils/trust/historical.beneficial.owner.mapper.spec.ts
@@ -3,12 +3,11 @@ jest.mock('uuid');
 import { beforeEach, describe, expect, jest, test } from "@jest/globals";
 import * as uuid from 'uuid';
 import * as Page from '../../../src/model/trust.page.model';
-import { TrustHistoricalBeneficialOwnerType } from '../../../src/model/trust.model';
 import {
   generateBoId,
   mapBeneficialOwnerToSession,
 } from '../../../src/utils/trust/historical.beneficial.owner.mapper';
-import { BeneficialOwnerTypeChoice } from "../../../src/model/beneficial.owner.type.model";
+import { TrusteeType } from "../../../src/model/trustee.type.model";
 
 describe('Historical Beneficial Owner page Mapper Service', () => {
   beforeEach(() => {
@@ -30,7 +29,7 @@ describe('Historical Beneficial Owner page Mapper Service', () => {
         const mockFormData = {
           ...mockFormDataBasic,
           boId: '9999',
-          type: BeneficialOwnerTypeChoice.individual as TrustHistoricalBeneficialOwnerType,
+          type: TrusteeType.INDIVIDUAL as TrusteeType,
           firstName: 'dummyFirstName',
           lastName: 'dummyLastName',
         };
@@ -52,7 +51,7 @@ describe('Historical Beneficial Owner page Mapper Service', () => {
       test('map corporate', () => {
         const mockFormData = {
           ...mockFormDataBasic,
-          type: BeneficialOwnerTypeChoice.otherLegal as TrustHistoricalBeneficialOwnerType,
+          type: TrusteeType.LEGAL_ENTITY as TrusteeType,
           corporateName: 'dummyCorporateName',
         };
 

--- a/views/trust-historical-beneficial-owner.html
+++ b/views/trust-historical-beneficial-owner.html
@@ -60,14 +60,14 @@
           value: formData.type,
           items: [
             {
-              value: 1,
+              value: pageData.trusteeType.LEGAL_ENTITY,
               text: "Legal Entity",
               conditional: {
                 html: legalEntityHtml
               }
             },
             {
-              value: 0,
+              value: pageData.trusteeType.INDIVIDUAL,
               text: "Individual",
               conditional: {
                 html: individualBoHtml

--- a/views/trust-involved.html
+++ b/views/trust-involved.html
@@ -44,6 +44,27 @@
         ) %}
       {% endfor %}
 
+      {% set formerTrustees = [] %}
+      {% for trustee in pageData.formerTrusteeData %}
+        {% set type = pageData.trusteeTypeTitle[pageData.trusteeType.HISTORICAL] %}
+        {% if trustee.forename and trustee.surname%}
+          {% set name = trustee.forename + " " + trustee.surname %}
+        {% else %}
+          {% set name = trustee.corporateName %}
+        {% endif %}
+        {% set formerTrustees = (
+          formerTrustees.push({
+            key: {
+              text: type  
+            },
+            value: {
+              text: name
+            }
+          }),
+          formerTrustees
+        ) %}
+      {% endfor %}
+
       {% set individualTrustees = [] %}
       {% for trustee in pageData.individualTrusteeData %}
         {% set type = pageData.trusteeType.INDIVIDUAL | capitalize %}
@@ -61,11 +82,11 @@
         ) %}
       {% endfor %}
 
-      {% set trustees = [] %}
+      {% set legalEntityTrustees = [] %}
       {% for trustee in pageData.trustees %}
         {% set type = pageData.trusteeTypeTitle[trustee.trusteeItemType] %}
-        {% set trustees = (
-          trustees.push({
+        {% set legalEntityTrustees = (
+          legalEntityTrustees.push({
             key: {
               text: type
             },
@@ -73,11 +94,11 @@
               text: trustee.name
             }
           }),
-          trustees
+          legalEntityTrustees
         ) %}
       {% endfor %}
 
-      {% if boItems | length %}
+      {% if boItems | length or formerTrustees | length or individualTrustees | length or legalEntityTrustees | length %}
         <h1 class="govuk-heading-m">
           What <span class="govuk-visually-hidden">individuals or entities</span>
           you have added so far for this trust
@@ -85,16 +106,21 @@
         {{ govukSummaryList({
           rows: boItems
         }) }}
-        {{ govukSummaryList({
-          rows: trustees
-        }) }}
-      {% endif %}
 
-      {% if individualTrustees | length %}
+        {{ govukSummaryList({
+          rows: formerTrustees
+        }) }}
+
         {{ govukSummaryList({
           rows: individualTrustees
         }) }}
+
+        {{ govukSummaryList({
+          rows: legalEntityTrustees
+        }) }}
+        
       {% endif %}
+      
 
       <form class="form" method="post">
         {% set fieldParam = {


### PR DESCRIPTION
### JIRA link

[ROE-1731](https://companieshouse.atlassian.net/browse/ROE-1731)

### Change description

- Add functionality to display former/historical trustees added to a trust to the trust involved page
- Add unit tests where required

**Changes that could be considered out of scope for PR**

- _Replacing the usage of `TrustHistoricalBeneficialOwnerType` with `TrusteeType`_: `TrustHistoricalBeneficialOwnerType` gets it's enum values from `BeneficialOwnerTypeChoice` which is used with beneficial owners and has some different values from what we'd be expecting with trustees. TrusteeType had previously been created to be used with trustees. 
I addressed this change in this PR as I discovered that former trustees were not mapping to the session correctly. If the former trustee was a legal entity/corporate then their name was never being saved to the session thus I couldn't display it on the trust involved page. 
I made the required changes so the name will save to the session and can not be displayed on the page. 

- _Added missing test in `test/controllers/trusts.involved.controller.spec.ts`_: Displaying the individual to the trust involved page had not been added to the controller get test. As the test is so similar to what I was implementing with former trustee I added the missing test additions now


### Work checklist

- [X] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.


[ROE-1731]: https://companieshouse.atlassian.net/browse/ROE-1731?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ