### PR TITLE
*PA*roe-2034: Fix trusts displaying on checkYourAnswers

### DIFF
--- a/views/check-your-answers.html
+++ b/views/check-your-answers.html
@@ -57,26 +57,6 @@
         {% endfor %}
       {% endif %}
 
-      {% if (pageParams.isTrustFeatureEnabled == true) %}
-        {% for trust in appData.trusts %}
-            {% if (trust.INDIVIDUALS and trust.INDIVIDUALS .length > 0) %}
-              {% for individualTrustee in trust.INDIVIDUALS  %}
-                {% include "includes/check-your-answers/individual-trustee.html" %}
-              {% endfor %}
-            {% endif %}
-            {% if (trust.CORPORATES and trust.CORPORATES.length > 0) %}
-              {% for legalEntity in trust.CORPORATES %}
-                {% include "includes/check-your-answers/legal-entity-trustee.html" %}
-              {% endfor %}
-            {% endif %}
-            {% if (trust.HISTORICAL_BO and trust.HISTORICAL_BO.length > 0) %}
-              {% for formerTrustee in trust.HISTORICAL_BO %}
-                {% include "includes/check-your-answers/historical-trustee.html" %}
-              {% endfor %}
-            {% endif %}
-        {% endfor %}
-      {% endif %}
-
       <br>
       <form method="post">
         <div class="govuk-button-group">

--- a/views/includes/check-your-answers/trusts.html
+++ b/views/includes/check-your-answers/trusts.html
@@ -56,6 +56,26 @@
       }
     ]
 }) }}
+  <br>
+  {% if (trust.HISTORICAL_BO and trust.HISTORICAL_BO.length > 0) %}
+    {% for formerTrustee in trust.HISTORICAL_BO %}
+      {% include "includes/check-your-answers/historical-trustee.html" %}
+    {% endfor %}
+    <br>
+  {% endif %}
+  {% if (trust.INDIVIDUALS and trust.INDIVIDUALS .length > 0) %}
+    {% for individualTrustee in trust.INDIVIDUALS  %}
+      {% include "includes/check-your-answers/individual-trustee.html" %}
+    {% endfor %}
+    <br>
+  {% endif %}
+  {% if (trust.CORPORATES and trust.CORPORATES.length > 0) %}
+    {% for legalEntity in trust.CORPORATES %}
+      {% include "includes/check-your-answers/legal-entity-trustee.html" %}
+    {% endfor %}
+    <br>
+  {% endif %}
+
 {% else %}
   {{ govukSummaryList({
     rows: [


### PR DESCRIPTION
### JIRA link

[ROE-2034](https://companieshouse.atlassian.net/browse/ROE-2034)

Local Video on Jira

### Change description

- Trusts and trustees are displaying incorrectly on the check your answers page. All trusts are shown then all trustee are shown.
- This changes makes it so that a trust is shown then it's associated trustees are shown before the next new trust and it's trustees

### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.


[ROE-2034]: https://companieshouse.atlassian.net/browse/ROE-2034?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ