### PR TITLE
PA-roe-2063: Update hasAllInfo Mapping

### DIFF
--- a/src/utils/trust/details.mapper.ts
+++ b/src/utils/trust/details.mapper.ts
@@ -23,10 +23,10 @@ const mapDetailToPage = (
   let unableToObtainAllTrustInfo: string;
   switch (trustData.unable_to_obtain_all_trust_info) {
       case "Yes":
-        unableToObtainAllTrustInfo = "1";
+        unableToObtainAllTrustInfo = "0";
         break;
       case "No":
-        unableToObtainAllTrustInfo = "0";
+        unableToObtainAllTrustInfo = "1";
         break;
       default:
         unableToObtainAllTrustInfo = ""; // forces user to enter a value on new trust
@@ -56,7 +56,7 @@ const mapDetailToSession = (
     creation_date_day: data.createdDateDay,
     creation_date_month: data.createdDateMonth,
     creation_date_year: data.createdDateYear,
-    unable_to_obtain_all_trust_info: (data.hasAllInfo === "1") ? "Yes" : "No",
+    unable_to_obtain_all_trust_info: (data.hasAllInfo === "0") ? "Yes" : "No",
   };
 };
 

--- a/test/utils/trust/details.mapper.spec.ts
+++ b/test/utils/trust/details.mapper.spec.ts
@@ -15,7 +15,7 @@ import {
   BeneficialOwnerOther,
   BeneficialOwnerOtherKey,
 } from '../../../src/model/beneficial.owner.other.model';
--
+
 describe('Trust Details page Mapper Service', () => {
   const mockTrust1 = {
     trust_id: '999',
@@ -65,7 +65,7 @@ describe('Trust Details page Mapper Service', () => {
   });
 
   describe('To Page mapper methods tests', () => {
-    test('mapDetailToPage should return object (verify napping of hasAllInfo when true)', () => {
+    test('mapDetailToPage should return object (verify mapping of hasAllInfo when false)', () => {
       expect(mapDetailToPage(mockAppData, mockTrust1.trust_id)).toEqual({
         trustId: mockTrust1.trust_id,
         name: mockTrust1.trust_name,
@@ -76,10 +76,10 @@ describe('Trust Details page Mapper Service', () => {
           mockBoIndividual1.id,
           mockBoOle1.id,
         ],
-        hasAllInfo: '1',
+        hasAllInfo: '0',
       });
     });
-    test('mapDetailToPage should return object (verify napping of hasAllInfo when false)', () => {
+    test('mapDetailToPage should return object (verify mapping of hasAllInfo when true)', () => {
       expect(mapDetailToPage(mockAppData, mockTrust2.trust_id)).toEqual({
         trustId: mockTrust2.trust_id,
         name: mockTrust2.trust_name,
@@ -89,10 +89,10 @@ describe('Trust Details page Mapper Service', () => {
         beneficialOwnersIds: [
           mockBoIndividual1.id,
         ],
-        hasAllInfo: '0',
+        hasAllInfo: '1',
       });
     });
-    test('mapDetailToPage should return object (verify napping of hasAllInfo for new trust)', () => {
+    test('mapDetailToPage should return object (verify mapping of hasAllInfo for new trust)', () => {
       const initialFormDetails = mapDetailToPage(mockAppData, unknownTrustId);
       expect(initialFormDetails.hasAllInfo).toBe("");
     });
@@ -117,25 +117,25 @@ describe('Trust Details page Mapper Service', () => {
       hasAllInfo: '0',
     } as Page.TrustDetailsForm;
 
-    test('mapDetailToSession should return object (verify napping of unable_to_obtain_all_trust_info when true)', () => {
+    test('mapDetailToSession should return object (verify mapping of unable_to_obtain_all_trust_info when false)', () => {
       expect(mapDetailToSession(mockFormData)).toEqual({
         trust_id: mockFormData.trustId,
         trust_name: mockFormData.name,
         creation_date_day: mockFormData.createdDateDay,
         creation_date_month: mockFormData.createdDateMonth,
         creation_date_year: mockFormData.createdDateYear,
-        unable_to_obtain_all_trust_info: "Yes",
+        unable_to_obtain_all_trust_info: "No",
       });
     });
 
-    test('mapDetailToSession should return object (verify napping of unable_to_obtain_all_trust_info when false)', () => {
+    test('mapDetailToSession should return object (verify mapping of unable_to_obtain_all_trust_info when true)', () => {
       expect(mapDetailToSession(mockFormData2)).toEqual({
         trust_id: mockFormData.trustId,
         trust_name: mockFormData.name,
         creation_date_day: mockFormData.createdDateDay,
         creation_date_month: mockFormData.createdDateMonth,
         creation_date_year: mockFormData.createdDateYear,
-        unable_to_obtain_all_trust_info: "No",
+        unable_to_obtain_all_trust_info: "Yes",
       });
     });
 


### PR DESCRIPTION

### JIRA link

[ROE-2079](https://companieshouse.atlassian.net/browse/ROE-2079)

### Change description

- the field `hasAllInfo` is currently being mapped wrong into mongo db. When `hasAllInfo` is mark Yes on the web then
`unable_to_obtain_all_trust_info` is also marked Yes in mongo. The values contradict each other so mapping needs to be inverted
- amend tests after mapper changes
-Screenshot can be seen on in the JIRA comments to provide better context to the above solution

### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.


[ROE-2079]: https://companieshouse.atlassian.net/browse/ROE-2079?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ