### PR TITLE
Feature/roe 1774 display former trustee on check your answers

### DIFF
--- a/src/utils/trust/historical.beneficial.owner.mapper.ts
+++ b/src/utils/trust/historical.beneficial.owner.mapper.ts
@@ -9,12 +9,12 @@ const mapBeneficialOwnerToSession = (
   const data = {
     id: formData.boId || generateBoId(),
     corporateIndicator: formData.type as TrusteeType,
-    ceased_date_day: formData.startDateDay,
-    ceased_date_month: formData.startDateMonth,
-    ceased_date_year: formData.startDateYear,
-    notified_date_day: formData.endDateDay,
-    notified_date_month: formData.endDateMonth,
-    notified_date_year: formData.endDateYear,
+    notified_date_day: formData.startDateDay,
+    notified_date_month: formData.startDateMonth,
+    notified_date_year: formData.startDateYear,
+    ceased_date_day: formData.endDateDay,
+    ceased_date_month: formData.endDateMonth,
+    ceased_date_year: formData.endDateYear,
   };
 
   if (formData.type === TrusteeType.LEGAL_ENTITY) {

--- a/test/utils/trust/historical.beneficial.owner.mapper.spec.ts
+++ b/test/utils/trust/historical.beneficial.owner.mapper.spec.ts
@@ -39,12 +39,13 @@ describe('Historical Beneficial Owner page Mapper Service', () => {
           corporateIndicator: mockFormData.type,
           forename: mockFormData.firstName,
           surname: mockFormData.lastName,
-          ceased_date_day: mockFormData.startDateDay,
-          ceased_date_month: mockFormData.startDateMonth,
-          ceased_date_year: mockFormData.startDateYear,
-          notified_date_day: mockFormData.endDateDay,
-          notified_date_month: mockFormData.endDateMonth,
-          notified_date_year: mockFormData.endDateYear,
+          notified_date_day: mockFormData.startDateDay,
+          notified_date_month: mockFormData.startDateMonth,
+          notified_date_year: mockFormData.startDateYear,
+          ceased_date_day: mockFormData.endDateDay,
+          ceased_date_month: mockFormData.endDateMonth,
+          ceased_date_year: mockFormData.endDateYear,
+
         });
       });
 
@@ -62,12 +63,12 @@ describe('Historical Beneficial Owner page Mapper Service', () => {
           id: expectNewId,
           corporateIndicator: mockFormData.type,
           corporateName: mockFormData.corporateName,
-          ceased_date_day: mockFormData.startDateDay,
-          ceased_date_month: mockFormData.startDateMonth,
-          ceased_date_year: mockFormData.startDateYear,
-          notified_date_day: mockFormData.endDateDay,
-          notified_date_month: mockFormData.endDateMonth,
-          notified_date_year: mockFormData.endDateYear,
+          notified_date_day: mockFormData.startDateDay,
+          notified_date_month: mockFormData.startDateMonth,
+          notified_date_year: mockFormData.startDateYear,
+          ceased_date_day: mockFormData.endDateDay,
+          ceased_date_month: mockFormData.endDateMonth,
+          ceased_date_year: mockFormData.endDateYear,
         });
       });
     });

--- a/views/check-your-answers.html
+++ b/views/check-your-answers.html
@@ -68,6 +68,11 @@
               {% include "includes/check-your-answers/legal-entity-trustee.html" %}
             {% endfor %}
           {% endif %}
+          {% if (trust.HISTORICAL_BO and trust.HISTORICAL_BO.length > 0) %}
+            {% for formerTrustee in trust.HISTORICAL_BO %}
+              {% include "includes/check-your-answers/historical-trustee.html" %}
+            {% endfor %}
+          {% endif %}
       {% endfor %}
 
       <br>

--- a/views/includes/check-your-answers/historical-trustee.html
+++ b/views/includes/check-your-answers/historical-trustee.html
@@ -1,0 +1,47 @@
+{% import "includes/date-macros.html" as dateMacros %}
+
+{% if formerTrustee.corporateName %}
+  {% set formerTrusteeName = formerTrustee.corporateName %}
+{% else %}
+  {% set formerTrusteeName = formerTrustee.forename + " " + formerTrustee.surname %}
+{% endif %}
+
+{% set formerTrusteeStartDate = dateMacros.formatDate(formerTrustee.notified_date_day, formerTrustee.notified_date_month, formerTrustee.notified_date_year) %}
+{% set formerTrusteeEndDate = dateMacros.formatDate(formerTrustee.ceased_date_day, formerTrustee.ceased_date_month, formerTrustee.ceased_date_year) %}
+
+
+{# Build and add each govukSummaryList row separately so that some rows can be optional #}
+{% set rows=[] %}
+
+{% set rows = (rows.push({
+  key: {
+    text: "Former beneficial owner's name"
+  },
+  value: {
+    text: formerTrusteeName
+  }
+}), rows) %}
+
+{% set rows = (rows.push({
+  key: {
+    text: "Date they became a beneficial owner"
+  },
+  value: {
+    text: formerTrusteeStartDate
+  }
+}), rows) %}
+
+{% set rows = (rows.push({
+  key: {
+    text: "Date they stopped being a beneficial owner"
+  },
+  value: {
+    text: formerTrusteeEndDate
+  }
+}), rows) %}
+
+<h3 class="govuk-heading-m">Former beneficial owner for {{trust.trust_name}}</h3>
+
+{{ govukSummaryList({
+  rows: rows
+}) }}


### PR DESCRIPTION
### JIRA link

[ROE-1774](https://companieshouse.atlassian.net/browse/ROE-1774)

### Change description

- create html component to display former(historical) trustees
- Use component to display former trustee data on the check your answers page
- former(historical) trustee mapping had been done wrong. End dates and start dates were mapped the wrong way around so were correct
- Reflected the mapping fix in the test class


### Work checklist

- [X] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.


[ROE-1774]: https://companieshouse.atlassian.net/browse/ROE-1774?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ