### PR TITLE
Update Trust Historical BO to allow both former Individuals and corporate trustee types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "@companieshouse/api-sdk-node": "^2.0.50",
+        "@companieshouse/api-sdk-node": "^2.0.52",
         "@companieshouse/node-session-handler": "^4.1.6",
         "@companieshouse/structured-logging-node": "^1.0.4",
         "cookie-parser": "^1.4.6",
@@ -641,9 +641,9 @@
       }
     },
     "node_modules/@companieshouse/api-sdk-node": {
-      "version": "2.0.50",
-      "resolved": "https://registry.npmjs.org/@companieshouse/api-sdk-node/-/api-sdk-node-2.0.50.tgz",
-      "integrity": "sha512-26IDlJTvFfhucBY9ZZjTzIQL0Vt3koBJhhrr7IjL+FwkT+iSz51Y4g63EYziyTYXdzC4TOzO+p22JybzitARow==",
+      "version": "2.0.52",
+      "resolved": "https://registry.npmjs.org/@companieshouse/api-sdk-node/-/api-sdk-node-2.0.52.tgz",
+      "integrity": "sha512-FaT1hFwwuVcDPEFarIBwB5dAa96uFCTUoeLw0vbPK6+0SsPt9Z+dfyzFbbEBpRV761dUIcckp7jqLXMdfXc+yg==",
       "dependencies": {
         "camelcase-keys": "~6.2.2",
         "request": "~2.88.2",
@@ -8873,9 +8873,9 @@
       "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ=="
     },
     "@companieshouse/api-sdk-node": {
-      "version": "2.0.50",
-      "resolved": "https://registry.npmjs.org/@companieshouse/api-sdk-node/-/api-sdk-node-2.0.50.tgz",
-      "integrity": "sha512-26IDlJTvFfhucBY9ZZjTzIQL0Vt3koBJhhrr7IjL+FwkT+iSz51Y4g63EYziyTYXdzC4TOzO+p22JybzitARow==",
+      "version": "2.0.52",
+      "resolved": "https://registry.npmjs.org/@companieshouse/api-sdk-node/-/api-sdk-node-2.0.52.tgz",
+      "integrity": "sha512-FaT1hFwwuVcDPEFarIBwB5dAa96uFCTUoeLw0vbPK6+0SsPt9Z+dfyzFbbEBpRV761dUIcckp7jqLXMdfXc+yg==",
       "requires": {
         "camelcase-keys": "~6.2.2",
         "request": "~2.88.2",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "license": "MIT",
   "homepage": "https://github.com/companieshouse/overseas-entities-web#readme",
   "dependencies": {
-    "@companieshouse/api-sdk-node": "^2.0.50",
+    "@companieshouse/api-sdk-node": "^2.0.52",
     "@companieshouse/node-session-handler": "^4.1.6",
     "@companieshouse/structured-logging-node": "^1.0.4",
     "@companieshouse/web-security-node": "^2.0.1",

--- a/src/model/trust.model.ts
+++ b/src/model/trust.model.ts
@@ -3,7 +3,6 @@ import { BeneficialOwnerOther } from '../model/beneficial.owner.other.model';
 import { BeneficialOwnerTypeChoice } from '../model/beneficial.owner.type.model';
 import { yesNoResponse } from './data.types.model';
 import { RoleWithinTrustType } from './role.within.trust.type.model';
-import { TrusteeType } from './trustee.type.model';
 
 export const TrustKey = "trusts";
 
@@ -69,7 +68,7 @@ interface TrustIndividual {
 
 interface TrustHistoricalBeneficialOwnerCommon {
   id?: string;
-  corporate_indicator: TrusteeType;
+  corporate_indicator: yesNoResponse;
   ceased_date_day: string;
   ceased_date_month: string;
   ceased_date_year: string;

--- a/src/utils/trust/historical.beneficial.owner.mapper.ts
+++ b/src/utils/trust/historical.beneficial.owner.mapper.ts
@@ -2,13 +2,13 @@ import { v4 as uuidv4 } from 'uuid';
 import { TrusteeType } from '../../model/trustee.type.model';
 import * as Trust from '../../model/trust.model';
 import * as Page from '../../model/trust.page.model';
+import { yesNoResponse } from '../../model/data.types.model';
 
 const mapBeneficialOwnerToSession = (
   formData: Page.TrustHistoricalBeneficialOwnerForm,
 ): Trust.TrustHistoricalBeneficialOwner => {
   const data = {
     id: formData.boId || generateBoId(),
-    corporate_indicator: formData.type as TrusteeType,
     notified_date_day: formData.startDateDay,
     notified_date_month: formData.startDateMonth,
     notified_date_year: formData.startDateYear,
@@ -20,12 +20,14 @@ const mapBeneficialOwnerToSession = (
   if (formData.type === TrusteeType.LEGAL_ENTITY) {
     return {
       ...data,
+      corporate_indicator: yesNoResponse.Yes,
       corporate_name: formData.corporate_name,
     };
   }
 
   return {
     ...data,
+    corporate_indicator: yesNoResponse.No,
     forename: formData.firstName,
     surname: formData.lastName,
   };

--- a/test/utils/trust/historical.beneficial.owner.mapper.spec.ts
+++ b/test/utils/trust/historical.beneficial.owner.mapper.spec.ts
@@ -8,6 +8,7 @@ import {
   mapBeneficialOwnerToSession,
 } from '../../../src/utils/trust/historical.beneficial.owner.mapper';
 import { TrusteeType } from "../../../src/model/trustee.type.model";
+import { yesNoResponse } from "../../../src/model/data.types.model";
 
 describe('Historical Beneficial Owner page Mapper Service', () => {
   beforeEach(() => {
@@ -36,7 +37,7 @@ describe('Historical Beneficial Owner page Mapper Service', () => {
 
         expect(mapBeneficialOwnerToSession(mockFormData as Page.TrustHistoricalBeneficialOwnerForm)).toEqual({
           id: mockFormData.boId,
-          corporate_indicator: mockFormData.type,
+          corporate_indicator: yesNoResponse.No,
           forename: mockFormData.firstName,
           surname: mockFormData.lastName,
           notified_date_day: mockFormData.startDateDay,
@@ -61,7 +62,7 @@ describe('Historical Beneficial Owner page Mapper Service', () => {
 
         expect(mapBeneficialOwnerToSession(mockFormData as Page.TrustHistoricalBeneficialOwnerForm)).toEqual({
           id: expectNewId,
-          corporate_indicator: mockFormData.type,
+          corporate_indicator: yesNoResponse.Yes,
           corporate_name: mockFormData.corporate_name,
           notified_date_day: mockFormData.startDateDay,
           notified_date_month: mockFormData.startDateMonth,


### PR DESCRIPTION
### JIRA link
[ROE-1992](https://companieshouse.atlassian.net/browse/ROE-1992) - for development work
[ROE-1919](https://companieshouse.atlassian.net/browse/ROE-1919) - for developer end to end testing with the API


### Change description
Need to change the model for historic BO corporate_indicator to YesNoIndicator so that it works with the Node SDK and `overseas-entities-api`. This also required a related mapping change


### Work checklist

- [x] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.


[ROE-1992]: https://companieshouse.atlassian.net/browse/ROE-1992?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[ROE-1919]: https://companieshouse.atlassian.net/browse/ROE-1919?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ