### PR TITLE
UAR-387/388/389: update pronouns for ceased date field depending on BO type

### DIFF
--- a/views/includes/inputs/date/ceased-date-input.html
+++ b/views/includes/inputs/date/ceased-date-input.html
@@ -1,4 +1,8 @@
-{% set dateText = "Date it ceased to be a registrable beneficial owner" %}
+{% if beneficialOwnerPronoun == "they" %}
+  {% set dateText = "Date they ceased to be a registrable beneficial owner" %}
+{% else %}
+  {% set dateText = "Date it ceased to be a registrable beneficial owner" %}
+{% endif %}
 
 {% set ceasedDateErrorMessage = '' %}
 {% set isCeasedDateDayError = false %}

--- a/views/includes/inputs/fields/is-on-sanctions-list-input.html
+++ b/views/includes/inputs/fields/is-on-sanctions-list-input.html
@@ -1,4 +1,4 @@
-{% if sanctionsPronoun == "they" %}
+{% if beneficialOwnerPronoun == "they" %}
   {% set sanctionsListHintText = "This means that they are subject to sanctions under the Sanctions and Anti-Money Laundering Act 2018." %}
   {% set sanctionsListText = "Are they on the UK Sanctions List?" %}
   {% set sanctionsListNoText = "No, they are not on the Sanctions List" %}

--- a/views/includes/inputs/fields/is-still-a-beneficial-owner-input.html
+++ b/views/includes/inputs/fields/is-still-a-beneficial-owner-input.html
@@ -3,9 +3,9 @@
 {% endset -%}
 
 {% if beneficialOwnerPronoun == "they" %}
-  {% set legendText = "Are they still a beneficial owner for the overseas entity?" %}
+  {% set stillBoText = "Are they still a beneficial owner for the overseas entity?" %}
 {% else %}
-  {% set legendText = "Is it still a beneficial owner for the overseas entity?" %}
+  {% set stillBoText = "Is it still a beneficial owner for the overseas entity?" %}
 {% endif %}
 
 {{ govukRadios({
@@ -15,7 +15,7 @@
   name: "is_still_bo",
   fieldset: {
     legend: {
-      text: legendText,
+      text: stillBoText,
       isPageHeading: false,
       classes: "govuk-fieldset__legend--m"
     }

--- a/views/includes/inputs/fields/is-still-a-beneficial-owner-input.html
+++ b/views/includes/inputs/fields/is-still-a-beneficial-owner-input.html
@@ -2,6 +2,12 @@
   {% include "includes/inputs/date/ceased-date-input.html" %}
 {% endset -%}
 
+{% if beneficialOwnerPronoun == "they" %}
+  {% set legendText = "Are they still a beneficial owner for the overseas entity?" %}
+{% else %}
+  {% set legendText = "Is it still a beneficial owner for the overseas entity?" %}
+{% endif %}
+
 {{ govukRadios({
   errorMessage: errors.is_still_bo if errors,
   classes: "govuk-radios",
@@ -9,7 +15,7 @@
   name: "is_still_bo",
   fieldset: {
     legend: {
-      text: "Is it still a beneficial owner for the overseas entity?",
+      text: legendText,
       isPageHeading: false,
       classes: "govuk-fieldset__legend--m"
     }

--- a/views/includes/page-templates/beneficial-owner-gov.html
+++ b/views/includes/page-templates/beneficial-owner-gov.html
@@ -7,6 +7,7 @@
     <p class="govuk-caption-l  govuk-!-margin-bottom-5 govuk-!-margin-top-5">You can add more later.</p>
 
     <form class="form" method="post">
+      {% set beneficialOwnerPronoun = "it" %}
       {% include "includes/inputs/fields/name-input.html" %}
 
       {% include "includes/inputs/address/principal-address-input.html" %}
@@ -27,7 +28,6 @@
       {% set natureOfControlText = "What is its nature of control?" %}
       {% include "includes/page-templates/beneficial-owner-nature-of-control-types.html" %}
 
-      {% set sanctionsPronoun = "it" %}
       {% include "includes/inputs/fields/is-on-sanctions-list-input.html" %}
 
       {% include "includes/inset-text.html" %}

--- a/views/includes/page-templates/beneficial-owner-individual.html
+++ b/views/includes/page-templates/beneficial-owner-individual.html
@@ -8,6 +8,7 @@
     <br> <p class="govuk-body">You can add more later.</p> <br>
 
     <form method="post">
+      {% set beneficialOwnerPronoun = "they" %}
       {% include "includes/inputs/fields/first-name-input.html" %}
 
       {% set hintLastNameText = "This is also known as your family name." %}
@@ -31,7 +32,6 @@
       {% set natureOfControlText = "What is their nature of control?" %}
       {% include "includes/page-templates/beneficial-owner-nature-of-control-types.html" %}
 
-      {% set sanctionsPronoun = "they" %}
       {% include "includes/inputs/fields/is-on-sanctions-list-input.html" %}
 
       {% set paragraphOne = '<p>We will not show the beneficial owner’s home address unless it is the same as their correspondence address. We’ll only show the month and year of their date of birth.</p>' %}

--- a/views/includes/page-templates/beneficial-owner-other.html
+++ b/views/includes/page-templates/beneficial-owner-other.html
@@ -10,6 +10,7 @@
     <br>
 
     <form class="form" method="post">
+      {% set beneficialOwnerPronoun = "it" %}
       {% include "includes/inputs/fields/name-input.html" %}
 
       {% include "includes/inputs/address/principal-address-input.html" %}
@@ -37,7 +38,6 @@
       {% set natureOfControlText = "What is its nature of control?" %}
       {% include "includes/page-templates/beneficial-owner-nature-of-control-types.html" %}
 
-      {% set sanctionsPronoun = "it" %}
       {% include "includes/inputs/fields/is-on-sanctions-list-input.html" %}
 
       {% include "includes/inset-text.html" %}


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/UAR-387

Comment raised in QA

### Change description

BO individual:
<img width="697" alt="BO individual" src="https://user-images.githubusercontent.com/117734784/232049321-e587ab97-1524-45cd-835b-7317c16d1010.png">

BO other:
<img width="689" alt="BO other" src="https://user-images.githubusercontent.com/117734784/232049367-7ac165ef-b7f3-4cd4-9723-ebbb018da65c.png">

BO gov:

<img width="655" alt="BO gov" src="https://user-images.githubusercontent.com/117734784/232049404-a45018b9-39ea-4da1-8a8c-d48c1e268f41.png">



### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
