### PR TITLE
Feature/roe 2058 bug fixes

### DIFF
--- a/src/utils/trust/individual.trustee.mapper.ts
+++ b/src/utils/trust/individual.trustee.mapper.ts
@@ -29,28 +29,45 @@ export const mapIndividualTrusteeToSession = (
     ura_address_care_of: '',
     ura_address_po_box: '',
     is_service_address_same_as_usual_residential_address: formData.is_service_address_same_as_usual_residential_address,
-    sa_address_premises: formData.service_address_property_name_number,
-    sa_address_line1: formData.service_address_line_1,
-    sa_address_line2: formData.service_address_line_2,
-    sa_address_locality: formData.service_address_town,
-    sa_address_region: formData.service_address_county,
-    sa_address_country: formData.service_address_country,
-    sa_address_postal_code: formData.service_address_postcode,
     sa_address_care_of: '',
     sa_address_po_box: '',
   };
 
+  let interestedPersonData = {};
+
   if (formData.roleWithinTrust === RoleWithinTrustType.INTERESTED_PERSON){
-    return {
-      ...data,
+    interestedPersonData = {
       date_became_interested_person_day: formData.dateBecameIPDay,
       date_became_interested_person_month: formData.dateBecameIPMonth,
       date_became_interested_person_year: formData.dateBecameIPYear,
+    };
+  }
+
+  if (formData.is_service_address_same_as_usual_residential_address.toString() === "0") {
+    return {
+      ...data,
+      ...interestedPersonData,
+      sa_address_premises: formData.service_address_property_name_number,
+      sa_address_line1: formData.service_address_line_1,
+      sa_address_line2: formData.service_address_line_2,
+      sa_address_locality: formData.service_address_town,
+      sa_address_region: formData.service_address_county,
+      sa_address_country: formData.service_address_country,
+      sa_address_postal_code: formData.service_address_postcode,
+    } as Trust.IndividualTrustee;
+  } else {
+    return {
+      ...data,
+      ...interestedPersonData,
+      sa_address_premises: "",
+      sa_address_line1: "",
+      sa_address_line2: "",
+      sa_address_locality: "",
+      sa_address_region: "",
+      sa_address_country: "",
+      sa_address_postal_code: "",
     } as Trust.IndividualTrustee;
   }
-  return {
-    ...data as Trust.IndividualTrustee
-  };
 };
 
 export const mapIndividualTrusteeFromSessionToPage = (

--- a/src/validation/fields/date.validation.ts
+++ b/src/validation/fields/date.validation.ts
@@ -113,7 +113,7 @@ const dateBecameIPContext: dateContextWithCondition = {
     name: "dateBecameIP",
     callBack: checkDateIP,
   },
-  condition: { elementName: "type", expectedValue: RoleWithinTrustType.INTERESTED_PERSON },
+  condition: { elementName: "roleWithinTrust", expectedValue: RoleWithinTrustType.INTERESTED_PERSON },
 };
 
 const trustCreatedDateValidationsContext: dateContext = {

--- a/test/utils/trust/individual.trustee.mapper.spec.ts
+++ b/test/utils/trust/individual.trustee.mapper.spec.ts
@@ -94,7 +94,7 @@ describe('Individual Beneficial Owner page Mapper Service', () => {
         });
       });
 
-      test('map Individual trustees', () => {
+      test('map Individual trustee with same service address as residential address', () => {
         const mockFormData = {
           ...mockFormDataBasic,
           trusteeId: '198',

--- a/test/utils/trust/individual.trustee.mapper.spec.ts
+++ b/test/utils/trust/individual.trustee.mapper.spec.ts
@@ -51,7 +51,6 @@ describe('Individual Beneficial Owner page Mapper Service', () => {
         dateBecameIPDay: '4',
         dateBecameIPMonth: '4',
         dateBecameIPYear: '1964',
-        is_service_address_same_as_usual_residential_address: yesNoResponse.Yes
       };
 
       test.each(testParam)('map Individual trustees', (id: string, roleWithinTrust: Exclude<RoleWithinTrustType, RoleWithinTrustType.INTERESTED_PERSON>) => {
@@ -59,6 +58,7 @@ describe('Individual Beneficial Owner page Mapper Service', () => {
           ...mockFormDataBasic,
           trusteeId: id,
           roleWithinTrust,
+          is_service_address_same_as_usual_residential_address: yesNoResponse.No
         };
 
         expect(mapIndividualTrusteeToSession(<Page.IndividualTrusteesFormCommon>mockFormData)).toEqual({
@@ -94,6 +94,47 @@ describe('Individual Beneficial Owner page Mapper Service', () => {
         });
       });
 
+      test('map Individual trustees', () => {
+        const mockFormData = {
+          ...mockFormDataBasic,
+          trusteeId: '198',
+          roleWithinTrust: RoleWithinTrustType.BENEFICIARY,
+          is_service_address_same_as_usual_residential_address: yesNoResponse.Yes
+        };
+
+        expect(mapIndividualTrusteeToSession(<Page.IndividualTrusteesFormCommon>mockFormData)).toEqual({
+          id: mockFormData.trusteeId,
+          type: mockFormData.roleWithinTrust,
+          forename: mockFormData.forename,
+          surname: mockFormData.surname,
+          other_forenames: '',
+          date_of_birth_day: mockFormData.dateOfBirthDay,
+          date_of_birth_month: mockFormData.dateOfBirthMonth,
+          date_of_birth_year: mockFormData.dateOfBirthYear,
+          nationality: mockFormData.nationality,
+          second_nationality: mockFormData.second_nationality,
+          ura_address_premises: mockFormData.usual_residential_address_property_name_number,
+          ura_address_line1: mockFormData.usual_residential_address_line_1,
+          ura_address_line2: mockFormData.usual_residential_address_line_2,
+          ura_address_locality: mockFormData.usual_residential_address_town,
+          ura_address_region: mockFormData.usual_residential_address_county,
+          ura_address_country: mockFormData.usual_residential_address_country,
+          ura_address_postal_code: mockFormData.usual_residential_address_postcode,
+          ura_address_care_of: '',
+          ura_address_po_box: '',
+          is_service_address_same_as_usual_residential_address: mockFormData.is_service_address_same_as_usual_residential_address,
+          sa_address_premises: '',
+          sa_address_line1: '',
+          sa_address_line2: '',
+          sa_address_locality: '',
+          sa_address_region: '',
+          sa_address_country: '',
+          sa_address_postal_code: '',
+          sa_address_care_of: '',
+          sa_address_po_box: '',
+        });
+      });
+
       test('map Interested trustees', () => {
         const mockFormData = {
           ...mockFormDataBasic,
@@ -102,6 +143,7 @@ describe('Individual Beneficial Owner page Mapper Service', () => {
           dateBecameIPDay: '2',
           dateBecameIPMonth: '11',
           dateBecameIPYear: '2022',
+          is_service_address_same_as_usual_residential_address: yesNoResponse.No
         };
 
         expect(mapIndividualTrusteeToSession(<Page.IndividualTrusteesFormCommon>mockFormData)).toEqual({
@@ -147,6 +189,7 @@ describe('Individual Beneficial Owner page Mapper Service', () => {
           dateBecameIPDay: '2',
           dateBecameIPMonth: '11',
           dateBecameIPYear: '2022',
+          is_service_address_same_as_usual_residential_address: yesNoResponse.No
         };
         const mappedObj = mapIndividualTrusteeToSession(<Page.IndividualTrusteesFormCommon>mockFormData);
 

--- a/views/includes/check-your-answers/individual-trustee.html
+++ b/views/includes/check-your-answers/individual-trustee.html
@@ -23,9 +23,9 @@
 {% set individualTrusteeFormattedServiceAddressHtml %}
   {% if individualTrustee.is_service_address_same_as_usual_residential_address == '1' %}
     The correspondence address is the same as the home address
-    {% set individualTrusteeChangeServiceAddressHtml = "#is_service_address_same_as_usual_residential_address" %}
+    {% set individualTrusteeChangeServiceAddressHtml = OE_CONFIGS.IS_SERVICE_ADDRESS_SAME_AS_USUAL_RESIDENTIAL_ADDRESS %}
   {% else %}
-    {% set individualTrusteeChangeServiceAddressHtml = "#service_address_property_name_number" %}
+    {% set individualTrusteeChangeServiceAddressHtml = OE_CONFIGS.CHANGE_SERVICE_ADDRESS %}
     {% set address = {
       property_name_number: individualTrustee.sa_address_premises,
       line_1: individualTrustee.sa_address_line1,
@@ -38,6 +38,7 @@
     {% include "includes/display_address.html" %}
   {% endif %}
 {% endset %}
+
 
 {# Build and add each govukSummaryList row separately so that some rows can be optional #}
 {% set rows=[] %}
@@ -185,7 +186,7 @@
     },
     actions: {
       items: [ CREATE_CHANGE_LINK(
-        OE_CONFIGS.TRUSTS_URL +  "/" + trust.trust_id + "/" + OE_CONFIGS.TRUST_INDIVIDUAL_BENEFICIAL_OWNER_PAGE + "/" + individualTrustee.id + OE_CONFIGS.CHANGE_SERVICE_ADDRESS,
+        OE_CONFIGS.TRUSTS_URL +  "/" + trust.trust_id + "/" + OE_CONFIGS.TRUST_INDIVIDUAL_BENEFICIAL_OWNER_PAGE + "/" + individualTrustee.id + individualTrusteeChangeServiceAddressHtml,
         "Individual beneficial owner " + individualTrusteeFullName + " - correspondence address",
         "change-individual-beneficial-owner-correspondence-address-button"
       ) ]


### PR DESCRIPTION
### JIRA link

[ROE-2058](https://companieshouse.atlassian.net/browse/ROE-2058)

Includes fix for [ROE-2089](https://companieshouse.atlassian.net/browse/ROE-2089)

### Change description

- fix small validation issue causing interested person data validation not to fire
- fix mapping so that optional data does not linger after data conditional has been alter. Ie if data is entered in an optional field then another option is selected the data fields relating to the first choice will not be saved
- amend address change links so they go to correct page location based on conditional data


### Work checklist

- [X] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.


[ROE-2058]: https://companieshouse.atlassian.net/browse/ROE-2058?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ROE-2089]: https://companieshouse.atlassian.net/browse/ROE-2089?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ