### PR TITLE
Add "save and resume" functionality for individual trustees

### DIFF
--- a/src/controllers/trust.individual.beneficial.owner.controller.ts
+++ b/src/controllers/trust.individual.beneficial.owner.controller.ts
@@ -11,6 +11,8 @@ import { mapIndividualTrusteeToSession } from '../utils/trust/individual.trustee
 import { safeRedirect } from '../utils/http.ext';
 import { FormattedValidationErrors, formatValidationError } from '../middleware/validation.middleware';
 import { validationResult } from 'express-validator';
+import { Session } from '@companieshouse/node-session-handler';
+import { saveAndContinue } from '../utils/save.and.continue';
 
 const INDIVIDUAL_BO_TEXTS = {
   title: 'Tell us about the individual',
@@ -69,7 +71,7 @@ const get = (
   }
 };
 
-const post = (
+const post = async (
   req: Request,
   res: Response,
   next: NextFunction,
@@ -108,7 +110,10 @@ const post = (
     appData = saveTrustInApp(appData, trustUpdate);
 
     // save to session
-    setExtraData(req.session, appData);
+    const session = req.session as Session;
+    setExtraData(session, appData);
+
+    await saveAndContinue(req, session);
 
     return safeRedirect(res, url);
   } catch (error) {

--- a/test/controllers/trust.individual.beneficial.owner.controller.spec.ts
+++ b/test/controllers/trust.individual.beneficial.owner.controller.spec.ts
@@ -2,6 +2,7 @@ jest.mock("ioredis");
 jest.mock("../../src/utils/application.data");
 jest.mock('../../src/middleware/authentication.middleware');
 jest.mock('../../src/middleware/navigation/has.trust.middleware');
+jest.mock('../../src/utils/save.and.continue');
 jest.mock('../../src/middleware/is.feature.enabled.middleware', () => ({
   isFeatureEnabled: () => (_, __, next: NextFunction) => next(),
 }));
@@ -27,6 +28,10 @@ import { IndividualTrustee, Trust, TrustKey } from '../../src/model/trust.model'
 import { mapCommonTrustDataToPage } from '../../src/utils/trust/common.trust.data.mapper';
 import { mapIndividualTrusteeToSession } from '../../src/utils/trust/individual.trustee.mapper';
 import { getTrustByIdFromApp, saveIndividualTrusteeInTrust, saveTrustInApp } from '../../src/utils/trusts';
+
+import { saveAndContinue } from '../../src/utils/save.and.continue';
+
+const mockSaveAndContinue = saveAndContinue as jest.Mock;
 
 describe('Trust Individual Beneficial Owner Controller', () => {
   const mockGetApplicationData = getApplicationData as jest.Mock;
@@ -171,11 +176,12 @@ describe('Trust Individual Beneficial Owner Controller', () => {
     });
 
     test('successfully access POST method', async () => {
-      const resp = await request(app).post(pageUrl);
+      const resp = await request(app).post(pageUrl).send({});
 
       expect(resp.status).toEqual(constants.HTTP_STATUS_OK);
       expect(authentication).toBeCalledTimes(1);
       expect(hasTrust).toBeCalledTimes(1);
+      expect(mockSaveAndContinue).toHaveBeenCalledTimes(1);
     });
   });
 });


### PR DESCRIPTION
### JIRA link
[ROE-1993](https://companieshouse.atlassian.net/browse/ROE-1993)


### Change description
Update the code for adding an individual trustee to use "Save and Control" rather than "continue"

Sonar has spotted some "duplicate" code but moving it away would obscure the code (for me at least)


### Work checklist

- [x] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.


[ROE-1993]: https://companieshouse.atlassian.net/browse/ROE-1993?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ