### PR TITLE
roe-1986: Feature flag page content

### DIFF
--- a/src/controllers/interrupt.card.controller.ts
+++ b/src/controllers/interrupt.card.controller.ts
@@ -2,12 +2,16 @@ import { Request, Response } from "express";
 
 import { logger } from "../utils/logger";
 import * as config from "../config";
+import { isActiveFeature } from "../utils/feature.flag";
 
 export const get = (req: Request, res: Response) => {
   logger.debugRequest(req, `GET ${config.INTERRUPT_CARD_PAGE}`);
 
   return res.render(config.INTERRUPT_CARD_PAGE, {
     backLinkUrl: config.SECURE_REGISTER_FILTER_URL,
-    templateName: config.INTERRUPT_CARD_PAGE
+    templateName: config.INTERRUPT_CARD_PAGE,
+    pageParams: {
+      isTrustFeatureEnabled: isActiveFeature(config.FEATURE_FLAG_ENABLE_TRUSTS_WEB),
+    },
   });
 };

--- a/test/controllers/interrupt.card.controller.spec.ts
+++ b/test/controllers/interrupt.card.controller.spec.ts
@@ -1,6 +1,7 @@
 jest.mock("ioredis");
 jest.mock('../../src/middleware/authentication.middleware');
 jest.mock('../../src/middleware/navigation/is.secure.register.middleware');
+jest.mock("../../src/utils/feature.flag" );
 
 import { NextFunction, Request, Response } from "express";
 import { expect, jest, test, describe } from "@jest/globals";
@@ -12,12 +13,14 @@ import { INTERRUPT_CARD_PAGE_TITLE } from "../__mocks__/text.mock";
 
 import { authentication } from "../../src/middleware/authentication.middleware";
 import { isSecureRegister } from "../../src/middleware/navigation/is.secure.register.middleware";
+import { isActiveFeature } from "../../src/utils/feature.flag";
 
 const mockIsSecureRegisterMiddleware = isSecureRegister as jest.Mock;
 mockIsSecureRegisterMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => next() );
 
 const mockAuthenticationMiddleware = authentication as jest.Mock;
 mockAuthenticationMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => next() );
+
 
 describe("INTERRUPT CARD controller", () => {
   describe("GET tests", () => {
@@ -27,6 +30,17 @@ describe("INTERRUPT CARD controller", () => {
       expect(resp.status).toEqual(200);
       expect(resp.text).toContain(INTERRUPT_CARD_PAGE_TITLE);
       expect(resp.text).toContain(LANDING_PAGE_URL);
+    });
+
+    test(`renders the ${INTERRUPT_CARD_PAGE} page with trust feature flag false`, async () => {
+      (isActiveFeature as jest.Mock).mockReturnValue(false);
+
+      const resp = await request(app).get(INTERRUPT_CARD_URL);
+
+      expect(resp.status).toEqual(200);
+      expect(resp.text).toContain(INTERRUPT_CARD_PAGE_TITLE);
+      expect(resp.text).toContain(LANDING_PAGE_URL);
+      expect(resp.text).toContain("Trusts");
     });
   });
 });

--- a/test/controllers/interrupt.card.controller.spec.ts
+++ b/test/controllers/interrupt.card.controller.spec.ts
@@ -21,7 +21,6 @@ mockIsSecureRegisterMiddleware.mockImplementation((req: Request, res: Response, 
 const mockAuthenticationMiddleware = authentication as jest.Mock;
 mockAuthenticationMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => next() );
 
-
 describe("INTERRUPT CARD controller", () => {
   describe("GET tests", () => {
     test(`renders the ${INTERRUPT_CARD_PAGE} page`, async () => {

--- a/views/interrupt-card.html
+++ b/views/interrupt-card.html
@@ -8,7 +8,6 @@
   {% include "includes/back-link.html" %}
 {% endblock %}
 
-
 {% block content %}
 
   <div class="govuk-grid-row">

--- a/views/interrupt-card.html
+++ b/views/interrupt-card.html
@@ -8,6 +8,7 @@
   {% include "includes/back-link.html" %}
 {% endblock %}
 
+
 {% block content %}
 
   <div class="govuk-grid-row">
@@ -17,20 +18,25 @@
         <h2 class="govuk-heading-m">Agent assurance codes for verification checks</h2>
         <p class="govuk-body">A UK-regulated agent must carry out <a href="https://www.gov.uk/guidance/register-an-overseas-entity#what-is-needed-for-verification-checks" class="govuk-link" data-event-id="identity-checks-link">verification checks</a> on all beneficial owners and managing officers no more than 3 months before the overseas entity is registered. They'll need to provide an <a href="https://www.gov.uk/guidance/agent-assurance-codes" class="govuk-link" data-event-id="agent-assurance-code-link">agent assurance code</a> to confirm they have authorisation to carry out verification checks.</p>
 
-        <h2 class="govuk-heading-m">Trusts</h2>
-        <p class="govuk-body">If you need to tell us about <a href="https://www.gov.uk/guidance/register-an-overseas-entity#how-to-submit-information-about-trusts" class="govuk-link" data-event-id="trusts-link">trusts</a>, we highly recommend that you complete the <a href="//{{CDN_HOST}}/static/services/overseas-entities/Companies%20House%20Trust%20Excel%20Document.xlsm" class="govuk-link" data-event-id="trusts-document-download-link">Trust Excel document (58KB)</a> before you start, as the service will time out if you do not use it for 60 minutes.</p>
+
+        {% if (pageParams.isTrustFeatureEnabled == false) %}
+
+          <h2 class="govuk-heading-m">Trusts</h2>
+          <p class="govuk-body">If you need to tell us about <a href="https://www.gov.uk/guidance/register-an-overseas-entity#how-to-submit-information-about-trusts" class="govuk-link" data-event-id="trusts-link">trusts</a>, we highly recommend that you complete the <a href="//{{CDN_HOST}}/static/services/overseas-entities/Companies%20House%20Trust%20Excel%20Document.xlsm" class="govuk-link" data-event-id="trusts-document-download-link">Trust Excel document (58KB)</a> before you start, as the service will time out if you do not use it for 60 minutes.</p>
 
 
-        <p class="govuk-body">You'll need to:</p>
-        <ul class="govuk-list govuk-list--bullet">
-          <li>open the document in Excel</li>
-          <li>enable macros when prompted</li>
-        </ul>
-        <p class="govuk-body">  Then follow the instructions within the document to enter the information into the service.</p>
+          <p class="govuk-body">You'll need to:</p>
+          <ul class="govuk-list govuk-list--bullet">
+            <li>open the document in Excel</li>
+            <li>enable macros when prompted</li>
+          </ul>
+          <p class="govuk-body">  Then follow the instructions within the document to enter the information into the service.</p>
 
-        <a href="{{OE_CONFIGS.OVERSEAS_NAME_URL}}"  id="continue" onclick="_paq.push(['trackGoal', '{{PIWIK_START_GOAL_ID}}'])" role="button" draggable="false" class="govuk-button" data-module="govuk-button">
-          Continue
-        </a>
+        {% endif %}
+
+    <a href="{{OE_CONFIGS.OVERSEAS_NAME_URL}}"  id="continue" onclick="_paq.push(['trackGoal', '{{PIWIK_START_GOAL_ID}}'])" role="button" draggable="false" class="govuk-button" data-module="govuk-button">
+      Continue
+    </a>
 
       </div>
     </div>


### PR DESCRIPTION
- add feature flag check around interrupt page content
- if trust flag is false then information regarding the trust spreadsheet is displayed on the interrupt page
- add test to ensure that trust excel information is contained on the page when trust feature flag is false.

### JIRA link

[ROE-1986](https://companieshouse.atlassian.net/browse/ROE-1986)

### Change description



### Work checklist

- [X] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.


[ROE-1986]: https://companieshouse.atlassian.net/browse/ROE-1986?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ