### PR TITLE
UAR-473: read nationalities from comma separated list

### DIFF
--- a/src/utils/update/managing.officer.mapper.ts
+++ b/src/utils/update/managing.officer.mapper.ts
@@ -9,6 +9,7 @@ export const mapToManagingOfficer = (officer: CompanyOfficer): ManagingOfficerIn
   const service_address = mapBOMOAddress(officer.address);
   const address = undefined;
   const names = splitNames(officer.name);
+  const nationalities = splitNationalities(officer.nationality);
   const formernames = getFormerNames(officer.formerNames);
 
   return {
@@ -18,7 +19,8 @@ export const mapToManagingOfficer = (officer: CompanyOfficer): ManagingOfficerIn
     has_former_names: officer.formerNames ? yesNoResponse.Yes : yesNoResponse.No,
     former_names: formernames,
     date_of_birth: mapDateOfBirth(officer.dateOfBirth),
-    nationality: officer.nationality,
+    nationality: nationalities[0],
+    second_nationality: nationalities[1],
     usual_residential_address: address,
     is_service_address_same_as_usual_residential_address: isSameAddress(service_address, address) ? yesNoResponse.Yes : yesNoResponse.No,
     service_address: service_address,
@@ -67,6 +69,13 @@ export const splitNames = (officerName: string): string[] => {
       return names;
     }
   }
+};
+
+export const splitNationalities = (officerNationalities: string | undefined): string[] => {
+  if (!officerNationalities) {
+    return [""];
+  }
+  return officerNationalities.split(/\s*,\s*/).slice(0, 2);
 };
 
 export const getFormerNames = (formerNames?: FormerNameResource[]): string => {

--- a/src/utils/update/managing.officer.mapper.ts
+++ b/src/utils/update/managing.officer.mapper.ts
@@ -64,7 +64,7 @@ export const splitNames = (officerName: string): string[] => {
           firstNames += " ";
         }
       }
-      return [firstNames, names[names.length - 1]];
+      return [firstNames.trim(), names[names.length - 1].trim()];
     } else {
       return names;
     }

--- a/test/__mocks__/session.mock.ts
+++ b/test/__mocks__/session.mock.ts
@@ -833,6 +833,39 @@ export const UPDATE_MANAGING_OFFICER_OBJECT_MOCK: managingOfficerType.ManagingOf
   role_and_responsibilities: "Some role and responsibilities"
 };
 
+export const UPDATE_MANAGING_OFFICER_SINGLE_NATIONALITY_MOCK: managingOfficerType.ManagingOfficerIndividual = {
+  id: MO_IND_ID,
+  ch_reference: "testchreference",
+  first_name: "Jimmy John",
+  last_name: "Wabb",
+  has_former_names: yesNoResponse.Yes,
+  former_names: "Jimmothy James Jimminny, Finn McCumhaill, Test Tester",
+  date_of_birth: { day: "1", month: "2", year: "1900" },
+  nationality: "country1",
+  usual_residential_address: ADDRESS,
+  service_address: ADDRESS,
+  is_service_address_same_as_usual_residential_address: yesNoResponse.Yes,
+  occupation: "occupation",
+  role_and_responsibilities: "role"
+};
+
+export const UPDATE_MANAGING_OFFICER_DUAL_NATIONALITY_MOCK: managingOfficerType.ManagingOfficerIndividual = {
+  id: MO_IND_ID,
+  ch_reference: "testchreference",
+  first_name: "Jimmy John",
+  last_name: "Wabb",
+  has_former_names: yesNoResponse.Yes,
+  former_names: "Jimmothy James Jimminny, Finn McCumhaill, Test Tester",
+  date_of_birth: { day: "1", month: "2", year: "1900" },
+  nationality: "country1",
+  second_nationality: "country2",
+  usual_residential_address: ADDRESS,
+  service_address: ADDRESS,
+  is_service_address_same_as_usual_residential_address: yesNoResponse.Yes,
+  occupation: "occupation",
+  role_and_responsibilities: "role"
+};
+
 export const REQ_BODY_MANAGING_OFFICER_OBJECT_EMPTY = {
   first_name: "",
   last_name: "",

--- a/test/utils/update/managing.officer.mapper.spec.ts
+++ b/test/utils/update/managing.officer.mapper.spec.ts
@@ -1,8 +1,8 @@
 import { CompanyOfficer } from '@companieshouse/api-sdk-node/dist/services/company-officers/types';
 import { yesNoResponse } from '../../../src/model/data.types.model';
-import { mapToManagingOfficer, mapToManagingOfficerCorporate, splitNames, getFormerNames } from '../../../src/utils/update/managing.officer.mapper';
+import { mapToManagingOfficer, mapToManagingOfficerCorporate, splitNames, getFormerNames, splitNationalities } from '../../../src/utils/update/managing.officer.mapper';
 import { MANAGING_OFFICER_MOCK_MAP_DATA } from '../../__mocks__/session.mock';
-import { managingOfficerMock } from './mocks';
+import { managingOfficerMock, managingOfficerMockDualNationality } from './mocks';
 
 describe("Test mapping to managing officer", () => {
 
@@ -34,7 +34,7 @@ describe("Test mapping to managing officer", () => {
         month: managingOfficerMock.dateOfBirth?.month,
         year: managingOfficerMock.dateOfBirth?.year
       },
-      nationality: managingOfficerMock.nationality,
+      nationality: splitNationalities(managingOfficerMock.nationality)[0],
       start_date: {
         day: "1",
         month: "4",
@@ -53,6 +53,41 @@ describe("Test mapping to managing officer", () => {
       },
       occupation: managingOfficerMock.occupation,
       role_and_responsibilities: managingOfficerMock.officerRole
+    });
+  });
+
+  test('map officer data to managing officer with two nationalities should return object', () => {
+    expect(mapToManagingOfficer(managingOfficerMockDualNationality)).toEqual({
+      id: undefined,
+      first_name: splitNames(managingOfficerMockDualNationality.name)[0],
+      last_name: splitNames(managingOfficerMockDualNationality.name)[1],
+      has_former_names: yesNoResponse.Yes,
+      former_names: getFormerNames(managingOfficerMockDualNationality.formerNames),
+      date_of_birth: {
+        day: managingOfficerMockDualNationality.dateOfBirth?.day,
+        month: managingOfficerMockDualNationality.dateOfBirth?.month,
+        year: managingOfficerMockDualNationality.dateOfBirth?.year
+      },
+      nationality: splitNationalities(managingOfficerMockDualNationality.nationality)[0],
+      second_nationality: splitNationalities(managingOfficerMockDualNationality.nationality)[1],
+      start_date: {
+        day: "1",
+        month: "4",
+        year: "2023",
+      },
+      usual_residential_address: undefined,
+      is_service_address_same_as_usual_residential_address: yesNoResponse.Yes,
+      service_address: {
+        property_name_number: managingOfficerMockDualNationality.address.premises,
+        line_1: managingOfficerMockDualNationality.address.addressLine1,
+        line_2: managingOfficerMockDualNationality.address.addressLine2,
+        town: managingOfficerMockDualNationality.address.locality,
+        county: managingOfficerMockDualNationality.address.region,
+        country: managingOfficerMockDualNationality.address.country,
+        postcode: managingOfficerMockDualNationality.address.postalCode,
+      },
+      occupation: managingOfficerMockDualNationality.occupation,
+      role_and_responsibilities: managingOfficerMockDualNationality.officerRole
     });
   });
 

--- a/test/utils/update/managing.officer.mapper.spec.ts
+++ b/test/utils/update/managing.officer.mapper.spec.ts
@@ -1,7 +1,7 @@
 import { CompanyOfficer } from '@companieshouse/api-sdk-node/dist/services/company-officers/types';
 import { yesNoResponse } from '../../../src/model/data.types.model';
-import { mapToManagingOfficer, mapToManagingOfficerCorporate, splitNames, getFormerNames, splitNationalities } from '../../../src/utils/update/managing.officer.mapper';
-import { MANAGING_OFFICER_MOCK_MAP_DATA } from '../../__mocks__/session.mock';
+import { mapToManagingOfficer, mapToManagingOfficerCorporate, getFormerNames } from '../../../src/utils/update/managing.officer.mapper';
+import { MANAGING_OFFICER_MOCK_MAP_DATA, UPDATE_MANAGING_OFFICER_DUAL_NATIONALITY_MOCK, UPDATE_MANAGING_OFFICER_SINGLE_NATIONALITY_MOCK } from '../../__mocks__/session.mock';
 import { managingOfficerMock, managingOfficerMockDualNationality } from './mocks';
 
 describe("Test mapping to managing officer", () => {
@@ -25,16 +25,16 @@ describe("Test mapping to managing officer", () => {
   test('map officer data to managing officer should return object', () => {
     expect(mapToManagingOfficer(managingOfficerMock)).toEqual({
       id: undefined,
-      first_name: splitNames(managingOfficerMock.name)[0],
-      last_name: splitNames(managingOfficerMock.name)[1],
+      first_name: UPDATE_MANAGING_OFFICER_SINGLE_NATIONALITY_MOCK.first_name,
+      last_name: UPDATE_MANAGING_OFFICER_SINGLE_NATIONALITY_MOCK.last_name,
       has_former_names: yesNoResponse.Yes,
-      former_names: getFormerNames(managingOfficerMock.formerNames),
+      former_names: UPDATE_MANAGING_OFFICER_SINGLE_NATIONALITY_MOCK.former_names,
       date_of_birth: {
-        day: managingOfficerMock.dateOfBirth?.day,
-        month: managingOfficerMock.dateOfBirth?.month,
-        year: managingOfficerMock.dateOfBirth?.year
+        day: UPDATE_MANAGING_OFFICER_SINGLE_NATIONALITY_MOCK.date_of_birth?.day,
+        month: UPDATE_MANAGING_OFFICER_SINGLE_NATIONALITY_MOCK.date_of_birth?.month,
+        year: UPDATE_MANAGING_OFFICER_SINGLE_NATIONALITY_MOCK.date_of_birth?.year
       },
-      nationality: splitNationalities(managingOfficerMock.nationality)[0],
+      nationality: UPDATE_MANAGING_OFFICER_SINGLE_NATIONALITY_MOCK.nationality,
       start_date: {
         day: "1",
         month: "4",
@@ -43,33 +43,33 @@ describe("Test mapping to managing officer", () => {
       usual_residential_address: undefined,
       is_service_address_same_as_usual_residential_address: yesNoResponse.Yes,
       service_address: {
-        property_name_number: managingOfficerMock.address.premises,
-        line_1: managingOfficerMock.address.addressLine1,
-        line_2: managingOfficerMock.address.addressLine2,
-        town: managingOfficerMock.address.locality,
-        county: managingOfficerMock.address.region,
-        country: managingOfficerMock.address.country,
-        postcode: managingOfficerMock.address.postalCode,
+        property_name_number: UPDATE_MANAGING_OFFICER_SINGLE_NATIONALITY_MOCK.service_address?.property_name_number,
+        line_1: UPDATE_MANAGING_OFFICER_SINGLE_NATIONALITY_MOCK.service_address?.line_1,
+        line_2: UPDATE_MANAGING_OFFICER_SINGLE_NATIONALITY_MOCK.service_address?.line_2,
+        town: UPDATE_MANAGING_OFFICER_SINGLE_NATIONALITY_MOCK.service_address?.town,
+        county: UPDATE_MANAGING_OFFICER_SINGLE_NATIONALITY_MOCK.service_address?.county,
+        country: UPDATE_MANAGING_OFFICER_SINGLE_NATIONALITY_MOCK.service_address?.country,
+        postcode: UPDATE_MANAGING_OFFICER_SINGLE_NATIONALITY_MOCK.service_address?.postcode,
       },
-      occupation: managingOfficerMock.occupation,
-      role_and_responsibilities: managingOfficerMock.officerRole
+      occupation: UPDATE_MANAGING_OFFICER_SINGLE_NATIONALITY_MOCK.occupation,
+      role_and_responsibilities: UPDATE_MANAGING_OFFICER_SINGLE_NATIONALITY_MOCK.role_and_responsibilities
     });
   });
 
   test('map officer data to managing officer with two nationalities should return object', () => {
     expect(mapToManagingOfficer(managingOfficerMockDualNationality)).toEqual({
       id: undefined,
-      first_name: splitNames(managingOfficerMockDualNationality.name)[0],
-      last_name: splitNames(managingOfficerMockDualNationality.name)[1],
+      first_name: UPDATE_MANAGING_OFFICER_DUAL_NATIONALITY_MOCK.first_name,
+      last_name: UPDATE_MANAGING_OFFICER_DUAL_NATIONALITY_MOCK.last_name,
       has_former_names: yesNoResponse.Yes,
       former_names: getFormerNames(managingOfficerMockDualNationality.formerNames),
       date_of_birth: {
-        day: managingOfficerMockDualNationality.dateOfBirth?.day,
-        month: managingOfficerMockDualNationality.dateOfBirth?.month,
-        year: managingOfficerMockDualNationality.dateOfBirth?.year
+        day: UPDATE_MANAGING_OFFICER_DUAL_NATIONALITY_MOCK.date_of_birth?.day,
+        month: UPDATE_MANAGING_OFFICER_DUAL_NATIONALITY_MOCK.date_of_birth?.month,
+        year: UPDATE_MANAGING_OFFICER_DUAL_NATIONALITY_MOCK.date_of_birth?.year
       },
-      nationality: splitNationalities(managingOfficerMockDualNationality.nationality)[0],
-      second_nationality: splitNationalities(managingOfficerMockDualNationality.nationality)[1],
+      nationality: UPDATE_MANAGING_OFFICER_DUAL_NATIONALITY_MOCK.nationality,
+      second_nationality: UPDATE_MANAGING_OFFICER_DUAL_NATIONALITY_MOCK.second_nationality,
       start_date: {
         day: "1",
         month: "4",
@@ -78,16 +78,16 @@ describe("Test mapping to managing officer", () => {
       usual_residential_address: undefined,
       is_service_address_same_as_usual_residential_address: yesNoResponse.Yes,
       service_address: {
-        property_name_number: managingOfficerMockDualNationality.address.premises,
-        line_1: managingOfficerMockDualNationality.address.addressLine1,
-        line_2: managingOfficerMockDualNationality.address.addressLine2,
-        town: managingOfficerMockDualNationality.address.locality,
-        county: managingOfficerMockDualNationality.address.region,
-        country: managingOfficerMockDualNationality.address.country,
-        postcode: managingOfficerMockDualNationality.address.postalCode,
+        property_name_number: UPDATE_MANAGING_OFFICER_DUAL_NATIONALITY_MOCK.service_address?.property_name_number,
+        line_1: UPDATE_MANAGING_OFFICER_DUAL_NATIONALITY_MOCK.service_address?.line_1,
+        line_2: UPDATE_MANAGING_OFFICER_DUAL_NATIONALITY_MOCK.service_address?.line_2,
+        town: UPDATE_MANAGING_OFFICER_DUAL_NATIONALITY_MOCK.service_address?.town,
+        county: UPDATE_MANAGING_OFFICER_DUAL_NATIONALITY_MOCK.service_address?.county,
+        country: UPDATE_MANAGING_OFFICER_DUAL_NATIONALITY_MOCK.service_address?.country,
+        postcode: UPDATE_MANAGING_OFFICER_DUAL_NATIONALITY_MOCK.service_address?.postcode,
       },
-      occupation: managingOfficerMockDualNationality.occupation,
-      role_and_responsibilities: managingOfficerMockDualNationality.officerRole
+      occupation: UPDATE_MANAGING_OFFICER_DUAL_NATIONALITY_MOCK.occupation,
+      role_and_responsibilities: UPDATE_MANAGING_OFFICER_DUAL_NATIONALITY_MOCK.role_and_responsibilities
     });
   });
 

--- a/test/utils/update/mocks.ts
+++ b/test/utils/update/mocks.ts
@@ -99,14 +99,14 @@ export const pscMock: CompanyPersonWithSignificantControl = {
 
 export const managingOfficerMock: CompanyOfficer = {
   address: {
-    premises: "1 Acme Road",
+    premises: "1",
     addressLine1: "addressLine1",
     addressLine2: "addressLine2",
-    locality: "locality",
+    locality: "town",
     careOf: "careOf",
     poBox: "pobox",
     postalCode: "BY 2",
-    region: "region",
+    region: "county",
     country: "country"
   },
   appointedOn: "2023-04-01",
@@ -138,14 +138,14 @@ export const managingOfficerMock: CompanyOfficer = {
 
 export const managingOfficerMockDualNationality: CompanyOfficer = {
   address: {
-    premises: "1 Acme Road",
+    premises: "1",
     addressLine1: "addressLine1",
     addressLine2: "addressLine2",
-    locality: "locality",
+    locality: "town",
     careOf: "careOf",
     poBox: "pobox",
     postalCode: "BY 2",
-    region: "region",
+    region: "county",
     country: "country"
   },
   appointedOn: "2023-04-01",

--- a/test/utils/update/mocks.ts
+++ b/test/utils/update/mocks.ts
@@ -135,3 +135,42 @@ export const managingOfficerMock: CompanyOfficer = {
   officerRole: "role",
   resignedOn: "resigned"
 };
+
+export const managingOfficerMockDualNationality: CompanyOfficer = {
+  address: {
+    premises: "1 Acme Road",
+    addressLine1: "addressLine1",
+    addressLine2: "addressLine2",
+    locality: "locality",
+    careOf: "careOf",
+    poBox: "pobox",
+    postalCode: "BY 2",
+    region: "region",
+    country: "country"
+  },
+  appointedOn: "2023-04-01",
+  countryOfResidence: "country1",
+  dateOfBirth: {
+    day: "1",
+    month: "2",
+    year: "1900"
+  },
+  formerNames: [ { forenames: "Jimmothy James", surname: "Jimminny" }, { forenames: "Finn", surname: "McCumhaill" }, { forenames: "Test", surname: "Tester" } ],
+  identification: {
+    legalForm: "all forms",
+    legalAuthority: "country2",
+    identificationType: "identification type",
+    placeRegistered: "place",
+    registrationNumber: "0000"
+  },
+  links: {
+    officer: {
+      appointments: ""
+    }
+  },
+  name: "Jimmy John Wabb",
+  nationality: "country1, country2",
+  occupation: "occupation",
+  officerRole: "role",
+  resignedOn: "resigned"
+};


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/UAR-473


### Change description
Nationality information for an MOs ‘nationality’ and an MOs ‘additional nationality’ is stored as a comma separated list in CHIPs. 
We need to a solution to ensure that the second nationality listed in the comma separated list, appears separately on the page as a second item. This solution will assist the ROE Agent in entering, checking and amending the MO ‘nationality’ and ‘additional nationality’ data.


### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
