### PR TITLE
Generate trustee ids on resuming a web submission

### DIFF
--- a/src/controllers/resume.submission.controller.ts
+++ b/src/controllers/resume.submission.controller.ts
@@ -20,6 +20,7 @@ import { ManagingOfficerCorporate, ManagingOfficerCorporateKey } from "../model/
 import { ManagingOfficerIndividual, ManagingOfficerKey } from "../model/managing.officer.model";
 import { startPaymentsSession } from "../service/payment.service";
 import { getTransaction } from "../service/transaction.service";
+import { generateTrusteeIds } from "../utils/trusts";
 
 export const get = async (req: Request, res: Response, next: NextFunction) => {
   try {
@@ -96,6 +97,8 @@ const setWebApplicationData = (session: Session, appData: ApplicationData, trans
   } else if (Object.keys(appData[DueDiligenceKey] as DueDiligence).length){
     appData[WhoIsRegisteringKey] = WhoIsRegisteringType.AGENT;
   }
+
+  generateTrusteeIds(appData);
 
   setExtraData(session, appData);
 };

--- a/src/model/trust.model.ts
+++ b/src/model/trust.model.ts
@@ -35,7 +35,7 @@ export interface Trust {
   CORPORATES?: TrustCorporate[];
 }
 
-interface TrustIndividual {
+export interface TrustIndividual {
   id?: string;
   type: RoleWithinTrustType;
   forename: string;

--- a/src/utils/trusts.ts
+++ b/src/utils/trusts.ts
@@ -1,3 +1,4 @@
+import { v4 as uuidv4 } from "uuid";
 import { TRUST_DETAILS_URL, TRUST_INTERRUPT_URL, TRUST_ENTRY_URL, ADD_TRUST_URL } from "../config";
 import { ApplicationData } from "../model";
 import { BeneficialOwnerIndividual, BeneficialOwnerIndividualKey } from "../model/beneficial.owner.individual.model";
@@ -10,6 +11,7 @@ import {
   IndividualTrustee,
   TrustKey,
   TrustCorporate,
+  TrustIndividual,
 } from "../model/trust.model";
 
 /**
@@ -281,6 +283,26 @@ const saveIndividualTrusteeInTrust = (trust: Trust, trusteeData: IndividualTrust
   return trust;
 };
 
+/**
+ * The Trustee Ids are NOT part of the OE API data model nor part of the SDK mapper object. They need
+ * to be generated when the Trust Data is got from the API (e.g. for a "Save and Resume" journey)
+ * @param appData - application data
+ * @returns void
+ */
+const generateTrusteeIds = (appData: ApplicationData) => {
+
+  if (containsTrustData(getTrustArray(appData))) {
+
+    for (const trust of appData.trusts ?? []) {
+
+      trust.CORPORATES = (trust.CORPORATES as TrustCorporate[]).map( te => {return { ...te, id: uuidv4() }; } );
+      trust.HISTORICAL_BO = (trust.HISTORICAL_BO as TrustHistoricalBeneficialOwner[]).map( te => {return { ...te, id: uuidv4() }; } );
+      trust.INDIVIDUALS = (trust.INDIVIDUALS as TrustIndividual[]).map( te => {return { ...te, id: uuidv4() }; } );
+
+    }
+  }
+};
+
 export {
   checkEntityRequiresTrusts,
   getBeneficialOwnerList,
@@ -302,4 +324,5 @@ export {
   getTrustLandingUrl,
   containsTrustData,
   getIndividualTrustee,
+  generateTrusteeIds,
 };

--- a/test/controllers/resume.submission.controller.spec.ts
+++ b/test/controllers/resume.submission.controller.spec.ts
@@ -7,6 +7,7 @@ jest.mock('../../src/service/payment.service');
 jest.mock('../../src/utils/application.data');
 jest.mock("../../src/utils/feature.flag" );
 jest.mock("../../src/utils/logger");
+jest.mock("../../src/utils/trusts");
 
 import { describe, expect, test, jest, beforeEach } from '@jest/globals';
 import { NextFunction, Request, Response } from "express";
@@ -44,6 +45,7 @@ import { HasSoldLandKey, IsSecureRegisterKey, OverseasEntityKey, Transactionkey 
 import { OverseasEntityDueDiligenceKey } from '../../src/model/overseas.entity.due.diligence.model';
 import { OVERSEAS_ENTITY_DUE_DILIGENCE_OBJECT_MOCK } from '../__mocks__/overseas.entity.due.diligence.mock';
 import { MOCK_GET_TRANSACTION_RESPONSE } from '../__mocks__/transaction.mock';
+import { generateTrusteeIds } from '../../src/utils/trusts';
 
 const mockServiceAvailabilityMiddleware = serviceAvailabilityMiddleware as jest.Mock;
 mockServiceAvailabilityMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => next() );
@@ -66,6 +68,8 @@ mockGetOverseasEntity.mockReturnValue( APPLICATION_DATA_MOCK );
 
 const mockAuthenticationMiddleware = authentication as jest.Mock;
 mockAuthenticationMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => next() );
+
+const mockGenerateTrusteeIds = generateTrusteeIds as jest.Mock;
 
 describe("Resume submission controller", () => {
 
@@ -107,6 +111,7 @@ describe("Resume submission controller", () => {
     expect(mockGetOverseasEntity).toHaveBeenCalledTimes(1);
     expect(mockCreateAndLogErrorRequest).not.toHaveBeenCalled();
     expect(mockSetExtraData).toHaveBeenCalledTimes(1);
+    expect(mockGenerateTrusteeIds).toHaveBeenCalledTimes(1);
   });
 
   test(`Redirect to ${SOLD_LAND_FILTER_PAGE} page after Resuming the OverseasEntity with Overseas Entity DueDiligence object`, async () => {
@@ -161,6 +166,7 @@ describe("Resume submission controller", () => {
     expect(mockGetOverseasEntity).toHaveBeenCalledTimes(1);
     expect(mockSetExtraData).toHaveBeenCalledTimes(1);
     expect(mockCreateAndLogErrorRequest).not.toHaveBeenCalled();
+    expect(mockGenerateTrusteeIds).toHaveBeenCalledTimes(1);
   });
 
   test(`Should throw an error on Resuming the OverseasEntity`, async () => {

--- a/test/utils/trust.spec.ts
+++ b/test/utils/trust.spec.ts
@@ -487,33 +487,64 @@ describe('Trust Utils method tests', () => {
   describe('test generating id for trustees', () => {
 
     const test_trust_id = '342';
+    const second_test_trust_id = '546';
     const individualTrustee1 = { forename: "Fred", surname: "Bloggs" } as IndividualTrustee;
     const individualTrustee2 = { forename: "John", surname: "Doe" } as IndividualTrustee;
+    const corporateTrustee1 = { name: "Orange" } as TrustCorporate;
+    const corporateTrustee2 = { name: "Apple" } as TrustCorporate;
+    const historicBoTrustee1 = { ceased_date_day: "1", ceased_date_month: "2" } as TrustHistoricalBeneficialOwner;
+    const historicBoTrustee2 = { ceased_date_day: "2", ceased_date_month: "4" } as TrustHistoricalBeneficialOwner;
+
     const appData = {
       [TrustKey]: [{
         'trust_id': test_trust_id,
         'CORPORATES': [] as TrustCorporate[],
         'INDIVIDUALS': [ individualTrustee1, individualTrustee2 ] as TrustIndividual[],
         'HISTORICAL_BO': [] as TrustHistoricalBeneficialOwner[],
-      }]
+      }, {
+        'trust_id': second_test_trust_id,
+        'CORPORATES': [ corporateTrustee1, corporateTrustee2 ] as TrustCorporate[],
+        'INDIVIDUALS': [] as TrustIndividual[],
+        'HISTORICAL_BO': [ historicBoTrustee1, historicBoTrustee2 ] as TrustHistoricalBeneficialOwner[],
+      }
+      ]
     } as ApplicationData;
 
-    test("test ids are added for simple app data with one trust and just individual trusees", () => {
+    test("test ids are added for multi-trust app data all trusees types", () => {
+
       const trusts = appData.trusts ?? [];
+
       const trust = trusts[0];
       let individualTrustees = trust.INDIVIDUALS ?? [];
       expect(individualTrustees[0]).not.toHaveProperty('id');
       expect(individualTrustees[1]).not.toHaveProperty('id');
 
+      const trust2 = trusts[1];
+      let corporateTrustees2 = trust2.CORPORATES ?? [];
+      expect(corporateTrustees2[0]).not.toHaveProperty('id');
+      expect(corporateTrustees2[1]).not.toHaveProperty('id');
+      let historicTrustees2 = trust2.HISTORICAL_BO ?? [];
+      expect(historicTrustees2[0]).not.toHaveProperty('id');
+      expect(historicTrustees2[1]).not.toHaveProperty('id');
+
       generateTrusteeIds(appData);
 
-      // the references are updated in the trustee arrays for these changes
+      // the trustee array references are updated in generateTrusteeIds
       individualTrustees = trust.INDIVIDUALS ?? [];
       expect(individualTrustees[0]).toHaveProperty('id');
       expect(individualTrustees[1]).toHaveProperty('id');
 
+      corporateTrustees2 = trust2.CORPORATES ?? [];
+      expect(corporateTrustees2[0]).toHaveProperty('id');
+      expect(corporateTrustees2[1]).toHaveProperty('id');
+      historicTrustees2 = trust2.HISTORICAL_BO ?? [];
+      expect(historicTrustees2[0]).toHaveProperty('id');
+      expect(historicTrustees2[1]).toHaveProperty('id');
     });
 
+  });
+  test("no trust data so nothing happens in generate trust ids", () => {
+    generateTrusteeIds({});
   });
 
 });

--- a/test/utils/trust.spec.ts
+++ b/test/utils/trust.spec.ts
@@ -17,6 +17,7 @@ import {
   getFormerTrusteesFromTrust,
   checkEntityRequiresTrusts,
   getTrustLandingUrl,
+  generateTrusteeIds,
 } from '../../src/utils/trusts';
 import { ApplicationData } from '../../src/model';
 import { NatureOfControlType } from '../../src/model/data.types.model';
@@ -479,6 +480,38 @@ describe('Trust Utils method tests', () => {
 
       const result = getTrustLandingUrl(appData);
       expect(result).toEqual(`${TRUST_DETAILS_URL}${TRUST_INTERRUPT_URL}`);
+    });
+
+  });
+
+  describe('test generating id for trustees', () => {
+
+    const test_trust_id = '342';
+    const individualTrustee1 = { forename: "Fred", surname: "Bloggs" } as IndividualTrustee;
+    const individualTrustee2 = { forename: "John", surname: "Doe" } as IndividualTrustee;
+    const appData = {
+      [TrustKey]: [{
+        'trust_id': test_trust_id,
+        'CORPORATES': [] as TrustCorporate[],
+        'INDIVIDUALS': [ individualTrustee1, individualTrustee2 ] as TrustIndividual[],
+        'HISTORICAL_BO': [] as TrustHistoricalBeneficialOwner[],
+      }]
+    } as ApplicationData;
+
+    test("test ids are added for simple app data with one trust and just individual trusees", () => {
+      const trusts = appData.trusts ?? [];
+      const trust = trusts[0];
+      let individualTrustees = trust.INDIVIDUALS ?? [];
+      expect(individualTrustees[0]).not.toHaveProperty('id');
+      expect(individualTrustees[1]).not.toHaveProperty('id');
+
+      generateTrusteeIds(appData);
+
+      // the references are updated in the trustee arrays for these changes
+      individualTrustees = trust.INDIVIDUALS ?? [];
+      expect(individualTrustees[0]).toHaveProperty('id');
+      expect(individualTrustees[1]).toHaveProperty('id');
+
     });
 
   });


### PR DESCRIPTION
### JIRA link
[ROE-2054](https://companieshouse.atlassian.net/browse/ROE-2054)

### Change description
The trustee Ids are not part of the API Model, therefore they need to be generated when we resume a submission. This has been done in a separate function to aid unit testing but in a similar manner to the Beneficial Owner arrays (where their objects also need to have their ID generated)

### Work checklist

- [x] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.


[ROE-2054]: https://companieshouse.atlassian.net/browse/ROE-2054?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ