### PR TITLE
Feature/roe 2059 legal entity trustee change links

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@companieshouse/api-sdk-node": "^2.0.52",
         "@companieshouse/node-session-handler": "^4.1.6",
         "@companieshouse/structured-logging-node": "^1.0.4",
+        "@companieshouse/web-security-node": "^2.0.1",
         "cookie-parser": "^1.4.6",
         "express": "^4.17.3",
         "express-validator": "^6.14.0",
@@ -673,6 +674,15 @@
         "moment": "~2.29.0",
         "on-finished": "~2.3.0",
         "winston": "~3.3.3"
+      }
+    },
+    "node_modules/@companieshouse/web-security-node": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@companieshouse/web-security-node/-/web-security-node-2.0.2.tgz",
+      "integrity": "sha512-DhHF5a8RIXRHXBE9lHCpzPf3y+k2cY90MrBSf4D4Npq4Iz+6OxtsTw6OaShIXmFRv9vGy8eq49azgBcYk/PAbg==",
+      "dependencies": {
+        "@companieshouse/node-session-handler": "~4.1.4",
+        "@companieshouse/structured-logging-node": "~1.0.3"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -8908,9 +8918,9 @@
       }
     },
     "@companieshouse/web-security-node": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@companieshouse/web-security-node/-/web-security-node-2.0.1.tgz",
-      "integrity": "sha512-k2yr8nKy0AO/eRx11K+CLtOStp6W+rL/md/s10Pej10OGIog3++mZS7zjDIH1w2be2vmKlH+4pFxOmIGCigJEg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@companieshouse/web-security-node/-/web-security-node-2.0.2.tgz",
+      "integrity": "sha512-DhHF5a8RIXRHXBE9lHCpzPf3y+k2cY90MrBSf4D4Npq4Iz+6OxtsTw6OaShIXmFRv9vGy8eq49azgBcYk/PAbg==",
       "requires": {
         "@companieshouse/node-session-handler": "~4.1.4",
         "@companieshouse/structured-logging-node": "~1.0.3"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,9 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "@companieshouse/api-sdk-node": "^2.0.52",
+        "@companieshouse/api-sdk-node": "^2.0.53",
         "@companieshouse/node-session-handler": "^4.1.6",
         "@companieshouse/structured-logging-node": "^1.0.4",
-        "@companieshouse/web-security-node": "^2.0.1",
         "cookie-parser": "^1.4.6",
         "express": "^4.17.3",
         "express-validator": "^6.14.0",
@@ -642,9 +641,9 @@
       }
     },
     "node_modules/@companieshouse/api-sdk-node": {
-      "version": "2.0.52",
-      "resolved": "https://registry.npmjs.org/@companieshouse/api-sdk-node/-/api-sdk-node-2.0.52.tgz",
-      "integrity": "sha512-FaT1hFwwuVcDPEFarIBwB5dAa96uFCTUoeLw0vbPK6+0SsPt9Z+dfyzFbbEBpRV761dUIcckp7jqLXMdfXc+yg==",
+      "version": "2.0.53",
+      "resolved": "https://registry.npmjs.org/@companieshouse/api-sdk-node/-/api-sdk-node-2.0.53.tgz",
+      "integrity": "sha512-N14HQdyfc3o16oyosOU7ANh859mFDjY3YXAYBICGDuPqJlGQXp/xuXIXnpKxdihWwOvJJGrFrQqsXZy5ZzVYXg==",
       "dependencies": {
         "camelcase-keys": "~6.2.2",
         "request": "~2.88.2",
@@ -674,15 +673,6 @@
         "moment": "~2.29.0",
         "on-finished": "~2.3.0",
         "winston": "~3.3.3"
-      }
-    },
-    "node_modules/@companieshouse/web-security-node": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@companieshouse/web-security-node/-/web-security-node-2.0.2.tgz",
-      "integrity": "sha512-DhHF5a8RIXRHXBE9lHCpzPf3y+k2cY90MrBSf4D4Npq4Iz+6OxtsTw6OaShIXmFRv9vGy8eq49azgBcYk/PAbg==",
-      "dependencies": {
-        "@companieshouse/node-session-handler": "~4.1.4",
-        "@companieshouse/structured-logging-node": "~1.0.3"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -8883,9 +8873,9 @@
       "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ=="
     },
     "@companieshouse/api-sdk-node": {
-      "version": "2.0.52",
-      "resolved": "https://registry.npmjs.org/@companieshouse/api-sdk-node/-/api-sdk-node-2.0.52.tgz",
-      "integrity": "sha512-FaT1hFwwuVcDPEFarIBwB5dAa96uFCTUoeLw0vbPK6+0SsPt9Z+dfyzFbbEBpRV761dUIcckp7jqLXMdfXc+yg==",
+      "version": "2.0.53",
+      "resolved": "https://registry.npmjs.org/@companieshouse/api-sdk-node/-/api-sdk-node-2.0.53.tgz",
+      "integrity": "sha512-N14HQdyfc3o16oyosOU7ANh859mFDjY3YXAYBICGDuPqJlGQXp/xuXIXnpKxdihWwOvJJGrFrQqsXZy5ZzVYXg==",
       "requires": {
         "camelcase-keys": "~6.2.2",
         "request": "~2.88.2",
@@ -8918,9 +8908,9 @@
       }
     },
     "@companieshouse/web-security-node": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@companieshouse/web-security-node/-/web-security-node-2.0.2.tgz",
-      "integrity": "sha512-DhHF5a8RIXRHXBE9lHCpzPf3y+k2cY90MrBSf4D4Npq4Iz+6OxtsTw6OaShIXmFRv9vGy8eq49azgBcYk/PAbg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@companieshouse/web-security-node/-/web-security-node-2.0.1.tgz",
+      "integrity": "sha512-k2yr8nKy0AO/eRx11K+CLtOStp6W+rL/md/s10Pej10OGIog3++mZS7zjDIH1w2be2vmKlH+4pFxOmIGCigJEg==",
       "requires": {
         "@companieshouse/node-session-handler": "~4.1.4",
         "@companieshouse/structured-logging-node": "~1.0.3"

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -243,11 +243,13 @@ export const CONTACT_EMAIL = "#contact_email";
 export const CREATED_DATE = "#createdDate-createdDateDay";
 export const INCORPORATION_COUNTRY = "#incorporation_country";
 export const ENTITY_NAME = "#entity_name";
-export const ROLE_WITHIN_TRUST = "#type";
+export const ROLE_WITHIN_TRUST = "#roleWithinTrust";
 export const FORENAME = "#forename";
 export const SURNAME = "#surname";
 export const TRUST_DATE_OF_BIRTH = "#dateOfBirth-dateOfBirthDay";
 export const INTERESTED_PERSON_START_DATE = "#dateBecameIP-dateBecameIPDay";
+export const PUBLIC_REGISTER_JURISDICTION = "#public_register_jurisdiction";
+export const LEGAL_ENTITY_NAME = "#legalEntityName";
 
 export const ENTITY_CHANGE_NAME = OVERSEAS_NAME_URL + ENTITY_NAME;
 export const PRESENTER_CHANGE_FULL_NAME = PRESENTER_URL + "#full_name";

--- a/src/controllers/trust.legal.entity.beneficial.owner.controller.ts
+++ b/src/controllers/trust.legal.entity.beneficial.owner.controller.ts
@@ -5,7 +5,7 @@ import { safeRedirect } from '../utils/http.ext';
 import { getApplicationData, setExtraData } from '../utils/application.data';
 import { getTrustByIdFromApp, saveLegalEntityBoInTrust, saveTrustInApp } from '../utils/trusts';
 import * as CommonTrustDataMapper from '../utils/trust/common.trust.data.mapper';
-import { mapLegalEntityToSession } from '../utils/trust/legal.entity.beneficial.owner.mapper';
+import { mapLegalEntityTrusteeFromSessionToPage, mapLegalEntityToSession } from '../utils/trust/legal.entity.beneficial.owner.mapper';
 import { RoleWithinTrustType } from '../model/role.within.trust.type.model';
 import { ApplicationData } from '../model';
 import { CommonTrustData, TrustLegalEntityForm } from '../model/trust.page.model';
@@ -31,8 +31,9 @@ type TrustLegalEntityBeneificalOwnerPageProperties = {
 
 const getPageProperties = (
   req: Request,
+  trustId: string,
+  formData?: TrustLegalEntityForm,
 ): TrustLegalEntityBeneificalOwnerPageProperties => {
-  const trustId = req.params[config.ROUTE_PARAM_TRUST_ID];
 
   return {
     backLinkUrl: `${config.TRUST_ENTRY_URL}/${trustId}${config.TRUST_INVOLVED_URL}`,
@@ -44,6 +45,7 @@ const getPageProperties = (
       trustData: CommonTrustDataMapper.mapCommonTrustDataToPage(getApplicationData(req.session), trustId),
       roleWithinTrustType: RoleWithinTrustType
     },
+    formData,
   };
 };
 
@@ -55,7 +57,16 @@ const get = (
   try {
     logger.debugRequest(req, `${req.method} ${req.route.path}`);
 
-    const pageProps = getPageProperties(req);
+    const trustId = req.params[config.ROUTE_PARAM_TRUST_ID];
+    const trusteeId = req.params[config.ROUTE_PARAM_TRUSTEE_ID];
+    const appData: ApplicationData = getApplicationData(req.session);
+
+    const formData: TrustLegalEntityForm = mapLegalEntityTrusteeFromSessionToPage(
+      appData,
+      trustId,
+      trusteeId
+    );
+    const pageProps = getPageProperties(req, trustId, formData);
 
     return res.render(pageProps.templateName, pageProps);
   } catch (error) {

--- a/src/controllers/trust.legal.entity.beneficial.owner.controller.ts
+++ b/src/controllers/trust.legal.entity.beneficial.owner.controller.ts
@@ -106,8 +106,6 @@ const post = async (
 
     await saveAndContinue(req, session);
 
-    logger.debugRequest(req, "requestHere");
-
     return safeRedirect(res, `${config.TRUST_ENTRY_URL}/${trustId}${config.TRUST_INVOLVED_URL}`);
   } catch (error) {
     logger.errorRequest(req, error);

--- a/src/model/trust.page.model.ts
+++ b/src/model/trust.page.model.ts
@@ -41,7 +41,7 @@ interface TrustHistoricalBeneficialOwnerFormCommon {
 
 type IndividualTrusteesFormCommon = {
   trusteeId?: string,
-  type: RoleWithinTrustType,
+  roleWithinTrust: RoleWithinTrustType,
   forename: string,
   surname: string,
   dateOfBirthDay: string,

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -262,7 +262,7 @@ router
   .post(...validator.trustIndividualBeneficialOwner, trustIndividualbeneficialOwner.post);
 
 router
-  .route(config.TRUST_ENTRY_URL + config.TRUST_ID + config.TRUST_LEGAL_ENTITY_BENEFICIAL_OWNER_URL + config.ID + '?')
+  .route(config.TRUST_ENTRY_URL + config.TRUST_ID + config.TRUST_LEGAL_ENTITY_BENEFICIAL_OWNER_URL + config.TRUSTEE_ID + '?')
   .all(
     isFeatureEnabled(config.FEATURE_FLAG_ENABLE_TRUSTS_WEB),
     authentication,

--- a/src/utils/trust/individual.trustee.mapper.ts
+++ b/src/utils/trust/individual.trustee.mapper.ts
@@ -10,7 +10,7 @@ export const mapIndividualTrusteeToSession = (
 ): Trust.IndividualTrustee => {
   const data = {
     id: formData.trusteeId || uuidv4(),
-    type: formData.type,
+    type: formData.roleWithinTrust,
     forename: formData.forename,
     other_forenames: '',
     surname: formData.surname,
@@ -40,7 +40,7 @@ export const mapIndividualTrusteeToSession = (
     sa_address_po_box: '',
   };
 
-  if (formData.type === RoleWithinTrustType.INTERESTED_PERSON){
+  if (formData.roleWithinTrust === RoleWithinTrustType.INTERESTED_PERSON){
     return {
       ...data,
       date_became_interested_person_day: formData.dateBecameIPDay,
@@ -62,7 +62,7 @@ export const mapIndividualTrusteeFromSessionToPage = (
 
   const data = {
     trusteeId: trustee.id,
-    type: trustee.type,
+    roleWithinTrust: trustee.type,
     forename: trustee.forename,
     surname: trustee.surname,
     dateOfBirthDay: trustee.date_of_birth_day,

--- a/src/utils/trust/legal.entity.beneficial.owner.mapper.ts
+++ b/src/utils/trust/legal.entity.beneficial.owner.mapper.ts
@@ -8,6 +8,7 @@ import { ApplicationData } from 'model';
 const mapLegalEntityToSession = (
   formData: Page.TrustLegalEntityForm
 ): Trust.TrustCorporate => {
+
   return {
     id: formData.legalEntityId || generateId(),
     type: formData.roleWithinTrust,
@@ -77,7 +78,7 @@ const mapLegalEntityTrusteeFromSessionToPage = (
     public_register_jurisdiction: trustee.identification_country_registration,
     registration_number: trustee.identification_registration_number,
     is_service_address_same_as_principal_address: trustee.is_service_address_same_as_principal_address,
-    is_on_register_in_country_formed_in: trustee.is_service_address_same_as_principal_address,
+    is_on_register_in_country_formed_in: trustee.is_on_register_in_country_formed_in,
   };
 };
 

--- a/src/utils/trust/legal.entity.beneficial.owner.mapper.ts
+++ b/src/utils/trust/legal.entity.beneficial.owner.mapper.ts
@@ -2,6 +2,8 @@ import { v4 as uuidv4 } from "uuid";
 import * as Trust from "../../model/trust.model";
 import * as Page from "../../model/trust.page.model";
 import { TrusteeType } from '../../model/trustee.type.model';
+import { getLegalEntityTrustee } from '../../utils/trusts';
+import { ApplicationData } from 'model';
 
 const mapLegalEntityToSession = (
   formData: Page.TrustLegalEntityForm
@@ -41,6 +43,44 @@ const mapLegalEntityToSession = (
   };
 };
 
+const mapLegalEntityTrusteeFromSessionToPage = (
+  appData: ApplicationData,
+  trustId: string,
+  trusteeId: string,
+): Page.TrustLegalEntityForm => {
+  const trustee = getLegalEntityTrustee(appData, trustId, trusteeId);
+
+  return {
+    legalEntityId: trustee.id,
+    roleWithinTrust: trustee.type,
+    legalEntityName: trustee.name,
+    interestedPersonStartDateDay: trustee.date_became_interested_person_day,
+    interestedPersonStartDateMonth: trustee.date_became_interested_person_month,
+    interestedPersonStartDateYear: trustee.date_became_interested_person_year,
+    principal_address_property_name_number: trustee.ro_address_premises,
+    principal_address_line_1: trustee.ro_address_line1,
+    principal_address_line_2: trustee.ro_address_line2,
+    principal_address_town: trustee.ro_address_locality,
+    principal_address_county: trustee.ro_address_region,
+    principal_address_country: trustee.ro_address_country,
+    principal_address_postcode: trustee.ro_address_postal_code,
+    service_address_property_name_number: trustee.sa_address_premises,
+    service_address_line_1: trustee.sa_address_line1,
+    service_address_line_2: trustee.sa_address_line2,
+    service_address_town: trustee.sa_address_locality,
+    service_address_county: trustee.sa_address_region,
+    service_address_country: trustee.sa_address_country,
+    service_address_postcode: trustee.sa_address_postal_code,
+    governingLaw: trustee.identification_legal_authority,
+    legalForm: trustee.identification_legal_form,
+    public_register_name: trustee.identification_place_registered,
+    public_register_jurisdiction: trustee.identification_country_registration,
+    registration_number: trustee.identification_registration_number,
+    is_service_address_same_as_principal_address: trustee.is_service_address_same_as_principal_address,
+    is_on_register_in_country_formed_in: trustee.is_service_address_same_as_principal_address,
+  };
+};
+
 const mapLegalEntityItemToPage = (
   legalEntity: Trust.TrustCorporate,
 ): Page.TrusteeItem => {
@@ -58,6 +98,7 @@ const generateId = (): string => {
 
 export {
   mapLegalEntityToSession,
+  mapLegalEntityTrusteeFromSessionToPage,
   mapLegalEntityItemToPage,
   generateId,
 };

--- a/src/utils/trust/who.is.involved.mapper.ts
+++ b/src/utils/trust/who.is.involved.mapper.ts
@@ -1,5 +1,5 @@
 import { TrustWhoIsInvolved } from '../../model/trust.page.model';
-import { getTrustBoIndividuals, getTrustBoOthers, getLegalEntityBosInTrust, getTrustByIdFromApp } from '../../utils/trusts';
+import { getTrustBoIndividuals, getTrustBoOthers, getLegalEntityBosInTrust } from '../../utils/trusts';
 import * as mapperBeneficialOwner from '../../utils/trust/beneficial.owner.mapper';
 import * as trustLegalEntityMapper from '../../utils/trust/legal.entity.beneficial.owner.mapper';
 import { ApplicationData } from '.../../model';
@@ -15,10 +15,8 @@ const mapTrustWhoIsInvolvedToPage = (
       .map(mapperBeneficialOwner.mapBoOtherToPage),
   ];
 
-  const trust = getTrustByIdFromApp(appData, trustId);
-
   const trustees = [
-    ...getLegalEntityBosInTrust(trust)
+    ...getLegalEntityBosInTrust(appData, trustId)
       .map(trustLegalEntityMapper.mapLegalEntityItemToPage)
   ];
 

--- a/src/utils/trusts.ts
+++ b/src/utils/trusts.ts
@@ -252,10 +252,31 @@ const saveHistoricalBoInTrust = (
 };
 
 const getLegalEntityBosInTrust = (
-  trust: Trust,
+  appData: ApplicationData,
+  trustId?: string,
 ): TrustCorporate[] => {
+  let legalEntities: TrustCorporate[] = [];
+  if (trustId) {
+    legalEntities = appData[TrustKey]?.find(trust =>
+      trust?.trust_id === trustId)?.CORPORATES as TrustCorporate[];
+    if (legalEntities === undefined) {
+      legalEntities = [] as TrustCorporate[];
+    }
+  }
+  return legalEntities;
+};
 
-  return trust.CORPORATES ?? [];
+const getLegalEntityTrustee = (
+  appData: ApplicationData,
+  trustId: string,
+  trusteeId?: string,
+): TrustCorporate => {
+  const legalEntityTrustees = getLegalEntityBosInTrust(appData, trustId);
+
+  if (legalEntityTrustees.length === 0 || trusteeId === undefined) {
+    return {} as TrustCorporate;
+  }
+  return legalEntityTrustees.find(trustee => trustee.id === trusteeId) ?? {} as TrustCorporate;
 };
 
 const saveLegalEntityBoInTrust = (
@@ -325,4 +346,5 @@ export {
   containsTrustData,
   getIndividualTrustee,
   generateTrusteeIds,
+  getLegalEntityTrustee,
 };

--- a/src/validation/trust.individual.beneficial.owner.validation.ts
+++ b/src/validation/trust.individual.beneficial.owner.validation.ts
@@ -31,7 +31,7 @@ export const trustIndividualBeneficialOwner = [
 
   ...dateOfBirthValidations,
 
-  body("type").notEmpty().withMessage(ErrorMessages.TRUST_INDIVIDUAL_ROLE_INDIVIDUAL_BO).if(body("type")),
+  body("roleWithinTrust").notEmpty().withMessage(ErrorMessages.TRUST_INDIVIDUAL_ROLE_INDIVIDUAL_BO).if(body("roleWithinTrust")),
 
   ...dateBecameIP,
 

--- a/test/utils/trust.spec.ts
+++ b/test/utils/trust.spec.ts
@@ -18,6 +18,8 @@ import {
   checkEntityRequiresTrusts,
   getTrustLandingUrl,
   generateTrusteeIds,
+  getLegalEntityBosInTrust,
+  getLegalEntityTrustee,
 } from '../../src/utils/trusts';
 import { ApplicationData } from '../../src/model';
 import { NatureOfControlType } from '../../src/model/data.types.model';
@@ -302,7 +304,7 @@ describe('Trust Utils method tests', () => {
       });
     });
 
-    test("test getTrusteeFromTrust with application data and trust id", () => {
+    test("test getIndividualTrusteesFromTrust with application data and trust id", () => {
       const test_trust_id = '247';
       const appData = {
         [TrustKey]: [{
@@ -316,7 +318,7 @@ describe('Trust Utils method tests', () => {
       expect(result).toEqual([{}, {}, {}]);
     });
 
-    test("test getTrusteeFromTrust with application data and no trust id", () => {
+    test("test getIndividualTrusteesFromTrust with application data and no trust id", () => {
       const appData = {
         [TrustKey]: [{
           'INDIVIDUALS': [{}, {}, {}] as TrustIndividual[],
@@ -347,6 +349,7 @@ describe('Trust Utils method tests', () => {
 
     test("test getIndividualTrusteeFromTrust with application data with no trusteeId", () => {
       const test_trust_id = '342';
+      const empty_trustee_id = '';
       const individualTrustee1 = { id: "999" } as IndividualTrustee;
       const individualTrustee2 = { id: "901" } as IndividualTrustee;
       const appData = {
@@ -356,7 +359,7 @@ describe('Trust Utils method tests', () => {
         }]
       } as ApplicationData;
 
-      const result = getIndividualTrustee(appData, test_trust_id, undefined);
+      const result = getIndividualTrustee(appData, test_trust_id, empty_trustee_id);
       expect(result).toEqual({});
     });
 
@@ -399,6 +402,78 @@ describe('Trust Utils method tests', () => {
       const result = getFormerTrusteesFromTrust(appData);
       expect(result.length).toEqual(6);
       expect(result).toEqual([{}, {}, {}, {}, {}, {}]);
+    });
+
+    test("test getLegalEntityBosInTrust with application data and trust id", () => {
+      const test_trust_id = '353';
+      const appData = {
+        [TrustKey]: [{
+          'trust_id': test_trust_id,
+          'CORPORATES': [{}, {}, {}] as TrustCorporate[],
+        }]
+      } as ApplicationData;
+
+      const result = getLegalEntityBosInTrust(appData, test_trust_id);
+      expect(result.length).toEqual(3);
+      expect(result).toEqual([{}, {}, {}]);
+    });
+
+    test("test getLegalEntityBosInTrust with application data and no trust id", () => {
+      const empty_test_trust_id = '';
+      const appData = {
+        [TrustKey]: [{
+          'CORPORATES': [{}, {}, {}] as TrustCorporate[],
+        }, {
+          'CORPORATES': [{}, {}, {}] as TrustCorporate[],
+        }]
+      } as ApplicationData;
+
+      const result = getLegalEntityBosInTrust(appData, empty_test_trust_id);
+      expect(result).toEqual([]);
+    });
+
+    test("test getLegalEntityTrustee from trust successfully", () => {
+      const test_trust_id = '342';
+      const legalEntityTrustee1 = { id: "999" } as TrustCorporate;
+      const legalEntityTrustee2 = { id: "901" } as TrustCorporate;
+      const appData = {
+        [TrustKey]: [{
+          'trust_id': test_trust_id,
+          'CORPORATES': [ legalEntityTrustee1, legalEntityTrustee2 ] as TrustCorporate[],
+        }]
+      } as ApplicationData;
+
+      const result = getLegalEntityTrustee(appData, test_trust_id, "999");
+      expect(result).toEqual(legalEntityTrustee1);
+    });
+
+    test("test getLegalEntityTrustee from trust with application data with no trusteeId", () => {
+      const test_trust_id = '342';
+      const empty_trustee_id = '';
+      const legalEntityTrustee1 = { id: "999" } as TrustCorporate;
+      const legalEntityTrustee2 = { id: "901" } as TrustCorporate;
+      const appData = {
+        [TrustKey]: [{
+          'trust_id': test_trust_id,
+          'CORPORATES': [ legalEntityTrustee1, legalEntityTrustee2 ] as TrustCorporate[],
+        }]
+      } as ApplicationData;
+
+      const result = getLegalEntityTrustee(appData, test_trust_id, empty_trustee_id);
+      expect(result).toEqual({});
+    });
+
+    test("test getLegalEntityTrustee from trust with application data and INDIVIDUALS array is empty", () => {
+      const test_trust_id = '342';
+      const appData = {
+        [TrustKey]: [{
+          'trust_id': test_trust_id,
+          'CORPORATES': [] as TrustCorporate[],
+        }]
+      } as ApplicationData;
+
+      const result = getLegalEntityTrustee(appData, test_trust_id, "999");
+      expect(result).toEqual({});
     });
 
   });

--- a/test/utils/trust/individual.trustee.mapper.spec.ts
+++ b/test/utils/trust/individual.trustee.mapper.spec.ts
@@ -58,12 +58,12 @@ describe('Individual Beneficial Owner page Mapper Service', () => {
         const mockFormData = {
           ...mockFormDataBasic,
           trusteeId: id,
-          type: roleWithinTrust,
+          roleWithinTrust,
         };
 
         expect(mapIndividualTrusteeToSession(<Page.IndividualTrusteesFormCommon>mockFormData)).toEqual({
           id: mockFormData.trusteeId,
-          type: mockFormData.type,
+          type: mockFormData.roleWithinTrust,
           forename: mockFormData.forename,
           surname: mockFormData.surname,
           other_forenames: '',
@@ -98,7 +98,7 @@ describe('Individual Beneficial Owner page Mapper Service', () => {
         const mockFormData = {
           ...mockFormDataBasic,
           trusteeId: '10002',
-          type: RoleWithinTrustType.INTERESTED_PERSON,
+          roleWithinTrust: RoleWithinTrustType.INTERESTED_PERSON,
           dateBecameIPDay: '2',
           dateBecameIPMonth: '11',
           dateBecameIPYear: '2022',
@@ -106,7 +106,7 @@ describe('Individual Beneficial Owner page Mapper Service', () => {
 
         expect(mapIndividualTrusteeToSession(<Page.IndividualTrusteesFormCommon>mockFormData)).toEqual({
           id: mockFormData.trusteeId,
-          type: mockFormData.type,
+          type: mockFormData.roleWithinTrust,
           forename: mockFormData.forename,
           surname: mockFormData.surname,
           other_forenames: '',
@@ -143,7 +143,7 @@ describe('Individual Beneficial Owner page Mapper Service', () => {
       test('trustee Id should not be null after mapping', () => {
         const mockFormData = {
           ...mockFormDataBasic,
-          type: RoleWithinTrustType.INTERESTED_PERSON,
+          roleWithinTrust: RoleWithinTrustType.INTERESTED_PERSON,
           dateBecameIPDay: '2',
           dateBecameIPMonth: '11',
           dateBecameIPYear: '2022',
@@ -207,7 +207,7 @@ describe('Individual Beneficial Owner page Mapper Service', () => {
         trusteeId: mockSessionData.id,
         forename: mockSessionData.forename,
         surname: mockSessionData.surname,
-        type: mockSessionData.type,
+        roleWithinTrust: mockSessionData.type,
         dateOfBirthDay: mockSessionData.date_of_birth_day,
         dateOfBirthMonth: mockSessionData.date_of_birth_month,
         dateOfBirthYear: mockSessionData.date_of_birth_year,
@@ -251,7 +251,7 @@ describe('Individual Beneficial Owner page Mapper Service', () => {
         trusteeId: mockSessionData.id,
         forename: mockSessionData.forename,
         surname: mockSessionData.surname,
-        type: mockSessionData.type,
+        roleWithinTrust: mockSessionData.type,
         dateOfBirthDay: mockSessionData.date_of_birth_day,
         dateOfBirthMonth: mockSessionData.date_of_birth_month,
         dateOfBirthYear: mockSessionData.date_of_birth_year,

--- a/test/utils/trust/legal.entity.beneficial.owner.mapper.spec.ts
+++ b/test/utils/trust/legal.entity.beneficial.owner.mapper.spec.ts
@@ -1,14 +1,16 @@
 jest.mock('uuid');
 
 import { beforeEach, describe, expect, jest, test } from "@jest/globals";
+import { ApplicationData } from "../../../src/model";
 import * as uuid from 'uuid';
-import * as Page from '../../../src/model/trust.page.model';
-import * as Trust from '../../../src/model/trust.model';
+import { TrustLegalEntityForm } from '../../../src/model/trust.page.model';
+import { TrustCorporate, TrustKey } from "../../../src/model/trust.model";
 import { TrusteeType } from "../../../src/model/trustee.type.model";
 import {
   generateId,
   mapLegalEntityItemToPage,
   mapLegalEntityToSession,
+  mapLegalEntityTrusteeFromSessionToPage,
 } from '../../../src/utils/trust/legal.entity.beneficial.owner.mapper';
 import { yesNoResponse } from "@companieshouse/api-sdk-node/dist/services/overseas-entities";
 
@@ -45,12 +47,13 @@ describe('Trust Legal Entity Beneficial Owner Page Mapper Service', () => {
         public_register_name: "Reg Name",
         public_register_jurisdiction: "Reg Jurisdiction",
         registration_number: "9001",
-        is_service_address_same_as_principal_address: yesNoResponse.Yes
+        is_service_address_same_as_principal_address: yesNoResponse.Yes,
+        is_on_register_in_country_formed_in: yesNoResponse.Yes
       };
 
       test('Map legal entity trustee to session', () => {
 
-        expect(mapLegalEntityToSession(mockFormData as Page.TrustLegalEntityForm)).toEqual({
+        expect(mapLegalEntityToSession(mockFormData as TrustLegalEntityForm)).toEqual({
           id: mockFormData.legalEntityId,
           type: mockFormData.roleWithinTrust,
           name: mockFormData.legalEntityName,
@@ -80,7 +83,8 @@ describe('Trust Legal Entity Beneficial Owner Page Mapper Service', () => {
           identification_place_registered: mockFormData.public_register_name,
           identification_country_registration: mockFormData.public_register_jurisdiction,
           identification_registration_number: mockFormData.registration_number,
-          is_service_address_same_as_principal_address: mockFormData.is_service_address_same_as_principal_address
+          is_service_address_same_as_principal_address: mockFormData.is_service_address_same_as_principal_address,
+          is_on_register_in_country_formed_in: mockFormData.is_on_register_in_country_formed_in,
         });
       });
 
@@ -124,11 +128,56 @@ describe('Trust Legal Entity Beneficial Owner Page Mapper Service', () => {
         identification_place_registered: "Reg Name",
         identification_country_registration: "Reg Jurisdiction",
         identification_registration_number: "9002",
-        is_service_address_same_as_principal_address: yesNoResponse.Yes
+        is_service_address_same_as_principal_address: yesNoResponse.Yes,
+        is_on_register_in_country_formed_in: yesNoResponse.Yes
       };
+      test("Map legal entity trustee session data to page", () => {
+
+        const trustId = '987';
+        const trusteeId = '9998';
+
+        const appData = {
+          [TrustKey]: [{
+            'trust_id': trustId,
+            'CORPORATES': [ mockSessionData ] as TrustCorporate[],
+          }]
+        } as ApplicationData;
+        expect(
+          mapLegalEntityTrusteeFromSessionToPage(appData, trustId, trusteeId)
+        ).toEqual({
+          legalEntityId: mockSessionData.id,
+          roleWithinTrust: mockSessionData.type,
+          legalEntityName: mockSessionData.name,
+          interestedPersonStartDateDay: mockSessionData.date_became_interested_person_day,
+          interestedPersonStartDateMonth: mockSessionData.date_became_interested_person_month,
+          interestedPersonStartDateYear: mockSessionData.date_became_interested_person_year,
+          principal_address_property_name_number: mockSessionData.ro_address_premises,
+          principal_address_line_1: mockSessionData.ro_address_line1,
+          principal_address_line_2: mockSessionData.ro_address_line2,
+          principal_address_town: mockSessionData.ro_address_locality,
+          principal_address_county: mockSessionData.ro_address_region,
+          principal_address_country: mockSessionData.ro_address_country,
+          principal_address_postcode: mockSessionData.ro_address_postal_code,
+          service_address_property_name_number: mockSessionData.sa_address_premises,
+          service_address_line_1: mockSessionData.sa_address_line1,
+          service_address_line_2: mockSessionData.sa_address_line2,
+          service_address_town: mockSessionData.sa_address_locality,
+          service_address_county: mockSessionData.sa_address_region,
+          service_address_country: mockSessionData.sa_address_country,
+          service_address_postcode: mockSessionData.sa_address_postal_code,
+          governingLaw: mockSessionData.identification_legal_authority,
+          legalForm: mockSessionData.identification_legal_form,
+          public_register_name: mockSessionData.identification_place_registered,
+          public_register_jurisdiction: mockSessionData.identification_country_registration,
+          registration_number: mockSessionData.identification_registration_number,
+          is_service_address_same_as_principal_address: mockSessionData.is_service_address_same_as_principal_address,
+          is_on_register_in_country_formed_in: mockSessionData.is_on_register_in_country_formed_in,
+        });
+      });
+
       test("Map legal entity trustee session data to page trustee item", () => {
         expect(
-          mapLegalEntityItemToPage(mockSessionData as Trust.TrustCorporate)
+          mapLegalEntityItemToPage(mockSessionData as TrustCorporate)
         ).toEqual({
           id: mockSessionData.id,
           name: mockSessionData.name,

--- a/test/utils/trust/who.is.involved.mapper.spec.ts
+++ b/test/utils/trust/who.is.involved.mapper.spec.ts
@@ -63,7 +63,7 @@ describe('Trust Involved Mapper to Page Service', () => {
 
       expect(getTrustBoIndividuals).toBeCalledWith(mockAppData, mockTrust1.trust_id);
       expect(getTrustBoOthers).toBeCalledWith(mockAppData, mockTrust1.trust_id);
-      expect(getLegalEntityBosInTrust).toBeCalledWith(mockTrust1);
+      expect(getLegalEntityBosInTrust).toBeCalledWith(mockAppData, mockTrust1.trust_id);
     });
   });
 });

--- a/views/includes/check-your-answers/legal-entity-trustee.html
+++ b/views/includes/check-your-answers/legal-entity-trustee.html
@@ -21,9 +21,9 @@
 {% set legalEntityFormattedServiceAddressHtml %}
   {% if legalEntity.is_service_address_same_as_principal_address == '1' %}
     The correspondence address is the same as the entity’s principal or registered office address
-    {% set legalEntityChangeServiceAddressHtml = "#is_service_address_same_as_usual_residential_address" %}
+    {% set legalEntityChangeServiceAddressHtml = OE_CONFIGS.IS_SERVICE_ADDRESS_SAME_AS_USUAL_RESIDENTIAL_ADDRESS %}
   {% else %}
-    {% set legalEntityChangeServiceAddressHtml = "#service_address_property_name_number" %}
+    {% set legalEntityChangeServiceAddressHtml = OE_CONFIGS.CHANGE_SERVICE_ADDRESS %}
     {% set address = {
       property_name_number: legalEntity.sa_address_premises,
       line_1: legalEntity.sa_address_line1,
@@ -57,7 +57,7 @@
   },
   actions: {
     items: [ CREATE_CHANGE_LINK(
-      OE_CONFIGS.TRUSTS_URL +  "/" + trust.trust_id + "/" + OE_CONFIGS.TRUST_LEGAL_ENTITY_BENEFICIAL_OWNER_PAGE + "/" + legalEntity.id + "#legalEntityName",
+      OE_CONFIGS.TRUSTS_URL +  "/" + trust.trust_id + "/" + OE_CONFIGS.TRUST_LEGAL_ENTITY_BENEFICIAL_OWNER_PAGE + "/" + legalEntity.id + OE_CONFIGS.LEGAL_ENTITY_NAME,
       "Legal entity " + legalEntity.name + " - name",
       "change-legal-entity-name-button"
    ) ]
@@ -73,7 +73,7 @@
   },
   actions: {
     items: [ CREATE_CHANGE_LINK(
-      OE_CONFIGS.TRUSTS_URL +  "/" + trust.trust_id + "/" + OE_CONFIGS.TRUST_LEGAL_ENTITY_BENEFICIAL_OWNER_PAGE + "/" + legalEntity.id + OE_CONFIGS.TYPE,
+      OE_CONFIGS.TRUSTS_URL +  "/" + trust.trust_id + "/" + OE_CONFIGS.TRUST_LEGAL_ENTITY_BENEFICIAL_OWNER_PAGE + "/" + legalEntity.id + OE_CONFIGS.ROLE_WITHIN_TRUST,
       "Legal entity " + legalEntity.name + " - type",
       "change-legal-entity-type-button"
     ) ]
@@ -90,7 +90,7 @@
     },
     actions: {
     items: [ CREATE_CHANGE_LINK(
-        OE_CONFIGS.TRUSTS_URL +  "/" + trust.trust_id + "/" + OE_CONFIGS.TRUST_INDIVIDUAL_BENEFICIAL_OWNER_PAGE + "/" + legalEntity.id + "#conditional-type-4",
+        OE_CONFIGS.TRUSTS_URL +  "/" + trust.trust_id + "/" + OE_CONFIGS.TRUST_INDIVIDUAL_BENEFICIAL_OWNER_PAGE + "/" + legalEntity.id + OE.CONFIGS.INTERESTED_PERSON_START_DATE,
         "Individual beneficial owner " + legalEntity.name + " - date of birth",
         "change-individual-beneficial-owner-interested-person-date-button"
       ) ]
@@ -142,7 +142,7 @@
     },
     actions: {
       items: [ CREATE_CHANGE_LINK(
-        OE_CONFIGS.TRUSTS_URL +  "/" + trust.trust_id + "/" + OE_CONFIGS.TRUST_LEGAL_ENTITY_BENEFICIAL_OWNER_PAGE + "/" + legalEntity.id + OE_CONFIGS.TYPE,
+        OE_CONFIGS.TRUSTS_URL +  "/" + trust.trust_id + "/" + OE_CONFIGS.TRUST_LEGAL_ENTITY_BENEFICIAL_OWNER_PAGE + "/" + legalEntity.id + OE_CONFIGS.PUBLIC_REGISTER_JURISDICTION,
         "Legal entity " + legalEntity.name + " - country formed in",
         "change-legal-entity-country-formed-in-button"
       ) ]
@@ -159,7 +159,7 @@
   },
   actions: {
     items: [ CREATE_CHANGE_LINK(
-      OE_CONFIGS.TRUSTS_URL +  "/" + trust.trust_id + "/" + OE_CONFIGS.TRUST_LEGAL_ENTITY_BENEFICIAL_OWNER_PAGE + "/" + legalEntity.id + "#legalForm",
+      OE_CONFIGS.TRUSTS_URL +  "/" + trust.trust_id + "/" + OE_CONFIGS.TRUST_LEGAL_ENTITY_BENEFICIAL_OWNER_PAGE + "/" + legalEntity.id + OE_CONFIGS.LEGAL_FORM,
       "Legal entity " + legalEntity.name + " - legal form",
       "change-legal-entity-legal-form-button"
     ) ]
@@ -175,7 +175,7 @@
   },
   actions: {
     items: [ CREATE_CHANGE_LINK(
-      OE_CONFIGS.TRUSTS_URL +  "/" + trust.trust_id + "/" + OE_CONFIGS.TRUST_LEGAL_ENTITY_BENEFICIAL_OWNER_PAGE + "/" + legalEntity.id + OE_CONFIGS.TYPE,
+      OE_CONFIGS.TRUSTS_URL +  "/" + trust.trust_id + "/" + OE_CONFIGS.TRUST_LEGAL_ENTITY_BENEFICIAL_OWNER_PAGE + "/" + legalEntity.id + OE_CONFIGS.LAW_GOVERNED,
       "Legal entity " + legalEntity.name + " - legal authority",
       "change-legal-entity-governing-law-button"
     ) ]
@@ -191,7 +191,7 @@
   },
   actions: {
     items: [ CREATE_CHANGE_LINK(
-      OE_CONFIGS.TRUSTS_URL +  "/" + trust.trust_id + "/" + OE_CONFIGS.TRUST_LEGAL_ENTITY_BENEFICIAL_OWNER_PAGE + "/" + legalEntity.id + OE_CONFIGS.TYPE,
+      OE_CONFIGS.TRUSTS_URL +  "/" + trust.trust_id + "/" + OE_CONFIGS.TRUST_LEGAL_ENTITY_BENEFICIAL_OWNER_PAGE + "/" + legalEntity.id + OE_CONFIGS.PUBLIC_REGISTER_NAME,
       "Legal entity " + legalEntity.name + " - legal authority",
       "change-legal-entity-identification-registration-number-button"
     ) ]

--- a/views/trust-individual-beneficial-owner.html
+++ b/views/trust-individual-beneficial-owner.html
@@ -68,36 +68,36 @@
         {% include "includes/inputs/date-input.html" %}
 
         {% set fieldParam = {
-          name: 'type',
+          name: 'roleWithinTrust',
           label: 'What is their role within the trust?',
-          value: formData.type,
-          error: errors.type if errors,
+          value: formData.roleWithinTrust,
+          error: errors.roleWithinTrust if errors,
           items: [
             {
               value: pageData.roleWithinTrustType.BENEFICIARY,
               text: "Beneficiary",
-              checked: formData.type == pageData.roleWithinTrustType.BENEFICIARY,
+              checked: formData.roleWithinTrust == pageData.roleWithinTrustType.BENEFICIARY,
               attributes: {
                 "data-event-id": "beneficiary-type-radio-option"
               }
             }, {
               value: pageData.roleWithinTrustType.SETTLOR,
               text: "Settlor",
-              checked: formData.type == pageData.roleWithinTrustType.SETTLOR,
+              checked: formData.roleWithinTrust == pageData.roleWithinTrustType.SETTLOR,
               attributes: {
                 "data-event-id": "settlor-type-radio-option"
               }
             }, {
               value: pageData.roleWithinTrustType.GRANTOR,
               text: "Grantor",
-              checked: formData.type == pageData.roleWithinTrustType.GRANTOR,
+              checked: formData.roleWithinTrust == pageData.roleWithinTrustType.GRANTOR,
               attributes: {
                 "data-event-id": "grantor-type-radio-option"
               }
             }, {
               value: pageData.roleWithinTrustType.INTERESTED_PERSON,
               text: "Interested Person",
-              checked: formData.type == pageData.roleWithinTrustType.INTERESTED_PERSON,
+              checked: formData.roleWithinTrust == pageData.roleWithinTrustType.INTERESTED_PERSON,
               attributes: {
                 "data-event-id": "interested-person-type-radio-option"
               },

--- a/views/trust-legal-entity-beneficial-owner.html
+++ b/views/trust-legal-entity-beneficial-owner.html
@@ -54,24 +54,28 @@
             {
               value: pageData.roleWithinTrustType.BENEFICIARY,
               text: "Beneficiary",
+              checked: formData.roleWithinTrust == pageData.roleWithinTrustType.BENEFICIARY,
               attributes: {
                 "data-event-id": "beneficiaries-type-radio-option"
               }
             }, {
               value: pageData.roleWithinTrustType.SETTLOR,
               text: "Settlor",
+              checked: formData.roleWithinTrust == pageData.roleWithinTrustType.SETTLOR,
               attributes: {
                 "data-event-id": "settlors-type-radio-option"
               }
             }, {
               value: pageData.roleWithinTrustType.GRANTOR,
               text: "Grantor",
+              checked: formData.roleWithinTrust == pageData.roleWithinTrustType.GRANTOR,
               attributes: {
                 "data-event-id": "grantors-type-radio-option"
               }
             }, {
               value: pageData.roleWithinTrustType.INTERESTED_PERSON,
               text: "Interested Person",
+              checked: formData.roleWithinTrust == pageData.roleWithinTrustType.INTERESTED_PERSON,
               attributes: {
                 "data-event-id": "interested-persons-type-radio-option"
               },
@@ -83,11 +87,27 @@
         } %}
         {% include "includes/inputs/radio-input.html" %}
 
+        {% set principal_address_property_name_number = formData.principal_address_property_name_number %}
+        {% set principal_address_line_1 = formData.principal_address_line_1 %}
+        {% set principal_address_line_2 = formData.principal_address_line_2 %}
+        {% set principal_address_town = formData.principal_address_town %}
+        {% set principal_address_county = formData.principal_address_county %}
+        {% set principal_address_country = formData.principal_address_country %}
+        {% set principal_address_postcode = formData.principal_address_postcode %}
+        {% set is_service_address_same_as_principal_address = formData.is_service_address_same_as_principal_address %}
 
+        {% set service_address_property_name_number = formData.service_address_property_name_number %}
+        {% set service_address_line_1 = formData.service_address_line_1 %}
+        {% set service_address_line_2 = formData.service_address_line_2 %}
+        {% set service_address_town = formData.service_address_town %}
+        {% set service_address_county = formData.service_address_county %}
+        {% set service_address_country = formData.service_address_country %}
+        {% set service_address_postcode = formData.service_address_postcode %}
         {% include "includes/inputs/address/principal-address-input.html" %}
 
         {% set fieldParam = {
           name: 'legalForm',
+          id: 'legal_form',
           label: 'What is its legal form?',
           value: formData.legalForm,
           hint: 'For example, limited company',
@@ -97,6 +117,7 @@
 
         {% set fieldParam = {
           name: 'governingLaw',
+          id: 'law_governed',
           label: 'What is the governing law?',
           value: formData.governingLaw,
           hint: 'This is the law that the entity operates under.',
@@ -108,7 +129,10 @@
         {% set registerHintText = "Include the full name. For example, Jersey Financial Services Commission." %}
         {% set includeJurisdiction = true %}
         {% set registrationNumberText = "Entity’s registration number" %}
-  
+        {% set is_on_register_in_country_formed_in = formData.is_on_register_in_country_formed_in %}
+        {% set public_register_name = formData.public_register_name %}
+        {% set public_register_jurisdiction = formData.public_register_jurisdiction %}
+        {% set registration_number = formData.registration_number %}
         {% include "includes/inputs/fields/is-on-register-in-country-formed-input.html" %}
 
         {{ govukInsetText({
@@ -118,7 +142,7 @@
           '
         }) }}
 
-        <input type="hidden" name="id" value="{{ pageData.id }}"/>
+        <input type="hidden" name="legalEntityId" value="{{ formData.legalEntityId }}"/>
 
         {% include "includes/save-and-continue-button.html" %}
       </form>


### PR DESCRIPTION
### JIRA link
Parent Jira: [ROE-2032](https://companieshouse.atlassian.net/browse/ROE-2032)

Subtask: [ROE-2059](https://companieshouse.atlassian.net/browse/ROE-2059)

### Change description

- add change link functionality to legal entity trustees
- enable previous entered data to be displayed on form page when navigated back to via change link
-  add relevant tests

Changes maybe considered out of scope:
- **renaming `type` to `roleWithinTrust` for page model and related use cases:** This was required as legal entity trustees also use the same data but is correctly named `roleWithinTrust`. Having the 2 named differently could cause future confusion for developers. The change was added now to save adding extra change link path vars to accommodate for the difference. Further refinement will have to take place to change the data model to reflect the same. This will be done in a separate ticket as it requires more work and changes to other services. 

### Work checklist

- [x] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.


[ROE-2032]: https://companieshouse.atlassian.net/browse/ROE-2032?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ROE-2059]: https://companieshouse.atlassian.net/browse/ROE-2059?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ