### PR TITLE
UAR-551: upgrade govuk-frontend to 4.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "cookie-parser": "^1.4.6",
         "express": "^4.17.3",
         "express-validator": "^6.14.0",
-        "govuk-frontend": "^4.0.1",
+        "govuk-frontend": "^4.6.0",
         "ioredis": "^4.28.5",
         "luxon": "^2.4.0",
         "nunjucks": "^3.2.3",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "cookie-parser": "^1.4.6",
     "express": "^4.17.3",
     "express-validator": "^6.14.0",
-    "govuk-frontend": "^4.0.1",
+    "govuk-frontend": "^4.6.0",
     "ioredis": "^4.28.5",
     "luxon": "^2.4.0",
     "nunjucks": "^3.2.3",

--- a/views/layout.html
+++ b/views/layout.html
@@ -23,7 +23,7 @@
 {% block head %}
 
   <!--[if !IE 8]><!-->
-  <link rel="stylesheet" type="text/css" media="all" href="//{{CDN_HOST}}/stylesheets/govuk-frontend/v3.11.0/govuk-frontend-3.11.0.min.css" />
+  <link rel="stylesheet" type="text/css" media="all" href="//{{CDN_HOST}}/stylesheets/govuk-frontend/v4.6.0/govuk-frontend-4.6.0.min.css" />
   <link rel="stylesheet" type="text/css" media="all" href="//{{CDN_HOST}}/stylesheets/services/overseas-entities/application.css"  />
   <!--<![endif]-->
 
@@ -89,7 +89,7 @@
 {% endblock %}
 
 {% block bodyEnd %}
-  <script src="//{{CDN_HOST}}/javascripts/govuk-frontend/v3.11.0/govuk-frontend-3.11.0.min.js"></script>
+  <script src="//{{CDN_HOST}}/javascripts/govuk-frontend/v4.6.0/govuk-frontend-4.6.0.min.js"></script>
   <script>window.GOVUKFrontend.initAll()</script>
   {% include "includes/piwik-scripts.html" %}
 {% endblock %}


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/UAR-551

### Change description
We have been able to update locally govuk-frontend to version 4.6.0, requires some manual effort to push CSS assets to local CDN container.
This results in no flicker replicated.

 

We can replicate the flicker by, instead of doing the above manual pushing of CSS assets, changing the CDN_HOST env variable for the overseas-entities-web container to the external cloudfront host d3uvya5a8a1ncx.cloudfront.net. It is this step that results in the ‘flicker’ on page loads.


The flicker is caused by GDS Transport fonts not existing on this host, which results in multiple 404s when govuk-frontend is trying to find fonts, as can be seen in attached screenshots. The page/library then falls back to displaying text in Arial.

From code point of view, nothing is required apart from updating the library.

TO STOP FLICKER: appropriate fonts will need to be added to cloudfront.
<img width="949" alt="Screenshot 2023-05-12 at 15 23 33" src="https://github.com/companieshouse/overseas-entities-web/assets/117734784/4c267cea-b98c-41c2-83b7-e4f320f9c619">

<img width="641" alt="Screenshot 2023-05-12 at 15 23 47" src="https://github.com/companieshouse/overseas-entities-web/assets/117734784/423fb271-6244-4361-81ba-39bd2ef46b52">


<img width="362" alt="Screenshot 2023-05-12 at 15 27 31" src="https://github.com/companieshouse/overseas-entities-web/assets/117734784/3b9df98c-6574-4742-a33d-5aebf2de1155">

### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
