### PR TITLE
Feature/roe 1992 correct parsing on trust has all info

### DIFF
--- a/src/model/trust.model.ts
+++ b/src/model/trust.model.ts
@@ -30,7 +30,7 @@ export interface Trust {
   creation_date_day: string;
   creation_date_month: string;
   creation_date_year: string;
-  unable_to_obtain_all_trust_info: string; // "Yes" or "No" required on the spreadsheet solution so we can use yesNoResponse
+  unable_to_obtain_all_trust_info: string; // "Yes" or "No" required on the spreadsheet solution so we can NOT use yesNoResponse
   INDIVIDUALS?: TrustIndividual[];
   HISTORICAL_BO?: TrustHistoricalBeneficialOwner[];
   CORPORATES?: TrustCorporate[];

--- a/src/model/trust.model.ts
+++ b/src/model/trust.model.ts
@@ -30,7 +30,7 @@ export interface Trust {
   creation_date_day: string;
   creation_date_month: string;
   creation_date_year: string;
-  unable_to_obtain_all_trust_info: string;
+  unable_to_obtain_all_trust_info: string; // "Yes" or "No" required on the spreadsheet solution so we can use yesNoResponse
   INDIVIDUALS?: TrustIndividual[];
   HISTORICAL_BO?: TrustHistoricalBeneficialOwner[];
   CORPORATES?: TrustCorporate[];

--- a/src/utils/trust/details.mapper.ts
+++ b/src/utils/trust/details.mapper.ts
@@ -20,13 +20,26 @@ const mapDetailToPage = (
       .filter((bo: TrustBeneficialOwner) => bo.trust_ids?.includes(trustId))
       .map(bo => bo.id || "");
 
+  let unableToObtainAllTrustInfo: string;
+  switch (trustData.unable_to_obtain_all_trust_info) {
+      case "Yes":
+        unableToObtainAllTrustInfo = "1";
+        break;
+      case "No":
+        unableToObtainAllTrustInfo = "0";
+        break;
+      default:
+        unableToObtainAllTrustInfo = ""; // forces user to enter a value on new trust
+        break;
+  }
+
   return {
     trustId: trustData.trust_id,
     name: trustData.trust_name,
     createdDateDay: trustData.creation_date_day,
     createdDateMonth: trustData.creation_date_month,
     createdDateYear: trustData.creation_date_year,
-    hasAllInfo: trustData.unable_to_obtain_all_trust_info,
+    hasAllInfo: unableToObtainAllTrustInfo,
     beneficialOwnersIds: trustBoIds,
   };
 };
@@ -43,7 +56,7 @@ const mapDetailToSession = (
     creation_date_day: data.createdDateDay,
     creation_date_month: data.createdDateMonth,
     creation_date_year: data.createdDateYear,
-    unable_to_obtain_all_trust_info: data.hasAllInfo,
+    unable_to_obtain_all_trust_info: (data.hasAllInfo === "1") ? "Yes" : "No",
   };
 };
 

--- a/test/utils/trust/details.mapper.spec.ts
+++ b/test/utils/trust/details.mapper.spec.ts
@@ -58,6 +58,8 @@ describe('Trust Details page Mapper Service', () => {
     ],
   };
 
+  const unknownTrustId = '3838373838';
+
   beforeEach(() => {
     jest.clearAllMocks();
   });
@@ -89,6 +91,10 @@ describe('Trust Details page Mapper Service', () => {
         ],
         hasAllInfo: '0',
       });
+    });
+    test('mapDetailToPage should return object (verify napping of hasAllInfo for new trust)', () => {
+      const initialFormDetails = mapDetailToPage(mockAppData, unknownTrustId);
+      expect(initialFormDetails.hasAllInfo).toBe("");
     });
   });
 

--- a/test/utils/trust/details.mapper.spec.ts
+++ b/test/utils/trust/details.mapper.spec.ts
@@ -23,11 +23,19 @@ describe('Trust Details page Mapper Service', () => {
     creation_date_day: '99',
     creation_date_month: '88',
     creation_date_year: '2077',
-    unable_to_obtain_all_trust_info: '1',
+    unable_to_obtain_all_trust_info: 'Yes',
+  };
+  const mockTrust2 = {
+    trust_id: '2000',
+    trust_name: 'dummyName2',
+    creation_date_day: '10',
+    creation_date_month: '11',
+    creation_date_year: '2077',
+    unable_to_obtain_all_trust_info: 'No',
   };
   const mockBoIndividual1 = {
     id: '9001',
-    trust_ids: ['901', mockTrust1.trust_id],
+    trust_ids: ['901', mockTrust1.trust_id, mockTrust2.trust_id],
   } as BeneficialOwnerIndividual;
 
   const mockBoOle1 = {
@@ -38,6 +46,7 @@ describe('Trust Details page Mapper Service', () => {
   const mockAppData = {
     [TrustKey]: [
       mockTrust1,
+      mockTrust2,
     ],
     [BeneficialOwnerIndividualKey]: [
       mockBoIndividual1,
@@ -54,7 +63,7 @@ describe('Trust Details page Mapper Service', () => {
   });
 
   describe('To Page mapper methods tests', () => {
-    test('mapDetailToPage should return object', () => {
+    test('mapDetailToPage should return object (verify napping of hasAllInfo when true)', () => {
       expect(mapDetailToPage(mockAppData, mockTrust1.trust_id)).toEqual({
         trustId: mockTrust1.trust_id,
         name: mockTrust1.trust_name,
@@ -65,7 +74,20 @@ describe('Trust Details page Mapper Service', () => {
           mockBoIndividual1.id,
           mockBoOle1.id,
         ],
-        hasAllInfo: mockTrust1.unable_to_obtain_all_trust_info,
+        hasAllInfo: '1',
+      });
+    });
+    test('mapDetailToPage should return object (verify napping of hasAllInfo when false)', () => {
+      expect(mapDetailToPage(mockAppData, mockTrust2.trust_id)).toEqual({
+        trustId: mockTrust2.trust_id,
+        name: mockTrust2.trust_name,
+        createdDateDay: mockTrust2.creation_date_day,
+        createdDateMonth: mockTrust2.creation_date_month,
+        createdDateYear: mockTrust2.creation_date_year,
+        beneficialOwnersIds: [
+          mockBoIndividual1.id,
+        ],
+        hasAllInfo: '0',
       });
     });
   });
@@ -80,14 +102,34 @@ describe('Trust Details page Mapper Service', () => {
       hasAllInfo: '1',
     } as Page.TrustDetailsForm;
 
-    test('mapDetailToSession should return object', () => {
+    const mockFormData2 = {
+      trustId: '999',
+      name: 'dummyName',
+      createdDateDay: '99',
+      createdDateMonth: '88',
+      createdDateYear: '2077',
+      hasAllInfo: '0',
+    } as Page.TrustDetailsForm;
+
+    test('mapDetailToSession should return object (verify napping of unable_to_obtain_all_trust_info when true)', () => {
       expect(mapDetailToSession(mockFormData)).toEqual({
         trust_id: mockFormData.trustId,
         trust_name: mockFormData.name,
         creation_date_day: mockFormData.createdDateDay,
         creation_date_month: mockFormData.createdDateMonth,
         creation_date_year: mockFormData.createdDateYear,
-        unable_to_obtain_all_trust_info: mockFormData.hasAllInfo,
+        unable_to_obtain_all_trust_info: "Yes",
+      });
+    });
+
+    test('mapDetailToSession should return object (verify napping of unable_to_obtain_all_trust_info when false)', () => {
+      expect(mapDetailToSession(mockFormData2)).toEqual({
+        trust_id: mockFormData.trustId,
+        trust_name: mockFormData.name,
+        creation_date_day: mockFormData.createdDateDay,
+        creation_date_month: mockFormData.createdDateMonth,
+        creation_date_year: mockFormData.createdDateYear,
+        unable_to_obtain_all_trust_info: "No",
       });
     });
 
@@ -101,7 +143,7 @@ describe('Trust Details page Mapper Service', () => {
       expect(actual).toEqual([
         {
           ...mockBoIndividual1,
-          trust_ids: ['901'],
+          trust_ids: ['901', mockTrust2.trust_id],
         },
         {
           trust_ids: [],
@@ -133,7 +175,7 @@ describe('Trust Details page Mapper Service', () => {
     });
   });
 
-  test('mapDetailToSession should return object', () => {
-    expect(generateTrustId(mockAppData)).toBe('2');
+  test('mapDetailToSession should return next trust id', () => {
+    expect(generateTrustId(mockAppData)).toBe('3');
   });
 });

--- a/views/trust-details.html
+++ b/views/trust-details.html
@@ -69,14 +69,14 @@
           error: errors.hasAllInfo if errors,
           items: [
             {
-              value: 1,
+              value: '1',
               text: 'Yes',
-              checked: formData.hasAllInfo == 1
+              checked: formData.hasAllInfo == '1'
             },
             {
-              value: 0,
+              value: '0',
               text: 'No',
-              checked: formData.hasAllInfo == 0
+              checked: formData.hasAllInfo == '0'
             }
           ]
         } %}


### PR DESCRIPTION
### JIRA link
[ROE-1992](https://companieshouse.atlassian.net/browse/ROE-1992)

### Change description
Fixed issue of trust has all info not saving properly and no displaying on "Save and Resume". Note that because we are still using the spreadsheet solution I could not change the trust variable unable_to_obtain_all_trust_info to a yesNoResponse type


### Work checklist

- [x] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.


[ROE-1992]: https://companieshouse.atlassian.net/browse/ROE-1992?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ