### PR TITLE
ROE-1938 - TL - Gov BO et al - Focus required for empty date error

### DIFF
--- a/src/validation/custom.validation.ts
+++ b/src/validation/custom.validation.ts
@@ -29,13 +29,6 @@ export const checkInvalidCharactersIfRadioButtonSelected = (selected: boolean, e
   return true;
 };
 
-export const checkDateIsNotCompletelyEmptyWithErrorThrown = (errMsg: string, day: string = "", month: string = "", year: string = "") => {
-  if ( !day.trim() && !month.trim() && !year.trim() ) {
-    throw new Error(errMsg);
-  }
-  return true;
-};
-
 export const checkDateIsNotCompletelyEmpty = (day: string = "", month: string = "", year: string = "") => {
   if ( !day.trim() && !month.trim() && !year.trim() ) {
     return false;
@@ -161,7 +154,9 @@ export const checkDateFieldDay = (dayStr: string = "", monthStr: string = "", ye
     } else if (dayStr === "" && monthStr !== "" && yearStr === "") {
       throw new Error(ErrorMessages.DAY_AND_YEAR);
     } else {
-      checkDateIsNotCompletelyEmptyWithErrorThrown(ErrorMessages.ENTER_DATE, dayStr, monthStr, yearStr);
+      if (!checkDateIsNotCompletelyEmpty(dayStr, monthStr, yearStr)) {
+        throw new Error(ErrorMessages.ENTER_DATE);
+      }
     }
   }
   return true;
@@ -176,7 +171,9 @@ export const checkDateFieldDayOfBirth = (dayStr: string = "", monthStr: string =
     } else if (dayStr === "" && monthStr !== "" && yearStr === "") {
       throw new Error(ErrorMessages.DAY_AND_YEAR_OF_BIRTH);
     } else {
-      checkDateIsNotCompletelyEmptyWithErrorThrown(ErrorMessages.ENTER_DATE_OF_BIRTH, dayStr, monthStr, yearStr);
+      if (!checkDateIsNotCompletelyEmpty(dayStr, monthStr, yearStr)) {
+        throw new Error(ErrorMessages.ENTER_DATE_OF_BIRTH);
+      }
     }
   }
   return true;
@@ -195,12 +192,12 @@ export const checkDateFieldDayForOptionalDates = (dayStr: string = "", monthStr:
   return true;
 };
 
-export const checkDateFieldMonth = (monthMissingMessage: string, monthYearMsg: string, dayStr: string = "", monthStr: string = "", yearStr: string = "") => {
+export const checkDateFieldMonth = (monthMissingMessage: string, monthYearMissingMessage: string, dayStr: string = "", monthStr: string = "", yearStr: string = "") => {
   if (isYearEitherMissingOrCorrectLength(yearStr)) {
     if (monthStr === "" && dayStr !== "" && yearStr !== "") {
       throw new Error(monthMissingMessage);
     } else if (dayStr !== "" && monthStr === "" && yearStr === "") {
-      throw new Error(monthYearMsg);
+      throw new Error(monthYearMissingMessage);
     }
   }
   return true;

--- a/src/validation/custom.validation.ts
+++ b/src/validation/custom.validation.ts
@@ -29,9 +29,16 @@ export const checkInvalidCharactersIfRadioButtonSelected = (selected: boolean, e
   return true;
 };
 
-export const checkDateIsNotCompletelyEmpty = (errMsg: string, day: string = "", month: string = "", year: string = "") => {
+export const checkDateIsNotCompletelyEmptyWithErrorThrown = (errMsg: string, day: string = "", month: string = "", year: string = "") => {
   if ( !day.trim() && !month.trim() && !year.trim() ) {
     throw new Error(errMsg);
+  }
+  return true;
+};
+
+export const checkDateIsNotCompletelyEmpty = (day: string = "", month: string = "", year: string = "") => {
+  if ( !day.trim() && !month.trim() && !year.trim() ) {
+    return false;
   }
   return true;
 };
@@ -104,13 +111,10 @@ const checkOptionalDateDetails = (dayStr: string = "", monthStr: string = "", ye
 
 export const checkIdentityDate = (dayStr: string = "", monthStr: string = "", yearStr: string = "") => {
   // to prevent more than 1 error reported on the date fields we first check for multiple empty fields and then check if the year is correct length or missing before doing the date check as a whole.
-  if (checkMoreThanOneDateFieldIsNotMissing(dayStr, monthStr, yearStr) && isYearEitherMissingOrCorrectLength(yearStr)) {
-    if (isYearEitherMissingOrCorrectLength(yearStr)) {
-      const isDatePresent = checkDateIsNotCompletelyEmpty(ErrorMessages.ENTER_DATE, dayStr, monthStr, yearStr);
-      if (isDatePresent) {
-        checkIdentityDateFields(dayStr, monthStr, yearStr);
-      }
-    }
+  if (checkMoreThanOneDateFieldIsNotMissing(dayStr, monthStr, yearStr)
+  && isYearEitherMissingOrCorrectLength(yearStr)
+  && checkDateIsNotCompletelyEmpty(dayStr, monthStr, yearStr)) {
+    checkIdentityDateFields(dayStr, monthStr, yearStr);
   }
   return true;
 };
@@ -130,13 +134,10 @@ const checkIdentityDateFields = (dayStr: string = "", monthStr: string = "", yea
 
 export const checkStartDate = (dayStr: string = "", monthStr: string = "", yearStr: string = "") => {
   // to prevent more than 1 error reported on the date fields we first check for multiple empty fields and then check if the year is correct length or missing before doing the date check as a whole.
-  if (checkMoreThanOneDateFieldIsNotMissing(dayStr, monthStr, yearStr) && isYearEitherMissingOrCorrectLength(yearStr)) {
-    if (isYearEitherMissingOrCorrectLength(yearStr)) {
-      const isDatePresent = checkDateIsNotCompletelyEmpty(ErrorMessages.ENTER_DATE, dayStr, monthStr, yearStr);
-      if (isDatePresent) {
-        checkStartDateFields(dayStr, monthStr, yearStr);
-      }
-    }
+  if (checkMoreThanOneDateFieldIsNotMissing(dayStr, monthStr, yearStr)
+  && isYearEitherMissingOrCorrectLength(yearStr)
+  && checkDateIsNotCompletelyEmpty(dayStr, monthStr, yearStr)) {
+    checkStartDateFields(dayStr, monthStr, yearStr);
   }
   return true;
 };
@@ -151,10 +152,40 @@ const checkStartDateFields = (dayStr: string = "", monthStr: string = "", yearSt
   }
 };
 
-export const checkDateFieldDay = (dayMissingMessage: string, dayStr: string = "", monthStr: string = "", yearStr: string = "") => {
+export const checkDateFieldDay = (dayStr: string = "", monthStr: string = "", yearStr: string = "") => {
   if (isYearEitherMissingOrCorrectLength(yearStr)) {
     if (dayStr === "" && monthStr !== "" && yearStr !== "") {
-      throw new Error(dayMissingMessage);
+      throw new Error(ErrorMessages.DAY);
+    } else if (dayStr === "" && monthStr === "" && yearStr !== "") {
+      throw new Error(ErrorMessages.DAY_AND_MONTH);
+    } else if (dayStr === "" && monthStr !== "" && yearStr === "") {
+      throw new Error(ErrorMessages.DAY_AND_YEAR);
+    } else {
+      checkDateIsNotCompletelyEmptyWithErrorThrown(ErrorMessages.ENTER_DATE, dayStr, monthStr, yearStr);
+    }
+  }
+  return true;
+};
+
+export const checkDateFieldDayOfBirth = (dayStr: string = "", monthStr: string = "", yearStr: string = "") => {
+  if (isYearEitherMissingOrCorrectLength(yearStr)) {
+    if (dayStr === "" && monthStr !== "" && yearStr !== "") {
+      throw new Error(ErrorMessages.DAY_OF_BIRTH);
+    } else if (dayStr === "" && monthStr === "" && yearStr !== "") {
+      throw new Error(ErrorMessages.DAY_AND_MONTH_OF_BIRTH);
+    } else if (dayStr === "" && monthStr !== "" && yearStr === "") {
+      throw new Error(ErrorMessages.DAY_AND_YEAR_OF_BIRTH);
+    } else {
+      checkDateIsNotCompletelyEmptyWithErrorThrown(ErrorMessages.ENTER_DATE_OF_BIRTH, dayStr, monthStr, yearStr);
+    }
+  }
+  return true;
+};
+
+export const checkDateFieldDayForOptionalDates = (dayStr: string = "", monthStr: string = "", yearStr: string = "") => {
+  if (isYearEitherMissingOrCorrectLength(yearStr)) {
+    if (dayStr === "" && monthStr !== "" && yearStr !== "") {
+      throw new Error(ErrorMessages.DAY);
     } else if (dayStr === "" && monthStr === "" && yearStr !== "") {
       throw new Error(ErrorMessages.DAY_AND_MONTH);
     } else if (dayStr === "" && monthStr !== "" && yearStr === "") {
@@ -164,12 +195,12 @@ export const checkDateFieldDay = (dayMissingMessage: string, dayStr: string = ""
   return true;
 };
 
-export const checkDateFieldMonth = (monthMissingMessage: string, dayStr: string = "", monthStr: string = "", yearStr: string = "") => {
+export const checkDateFieldMonth = (monthMissingMessage: string, monthYearMsg: string, dayStr: string = "", monthStr: string = "", yearStr: string = "") => {
   if (isYearEitherMissingOrCorrectLength(yearStr)) {
     if (monthStr === "" && dayStr !== "" && yearStr !== "") {
       throw new Error(monthMissingMessage);
     } else if (dayStr !== "" && monthStr === "" && yearStr === "") {
-      throw new Error(ErrorMessages.MONTH_AND_YEAR);
+      throw new Error(monthYearMsg);
     }
   }
   return true;
@@ -208,15 +239,14 @@ export const checkMoreThanOneDateFieldIsNotMissing = (dayStr: string = "", month
 
 export const checkDateOfBirth = (dayStr: string = "", monthStr: string = "", yearStr: string = "") => {
   // to prevent more than 1 error reported on the date fields we check if the year is correct length or missing before doing the date check as a whole.
-  if (isYearEitherMissingOrCorrectLength(yearStr)) {
-    const isDatePresent = checkDateIsNotCompletelyEmpty(ErrorMessages.ENTER_DATE_OF_BIRTH, dayStr, monthStr, yearStr);
-    if (isDatePresent) {
-      const areDateOfBirthFieldsPresent = checkDateOfBirthFieldsArePresent(dayStr, monthStr, yearStr);
-      if (areDateOfBirthFieldsPresent) {
-        const isDateValid = checkDateValueIsValid(ErrorMessages.INVALID_DATE_OF_BIRTH, dayStr, monthStr, yearStr);
-        if (isDateValid) {
-          checkDateIsInPast(ErrorMessages.DATE_OF_BIRTH_NOT_IN_PAST, dayStr, monthStr, yearStr);
-        }
+  if (checkMoreThanOneDateFieldIsNotMissing(dayStr, monthStr, yearStr)
+  && isYearEitherMissingOrCorrectLength(yearStr)
+  && checkDateIsNotCompletelyEmpty(dayStr, monthStr, yearStr)) {
+    const areDateOfBirthFieldsPresent = checkDateOfBirthFieldsArePresent(dayStr, monthStr, yearStr);
+    if (areDateOfBirthFieldsPresent) {
+      const isDateValid = checkDateValueIsValid(ErrorMessages.INVALID_DATE_OF_BIRTH, dayStr, monthStr, yearStr);
+      if (isDateValid) {
+        checkDateIsInPast(ErrorMessages.DATE_OF_BIRTH_NOT_IN_PAST, dayStr, monthStr, yearStr);
       }
     }
   }

--- a/src/validation/fields/date.validation.ts
+++ b/src/validation/fields/date.validation.ts
@@ -1,6 +1,7 @@
 import { body } from "express-validator";
 import {
   checkDateFieldDay,
+  checkDateFieldDayOfBirth,
   checkDateFieldMonth,
   checkDateFieldYear,
   checkDateOfBirth,
@@ -13,9 +14,9 @@ import { ErrorMessages } from "../error.messages";
 // This means that the year check is checked before some others
 export const start_date_validations = [
   body("start_date-day")
-    .custom((value, { req }) => checkDateFieldDay(ErrorMessages.DAY, req.body["start_date-day"], req.body["start_date-month"], req.body["start_date-year"])),
+    .custom((value, { req }) => checkDateFieldDay(req.body["start_date-day"], req.body["start_date-month"], req.body["start_date-year"])),
   body("start_date-month")
-    .custom((value, { req }) => checkDateFieldMonth(ErrorMessages.MONTH, req.body["start_date-day"], req.body["start_date-month"], req.body["start_date-year"])),
+    .custom((value, { req }) => checkDateFieldMonth(ErrorMessages.MONTH, ErrorMessages.MONTH_AND_YEAR, req.body["start_date-day"], req.body["start_date-month"], req.body["start_date-year"])),
   body("start_date-year")
     .custom((value, { req }) => checkDateFieldYear(ErrorMessages.YEAR, ErrorMessages.YEAR_LENGTH, req.body["start_date-day"], req.body["start_date-month"], req.body["start_date-year"])),
   body("start_date")
@@ -26,11 +27,9 @@ export const start_date_validations = [
 // This means that the year check is checked before some others
 export const date_of_birth_validations = [
   body("date_of_birth-day")
-    .if(body("date_of_birth-year").isLength({ min: 4, max: 4 }))
-    .custom((value, { req }) => checkDateFieldDay(ErrorMessages.DAY_OF_BIRTH, req.body["date_of_birth-day"], req.body["date_of_birth-month"], req.body["date_of_birth-year"])),
+    .custom((value, { req }) => checkDateFieldDayOfBirth(req.body["date_of_birth-day"], req.body["date_of_birth-month"], req.body["date_of_birth-year"])),
   body("date_of_birth-month")
-    .if(body("date_of_birth-year").isLength({ min: 4, max: 4 }))
-    .custom((value, { req }) => checkDateFieldMonth(ErrorMessages.MONTH_OF_BIRTH, req.body["date_of_birth-day"], req.body["date_of_birth-month"], req.body["date_of_birth-year"])),
+    .custom((value, { req }) => checkDateFieldMonth(ErrorMessages.MONTH_OF_BIRTH, ErrorMessages.MONTH_AND_YEAR_OF_BIRTH, req.body["date_of_birth-day"], req.body["date_of_birth-month"], req.body["date_of_birth-year"])),
   body("date_of_birth-year")
     .custom((value, { req }) => checkDateFieldYear(ErrorMessages.YEAR_OF_BIRTH, ErrorMessages.DATE_OF_BIRTH_YEAR_LENGTH, req.body["date_of_birth-day"], req.body["date_of_birth-month"], req.body["date_of_birth-year"])),
   body("date_of_birth")
@@ -41,9 +40,9 @@ export const date_of_birth_validations = [
 // This means that the year check is checked before some others
 export const identity_check_date_validations = [
   body("identity_date-day")
-    .custom((value, { req }) => checkDateFieldDay(ErrorMessages.DAY, req.body["identity_date-day"], req.body["identity_date-month"], req.body["identity_date-year"])),
+    .custom((value, { req }) => checkDateFieldDay(req.body["identity_date-day"], req.body["identity_date-month"], req.body["identity_date-year"])),
   body("identity_date-month")
-    .custom((value, { req }) => checkDateFieldMonth(ErrorMessages.MONTH, req.body["identity_date-day"], req.body["identity_date-month"], req.body["identity_date-year"])),
+    .custom((value, { req }) => checkDateFieldMonth(ErrorMessages.MONTH, ErrorMessages.MONTH_AND_YEAR, req.body["identity_date-day"], req.body["identity_date-month"], req.body["identity_date-year"])),
   body("identity_date-year")
     .custom((value, { req }) => checkDateFieldYear(ErrorMessages.YEAR, ErrorMessages.YEAR_LENGTH, req.body["identity_date-day"], req.body["identity_date-month"], req.body["identity_date-year"])),
   body("identity_date")

--- a/src/validation/overseas.entity.due.diligence.validation.ts
+++ b/src/validation/overseas.entity.due.diligence.validation.ts
@@ -4,7 +4,7 @@ import { ErrorMessages } from "./error.messages";
 import { identity_address_validations } from "./fields/address.validation";
 import { VALID_CHARACTERS } from "./regex/regex.validation";
 import {
-  checkDateFieldDay,
+  checkDateFieldDayForOptionalDates,
   checkDateFieldMonth,
   checkDateFieldYear,
   checkOptionalDate
@@ -16,9 +16,9 @@ export const overseasEntityDueDiligence = [
   // to prevent more than 1 error reported on the date fields we check if the year is valid before doing some checks.
   // This means that the year check is checked before some others
   body("identity_date-day")
-    .custom((value, { req }) => checkDateFieldDay(ErrorMessages.DAY, req.body["identity_date-day"], req.body["identity_date-month"], req.body["identity_date-year"])),
+    .custom((value, { req }) => checkDateFieldDayForOptionalDates(req.body["identity_date-day"], req.body["identity_date-month"], req.body["identity_date-year"])),
   body("identity_date-month")
-    .custom((value, { req }) => checkDateFieldMonth(ErrorMessages.MONTH, req.body["identity_date-day"], req.body["identity_date-month"], req.body["identity_date-year"])),
+    .custom((value, { req }) => checkDateFieldMonth(ErrorMessages.MONTH, ErrorMessages.MONTH_AND_YEAR, req.body["identity_date-day"], req.body["identity_date-month"], req.body["identity_date-year"])),
   body("identity_date-year")
     .custom((value, { req }) => checkDateFieldYear(ErrorMessages.YEAR, ErrorMessages.YEAR_LENGTH, req.body["identity_date-day"], req.body["identity_date-month"], req.body["identity_date-year"])),
   body("identity_date")


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/ROE-1938


### Change description

Mainly refactoring: 

Moved empty date check to the day field validation to provide the click and focus required.
Replaced existing check in the test for the whole date with a simple true or false check and appended it to the other checks.

Also noticed here that a condition was being repeated for start dates for the work done on ROE-1987: https://github.com/companieshouse/overseas-entities-web/pull/694/files

 if (checkMoreThanOneDateFieldIsNotMissing(dayStr, monthStr, yearStr) && isYearEitherMissingOrCorrectLength(yearStr)) {
    if (isYearEitherMissingOrCorrectLength(yearStr)) {

so removed the unnecessary extra check.

As the changes affected the optional date and date of birth so have had to update these as well to be consistent with the start date.

We now have separate day field checks for date of birth, start date and optional/identity date. Moreover, the month and year checks need another parameter as dob has a different message.


### Work checklist

- [x] Tests added where applicable
- [x] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
