### PR TITLE
roe-2061: update change link for bo list

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -250,6 +250,7 @@ export const TRUST_DATE_OF_BIRTH = "#dateOfBirth-dateOfBirthDay";
 export const INTERESTED_PERSON_START_DATE = "#dateBecameIP-dateBecameIPDay";
 export const PUBLIC_REGISTER_JURISDICTION = "#public_register_jurisdiction";
 export const LEGAL_ENTITY_NAME = "#legalEntityName";
+export const TRUST_BENEFICIAL_OWNERS = "#trustBeneficialOwners";
 
 export const ENTITY_CHANGE_NAME = OVERSEAS_NAME_URL + ENTITY_NAME;
 export const PRESENTER_CHANGE_FULL_NAME = PRESENTER_URL + "#full_name";

--- a/views/includes/check-your-answers/trusts.html
+++ b/views/includes/check-your-answers/trusts.html
@@ -4,6 +4,7 @@
 {% set trustBeneficialOwnersHtml %}
   {% include "includes/check-your-answers/trust-beneficial-owners.html" %}
 {% endset %}
+
 {% if pageParams.isTrustFeatureEnabled %}
   {% set trustCreationDate = dateMacros.formatDate(trust.creation_date_day, trust.creation_date_month, trust.creation_date_year) %}
   {{ govukSummaryList({
@@ -47,7 +48,7 @@
         },  
         actions: {
           items: [ CREATE_CHANGE_LINK(
-            OE_CONFIGS.TRUST_DETAILS_URL + "/" + trust.trust_id,
+            OE_CONFIGS.TRUST_DETAILS_URL + "/" + trust.trust_id + OE_CONFIGS.TRUST_BENEFICIAL_OWNERS,
             "Trust " + trust.trust_name + " -  Beneficial Owner",
             "change-beneficial-owner-button"
           ) ]

--- a/views/trust-details.html
+++ b/views/trust-details.html
@@ -44,7 +44,7 @@
         {% for bo in pageData.beneficialOwners %}
           {% set boItems = (
             boItems.push({
-              id: bo.id,
+              id: "trustBeneficialOwners", 
               value: bo.id,
               text: bo.name,
               checked: true if bo.id in beneficialOwnersIds


### PR DESCRIPTION
- update change link
- add new change link path var
- update bo list id's to use static ID so that change link can link to the list

### JIRA link

Parent Jira: [ROE-2032](https://companieshouse.atlassian.net/browse/ROE-2032)

Subtask: [ROE-2061](https://companieshouse.atlassian.net/browse/ROE-2061)

### Change description

- Update change link so that when pressed you are taken directly to the list of BO's on the trust-details page. 
- Update Id's on the bo list to use a static ID when being placed into array for displaying on the page. After some manual testing after this change data regarding the BO's and their assigned trust ID's are as expected.

### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.


[ROE-2032]: https://companieshouse.atlassian.net/browse/ROE-2032?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ROE-2061]: https://companieshouse.atlassian.net/browse/ROE-2061?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ