### PR TITLE
UAR-397: Fix feature flag logic on save and continue button

### DIFF
--- a/test/__mocks__/text.mock.ts
+++ b/test/__mocks__/text.mock.ts
@@ -115,6 +115,7 @@ export const DATA_EVENT_ID = "data-event-id";
 export const PAGE_TITLE_ERROR = "Error:";
 export const PAGE_NOT_FOUND_TEXT = "Page not found";
 export const UPDATE_OE_MSG_ERROR = "Something went wrong with updating Overseas Entity";
+export const CONTINUE_BUTTON_TEXT = "Continue";
 export const SAVE_AND_CONTINUE_BUTTON_TEXT = "Save and continue";
 export const SECOND_NATIONALITY = "Second nationality (optional)";
 export const SECOND_NATIONALITY_HINT = "Dual citizenship (also known as dual nationality) is allowed in some countries.";

--- a/test/controllers/update/overseas.entity.presenter.controller.spec.ts
+++ b/test/controllers/update/overseas.entity.presenter.controller.spec.ts
@@ -22,6 +22,7 @@ import { getApplicationData, prepareData, setApplicationData } from "../../../sr
 import { ApplicationDataType } from '../../../src/model';
 import {
   ANY_MESSAGE_ERROR,
+  CONTINUE_BUTTON_TEXT,
   FOUND_REDIRECT_TO,
   INFORMATION_SHOWN_ON_THE_PUBLIC_REGISTER,
   NOT_SHOW_INFORMATION_ON_PUBLIC_REGISTER,
@@ -76,6 +77,7 @@ describe("OVERSEAS ENTITY PRESENTER controller", () => {
       expect(resp.text).toContain(OVERSEAS_ENTITY_PRESENTER_PAGE_TITLE);
       expect(resp.text).not.toContain(PAGE_TITLE_ERROR);
       expect(resp.text).toContain(UPDATE_USE_INFORMATION_NEED_MORE);
+      expect(resp.text).toContain(CONTINUE_BUTTON_TEXT);
       expect(resp.text).toContain(INFORMATION_SHOWN_ON_THE_PUBLIC_REGISTER);
       expect(resp.text).toContain(NOT_SHOW_INFORMATION_ON_PUBLIC_REGISTER);
     });

--- a/test/controllers/update/update.beneficial.owner.gov.spec.ts
+++ b/test/controllers/update/update.beneficial.owner.gov.spec.ts
@@ -30,7 +30,7 @@ import {
   INFORMATION_SHOWN_ON_THE_PUBLIC_REGISTER,
   MESSAGE_ERROR,
   PAGE_TITLE_ERROR,
-  SAVE_AND_CONTINUE_BUTTON_TEXT,
+  CONTINUE_BUTTON_TEXT,
   SERVICE_UNAVAILABLE,
   SHOW_INFORMATION_ON_PUBLIC_REGISTER
 } from "../../__mocks__/text.mock";
@@ -96,7 +96,7 @@ describe("UPDATE BENEFICIAL OWNER GOV controller", () => {
       expect(resp.text).toContain(LANDING_PAGE_URL);
       expect(resp.text).not.toContain(PAGE_TITLE_ERROR);
       expect(resp.text).toContain(BENEFICIAL_OWNER_GOV_PAGE_HEADING);
-      expect(resp.text).toContain(SAVE_AND_CONTINUE_BUTTON_TEXT);
+      expect(resp.text).toContain(CONTINUE_BUTTON_TEXT);
       expect(resp.text).toContain(INFORMATION_SHOWN_ON_THE_PUBLIC_REGISTER);
       expect(resp.text).toContain(SHOW_INFORMATION_ON_PUBLIC_REGISTER);
     });
@@ -124,7 +124,7 @@ describe("UPDATE BENEFICIAL OWNER GOV controller", () => {
       expect(resp.text).toContain("LegalForm");
       expect(resp.text).toContain("a11");
       expect(resp.text).toContain("name=\"is_on_sanctions_list\" type=\"radio\" value=\"1\" checked");
-      expect(resp.text).toContain(SAVE_AND_CONTINUE_BUTTON_TEXT);
+      expect(resp.text).toContain(CONTINUE_BUTTON_TEXT);
     });
 
     test("Should render the error page", async () => {

--- a/test/controllers/update/update.beneficial.owner.individual.controller.spec.ts
+++ b/test/controllers/update/update.beneficial.owner.individual.controller.spec.ts
@@ -34,7 +34,7 @@ import {
   ERROR_LIST,
   PAGE_TITLE_ERROR,
   SERVICE_UNAVAILABLE,
-  SAVE_AND_CONTINUE_BUTTON_TEXT,
+  CONTINUE_BUTTON_TEXT,
   SECOND_NATIONALITY,
   SECOND_NATIONALITY_HINT,
   INFORMATION_SHOWN_ON_THE_PUBLIC_REGISTER,
@@ -107,7 +107,7 @@ describe("UPDATE BENEFICIAL OWNER INDIVIDUAL controller", () => {
       expect(resp.status).toEqual(200);
       expect(resp.text).toContain(config.LANDING_PAGE_URL);
       expect(resp.text).toContain(BENEFICIAL_OWNER_INDIVIDUAL_PAGE_HEADING);
-      expect(resp.text).toContain(SAVE_AND_CONTINUE_BUTTON_TEXT);
+      expect(resp.text).toContain(CONTINUE_BUTTON_TEXT);
       expect(resp.text).toContain(SECOND_NATIONALITY);
       expect(resp.text).toContain(SECOND_NATIONALITY_HINT);
       expect(resp.text).not.toContain(PAGE_TITLE_ERROR);
@@ -124,7 +124,7 @@ describe("UPDATE BENEFICIAL OWNER INDIVIDUAL controller", () => {
 
       expect(resp.status).toEqual(200);
       expect(resp.text).toContain(BENEFICIAL_OWNER_INDIVIDUAL_PAGE_HEADING);
-      expect(resp.text).toContain(SAVE_AND_CONTINUE_BUTTON_TEXT);
+      expect(resp.text).toContain(CONTINUE_BUTTON_TEXT);
       expect(resp.text).toContain("Ivan");
       expect(resp.text).toContain("Drago");
       expect(resp.text).toContain("Russian");

--- a/test/controllers/update/update.beneficial.owner.other.controller.spec.ts
+++ b/test/controllers/update/update.beneficial.owner.other.controller.spec.ts
@@ -5,6 +5,7 @@ jest.mock('../../../src/utils/application.data');
 jest.mock('../../../src/utils/save.and.continue');
 jest.mock('../../../src/middleware/navigation/update/has.presenter.middleware');
 jest.mock('../../../src/middleware/service.availability.middleware');
+jest.mock("../../../src/utils/feature.flag" );
 
 import { describe, expect, jest, test, beforeEach } from "@jest/globals";
 import request from "supertest";
@@ -48,7 +49,7 @@ import {
   MESSAGE_ERROR,
   PAGE_TITLE_ERROR,
   PUBLIC_REGISTER_HINT_TEXT,
-  SAVE_AND_CONTINUE_BUTTON_TEXT,
+  CONTINUE_BUTTON_TEXT,
   SERVICE_UNAVAILABLE,
   SHOW_INFORMATION_ON_PUBLIC_REGISTER
 } from "../../__mocks__/text.mock";
@@ -112,7 +113,7 @@ describe("UPDATE BENEFICIAL OWNER OTHER controller", () => {
       expect(resp.text).toContain(config.LANDING_PAGE_URL);
       expect(resp.text).not.toContain(PAGE_TITLE_ERROR);
       expect(resp.text).toContain(BENEFICIAL_OWNER_OTHER_PAGE_HEADING);
-      expect(resp.text).toContain(SAVE_AND_CONTINUE_BUTTON_TEXT);
+      expect(resp.text).toContain(CONTINUE_BUTTON_TEXT);
       expect(resp.text).toContain(INFORMATION_SHOWN_ON_THE_PUBLIC_REGISTER);
       expect(resp.text).toContain(SHOW_INFORMATION_ON_PUBLIC_REGISTER);
     });
@@ -125,7 +126,7 @@ describe("UPDATE BENEFICIAL OWNER OTHER controller", () => {
       expect(resp.text).not.toContain(PAGE_TITLE_ERROR);
       expect(resp.text).not.toContain(JURISDICTION_FIELD_LABEL);
       expect(resp.text).toContain(PUBLIC_REGISTER_HINT_TEXT);
-      expect(resp.text).toContain(SAVE_AND_CONTINUE_BUTTON_TEXT);
+      expect(resp.text).toContain(CONTINUE_BUTTON_TEXT);
     });
   });
 
@@ -142,7 +143,7 @@ describe("UPDATE BENEFICIAL OWNER OTHER controller", () => {
       expect(resp.text).toContain("town");
       expect(resp.text).toContain("country");
       expect(resp.text).toContain("BY 2");
-      expect(resp.text).toContain(SAVE_AND_CONTINUE_BUTTON_TEXT);
+      expect(resp.text).toContain(CONTINUE_BUTTON_TEXT);
     });
 
     test("Should render the error page", async () => {

--- a/test/controllers/update/update.filing.date.controller.spec.ts
+++ b/test/controllers/update/update.filing.date.controller.spec.ts
@@ -37,6 +37,7 @@ import {
   FOUND_REDIRECT_TO,
   PAGE_TITLE_ERROR,
   SERVICE_UNAVAILABLE,
+  CONTINUE_BUTTON_TEXT
 } from "../../__mocks__/text.mock";
 import { NextFunction } from "express";
 
@@ -80,6 +81,7 @@ describe("Update Filing Date controller", () => {
       expect(resp.status).toEqual(200);
       expect(resp.text).toContain("Date (NOT LIVE)");
       expect(resp.text).toContain(BACK_LINK_FOR_UPDATE_FILING_DATE);
+      expect(resp.text).toContain(CONTINUE_BUTTON_TEXT);
       expect(resp.text).not.toContain(PAGE_TITLE_ERROR);
     });
 

--- a/test/controllers/update/update.managing.officer.controller.spec.ts
+++ b/test/controllers/update/update.managing.officer.controller.spec.ts
@@ -47,10 +47,10 @@ import {
   UPDATE_MANAGING_OFFICER_PAGE_TITLE,
   NOT_SHOW_MANAGING_OFFICER_INFORMATION_ON_PUBLIC_REGISTER,
   PAGE_TITLE_ERROR,
-  SAVE_AND_CONTINUE_BUTTON_TEXT,
   SECOND_NATIONALITY,
   SECOND_NATIONALITY_HINT,
-  SERVICE_UNAVAILABLE
+  SERVICE_UNAVAILABLE,
+  CONTINUE_BUTTON_TEXT
 } from '../../__mocks__/text.mock';
 import { ApplicationDataType, managingOfficerType } from '../../../src/model';
 import { ErrorMessages } from '../../../src/validation/error.messages';
@@ -105,7 +105,7 @@ describe("UPDATE MANAGING OFFICER controller", () => {
       expect(resp.text).toContain(LANDING_PAGE_URL);
       expect(resp.text).toContain(UPDATE_MANAGING_OFFICER_PAGE_TITLE);
       expect(resp.text).not.toContain(PAGE_TITLE_ERROR);
-      expect(resp.text).toContain(SAVE_AND_CONTINUE_BUTTON_TEXT);
+      expect(resp.text).toContain(CONTINUE_BUTTON_TEXT);
       expect(resp.text).toContain(SECOND_NATIONALITY);
       expect(resp.text).toContain(SECOND_NATIONALITY_HINT);
       expect(resp.text).toContain(INFORMATION_SHOWN_ON_THE_PUBLIC_REGISTER);

--- a/test/controllers/update/update.managing.officer.corporate.spec.ts
+++ b/test/controllers/update/update.managing.officer.corporate.spec.ts
@@ -6,6 +6,7 @@ jest.mock('../../../src/middleware/service.availability.middleware');
 jest.mock('../../../src/utils/application.data');
 jest.mock("../../../src/utils/logger");
 jest.mock('../../../src/utils/save.and.continue');
+jest.mock("../../../src/utils/feature.flag" );
 
 import { describe, expect, test, jest, beforeEach } from '@jest/globals';
 import { NextFunction, Request, Response } from "express";
@@ -36,7 +37,7 @@ import {
   MESSAGE_ERROR,
   ANY_MESSAGE_ERROR,
   PAGE_TITLE_ERROR,
-  SAVE_AND_CONTINUE_BUTTON_TEXT,
+  CONTINUE_BUTTON_TEXT,
   SERVICE_UNAVAILABLE,
   SHOW_INFORMATION_ON_PUBLIC_REGISTER
 } from "../../__mocks__/text.mock";
@@ -65,6 +66,7 @@ import {
 import { logger } from "../../../src/utils/logger";
 import { hasUpdatePresenter } from "../../../src/middleware/navigation/update/has.presenter.middleware";
 import { serviceAvailabilityMiddleware } from "../../../src/middleware/service.availability.middleware";
+import { isActiveFeature } from "../../../src/utils/feature.flag";
 
 const mockHasUpdatePresenterMiddleware = hasUpdatePresenter as jest.Mock;
 mockHasUpdatePresenterMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => next() );
@@ -83,6 +85,9 @@ const mockPrepareData = prepareData as jest.Mock;
 const mockLoggerDebugRequest = logger.debugRequest as jest.Mock;
 const mockMapFieldsToDataObject = mapFieldsToDataObject as jest.Mock;
 const mockSaveAndContinue = saveAndContinue as jest.Mock;
+
+const mockIsActiveFeature = isActiveFeature as jest.Mock;
+mockIsActiveFeature.mockReturnValue(true);
 
 const DUMMY_DATA_OBJECT = { dummy: "data" };
 
@@ -103,7 +108,7 @@ describe("UPDATE MANAGING OFFICER CORPORATE controller", () => {
       expect(resp.text).toContain(MANAGING_OFFICER_CORPORATE_PAGE_TITLE);
       expect(resp.text).toContain(LANDING_PAGE_URL);
       expect(resp.text).not.toContain(PAGE_TITLE_ERROR);
-      expect(resp.text).toContain(SAVE_AND_CONTINUE_BUTTON_TEXT);
+      expect(resp.text).toContain(CONTINUE_BUTTON_TEXT);
       expect(resp.text).toContain(INFORMATION_SHOWN_ON_THE_PUBLIC_REGISTER);
       expect(resp.text).toContain(SHOW_INFORMATION_ON_PUBLIC_REGISTER);
     });

--- a/views/includes/save-and-continue-button.html
+++ b/views/includes/save-and-continue-button.html
@@ -1,7 +1,13 @@
 {% set textContinueButton = "Continue" %}
 
-{% if OE_CONFIGS.FEATURE_FLAG_ENABLE_SAVE_AND_RESUME_17102022 == "true" or OE_CONFIGS.FEATURE_FLAG_ENABLE_UPDATE_SAVE_AND_RESUME == "true" %}
-  {% set textContinueButton = "Save and continue" %}
+{% if ('/update-an-overseas-entity' in backLinkUrl) %}
+  {% if OE_CONFIGS.FEATURE_FLAG_ENABLE_UPDATE_SAVE_AND_RESUME === "true" %}
+    {% set textContinueButton = "Save and continue" %}
+  {% endif %}
+{% else %}
+  {% if OE_CONFIGS.FEATURE_FLAG_ENABLE_SAVE_AND_RESUME_17102022 === "true" %}
+    {% set textContinueButton = "Save and continue" %}
+  {% endif %}
 {% endif %}
 
 {{ govukButton({


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/UAR-397

### Change description
- Display “Save and Continue” or “Continue” for submit buttons depending on the feature flags for register and update journey

### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
