### PR TITLE
Add save and resume for Historic Beneficial Owners

### DIFF
--- a/src/controllers/trust.historical.beneficial.owner.controller.ts
+++ b/src/controllers/trust.historical.beneficial.owner.controller.ts
@@ -9,6 +9,8 @@ import * as CommonTrustDataMapper from '../utils/trust/common.trust.data.mapper'
 import { ApplicationData } from '../model';
 import * as PageModel from '../model/trust.page.model';
 import { CommonTrustData } from '../model/trust.page.model';
+import { saveAndContinue } from '../utils/save.and.continue';
+import { Session } from '@companieshouse/node-session-handler';
 
 const HISTORICAL_BO_TEXTS = {
   title: 'Tell us about the former beneficial owner',
@@ -65,7 +67,7 @@ const get = (
   }
 };
 
-const post = (
+const post = async (
   req: Request,
   res: Response,
   next: NextFunction,
@@ -91,7 +93,10 @@ const post = (
     appData = saveTrustInApp(appData, updatedTrust);
 
     //  save to session
-    setExtraData(req.session, appData);
+    const session = req.session as Session;
+    setExtraData(session, appData);
+
+    await saveAndContinue(req, session);
 
     return res.redirect(`${config.TRUST_ENTRY_URL}/${trustId}${config.TRUST_INVOLVED_URL}`);
   } catch (error) {

--- a/src/utils/trusts.ts
+++ b/src/utils/trusts.ts
@@ -43,15 +43,9 @@ const checkEntityRequiresTrusts = (appData: ApplicationData): boolean => {
  */
 const getTrustLandingUrl = (appData: ApplicationData): string => {
 
-  const allBenficialOwnersToCheck = beneficialOwnersThatCanBeTrustees(appData);
-
-  for (const benficialOwners of allBenficialOwnersToCheck) {
-    if (benficialOwners) {
-      if (containsTrustData(benficialOwners)) {
-        // Once naviation changes are agreed the following will change
-        return `${CHECK_YOUR_ANSWERS_URL}`;
-      }
-    }
+  if (containsTrustData(getTrustArray(appData))) {
+    // Once naviation changes are agreed the following will change
+    return `${CHECK_YOUR_ANSWERS_URL}`;
   }
 
   return `${TRUST_DETAILS_URL}${TRUST_INTERRUPT_URL}`;
@@ -88,8 +82,8 @@ const containsTrusteeNatureOfControl = (beneficialOwners: BeneficialOwnerIndivid
   return beneficialOwners.some(bo => bo.trustees_nature_of_control_types?.length);
 };
 
-const containsTrustData = (beneficialOwners: BeneficialOwnerIndividual[] | BeneficialOwnerOther[]): boolean => {
-  return beneficialOwners.some(bo => bo.trust_ids?.length);
+const containsTrustData = (trusts: Trust[]): boolean => {
+  return (trusts.length > 0);
 };
 
 /**

--- a/test/utils/trust.spec.ts
+++ b/test/utils/trust.spec.ts
@@ -423,10 +423,6 @@ describe('Trust Utils method tests', () => {
       } as BeneficialOwnerOther;
 
       const appData = {
-        [TrustKey]: [
-          mockTrust1Data,
-          mockTrust2Data,
-        ],
         [BeneficialOwnerIndividualKey]: [
           {} as BeneficialOwnerIndividual,
           mockBoIndividualNoTrustData,


### PR DESCRIPTION
### JIRA link
[ROE-1992](https://companieshouse.atlassian.net/browse/ROE-1992)

### Change description
Add "Save and Resume" functionality for Historic Beneficial Owners.
Also changed the function in trusts.ts for working out if we have trust data (use trust array rather than any trust links in BO to cover any edge cases where these might have been removed)


### Work checklist

- [x] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.


[ROE-1992]: https://companieshouse.atlassian.net/browse/ROE-1992?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ