### PR TITLE
*PA*roe-2132: Add function to convert api corporate_Indicator

### DIFF
--- a/src/utils/trusts.ts
+++ b/src/utils/trusts.ts
@@ -13,6 +13,7 @@ import {
   TrustKey,
   TrustCorporate,
 } from "../model/trust.model";
+import { yesNoResponse } from "../model/data.types.model";
 
 /**
  * Checks whether any beneficial owners requires trust data due to at least one of them
@@ -422,10 +423,8 @@ const mapTrustApiReturnModelToWebModel = (appData: ApplicationData) => {
       });
 
       trust.HISTORICAL_BO = (trust.HISTORICAL_BO as TrustHistoricalBeneficialOwner[]).map(
-        hbo => {return { id: uuidv4(), ...hbo }; } );
-
+        hbo => {return { id: uuidv4(), ...hbo, corporate_indicator: convertBooleanToYesNoResponse(hbo.corporate_indicator), }; } );
     }
-
   }
 };
 
@@ -444,6 +443,16 @@ function getRoleWithinTrustType(type: any): RoleWithinTrustType | undefined {
         break;
   }
   return undefined;
+}
+
+function convertBooleanToYesNoResponse(apiYesNoResponse: yesNoResponse): yesNoResponse {
+  // used to convert boolean recieved from api to number for yesNoResponse used in web.
+  // although true/false is sent by the api, typescript still detects it as a yesNoResponse hence why yesNoResponse is passed to this function
+
+  if (apiYesNoResponse === undefined){
+    return yesNoResponse.No;
+  }
+  return Number(apiYesNoResponse);
 }
 
 export {

--- a/test/utils/trust.spec.ts
+++ b/test/utils/trust.spec.ts
@@ -943,7 +943,7 @@ describe('Trust Utils method tests', () => {
       expect(historicalTrusteesWebModel[0]["forename"]).toEqual("Ben");
       expect(historicalTrusteesWebModel[0]["other_forenames"]).toEqual("");
       expect(historicalTrusteesWebModel[0]["surname"]).toEqual("Gone");
-      expect(historicalTrusteesWebModel[0]["corporate_indicator"]).toEqual(false);
+      expect(historicalTrusteesWebModel[0]["corporate_indicator"]).toEqual(0);
       expect(historicalTrusteesWebModel[0]["notified_date_day"]).toEqual("10");
       expect(historicalTrusteesWebModel[0]["notified_date_month"]).toEqual("12");
       expect(historicalTrusteesWebModel[0]["notified_date_year"]).toEqual("2010");
@@ -953,7 +953,7 @@ describe('Trust Utils method tests', () => {
 
       expect(historicalTrusteesWebModel[1]).toHaveProperty('id');
       expect(historicalTrusteesWebModel[1]["corporate_name"]).toEqual("Yesterday Limited");
-      expect(historicalTrusteesWebModel[1]["corporate_indicator"]).toEqual(true);
+      expect(historicalTrusteesWebModel[1]["corporate_indicator"]).toEqual(1);
       expect(historicalTrusteesWebModel[1]["notified_date_day"]).toEqual("10");
       expect(historicalTrusteesWebModel[1]["notified_date_month"]).toEqual("12");
       expect(historicalTrusteesWebModel[1]["notified_date_year"]).toEqual("2010");
@@ -966,5 +966,4 @@ describe('Trust Utils method tests', () => {
   test("no trust data so nothing happens in mapTrustApiReturnModelToWebModel", () => {
     mapTrustApiReturnModelToWebModel({});
   });
-
 });


### PR DESCRIPTION
### JIRA link

[ROE-2132](https://companieshouse.atlassian.net/browse/ROE-2132)

### Change description

- The web uses a yesNoResponse which reflects a yes or no choice using 1 and 0. The api is returing the corporate_indicator as true or false which makes checking it more difficult.
- This private function is used to convert the api corporate_indicator into a 1 or 0 so that the web app understands it. This function is called when data is being populated to the session from a save and resumed application

### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.


[ROE-2132]: https://companieshouse.atlassian.net/browse/ROE-2132?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ