### PR TITLE
[UAR-486] capture resigned_on and start_date dates for new MOs

### DIFF
--- a/src/model/date.model.ts
+++ b/src/model/date.model.ts
@@ -8,6 +8,7 @@ export const StartDateKey: string = "start_date";
 export const IdentityDateKey: string = "identity_date";
 export const CeasedDateKey: string = "ceased_date";
 export const FilingDateKey: string = "filing_date";
+export const ResignedOnDateKey: string = "resigned_on";
 
 /*
   The sub-fields for Date Objects used in the templates
@@ -40,4 +41,10 @@ export const FilingDateKeys: string[] = [
   "filing_date-day",
   "filing_date-month",
   "filing_date-year",
+];
+
+export const ResignedOnDateKeys: string[] = [
+  "resigned_on-day",
+  "resigned_on-month",
+  "resigned_on-year",
 ];

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -546,7 +546,7 @@ router.route(config.UPDATE_MANAGING_OFFICER_CORPORATE_URL)
     navigation.hasUpdatePresenter
   )
   .get(updateManagingOfficerCorporate.get)
-  .post(...validator.managingOfficerCorporate, checkValidations, updateManagingOfficerCorporate.post);
+  .post(...validator.updateManagingOfficerCorporate, checkValidations, updateManagingOfficerCorporate.post);
 
 router.route(config.UPDATE_MANAGING_OFFICER_CORPORATE_URL + config.ID)
   .all(
@@ -555,7 +555,7 @@ router.route(config.UPDATE_MANAGING_OFFICER_CORPORATE_URL + config.ID)
     navigation.hasUpdatePresenter
   )
   .get(updateManagingOfficerCorporate.getById)
-  .post(...validator.managingOfficerCorporate, checkValidations, updateManagingOfficerCorporate.update);
+  .post(...validator.updateManagingOfficerCorporate, checkValidations, updateManagingOfficerCorporate.update);
 router.get(config.UPDATE_MANAGING_OFFICER_CORPORATE_URL + config.REMOVE + config.ID, authentication, navigation.hasUpdatePresenter, updateManagingOfficerCorporate.remove);
 
 router.route(config.UPDATE_CONFIRM_TO_REMOVE_URL + config.ROUTE_PARAM_BENEFICIAL_OWNER_TYPE + config.ID)

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -509,7 +509,7 @@ router.route(config.UPDATE_MANAGING_OFFICER_URL)
     navigation.hasUpdatePresenter
   )
   .get(updateManagingOfficerIndividual.get)
-  .post(...validator.managingOfficerIndividual, checkValidations, updateManagingOfficerIndividual.post);
+  .post(...validator.updateManagingOfficerIndividual, checkValidations, updateManagingOfficerIndividual.post);
 
 router.route(config.UPDATE_MANAGING_OFFICER_URL + config.ID)
   .all(
@@ -518,7 +518,7 @@ router.route(config.UPDATE_MANAGING_OFFICER_URL + config.ID)
     navigation.hasUpdatePresenter
   )
   .get(updateManagingOfficerIndividual.getById)
-  .post(...validator.managingOfficerIndividual, checkValidations, updateManagingOfficerIndividual.update);
+  .post(...validator.updateManagingOfficerIndividual, checkValidations, updateManagingOfficerIndividual.update);
 router.get(config.UPDATE_MANAGING_OFFICER_URL + config.REMOVE + config.ID, authentication, navigation.hasUpdatePresenter, updateManagingOfficerIndividual.remove);
 
 router.route(config.UPDATE_BENEFICIAL_OWNER_OTHER_URL)

--- a/src/utils/managing.officer.corporate.ts
+++ b/src/utils/managing.officer.corporate.ts
@@ -20,11 +20,13 @@ import {
   EntityNumberKey,
   HasSamePrincipalAddressKey,
   ID,
+  InputDateKeys,
   IsOnRegisterInCountryFormedInKey,
   PublicRegisterNameKey,
   RegistrationNumberKey
 } from "../model/data.types.model";
 import { PrincipalAddressKey, PrincipalAddressKeys, ServiceAddressKey, ServiceAddressKeys } from "../model/address.model";
+import { ResignedOnDateKey, ResignedOnDateKeys, StartDateKey, StartDateKeys } from "../model/date.model";
 
 export const getManagingOfficerCorporate = (req: Request, res: Response, backLinkUrl: string, templateName: string) => {
   logger.debugRequest(req, `${req.method} ${req.route.path}`);
@@ -134,6 +136,15 @@ const setOfficerData = (reqBody: any, id: string): ApplicationDataType => {
     data[PublicRegisterNameKey] = "";
     data[RegistrationNumberKey] = "";
   }
+
+  // only set start_date and resigned_on keys for Update journey
+  if (reqBody['start_date-day']){
+    data[StartDateKey] = mapFieldsToDataObject(reqBody, StartDateKeys, InputDateKeys);
+  }
+  if (reqBody['is_still_mo']){
+    data[ResignedOnDateKey] = reqBody["is_still_mo"] === '0' ? mapFieldsToDataObject(reqBody, ResignedOnDateKeys, InputDateKeys) : {};
+  }
+
   data[ID] = id;
 
   return data;

--- a/src/utils/managing.officer.corporate.ts
+++ b/src/utils/managing.officer.corporate.ts
@@ -138,10 +138,10 @@ const setOfficerData = (reqBody: any, id: string): ApplicationDataType => {
   }
 
   // only set start_date and resigned_on keys for Update journey
-  if (reqBody['start_date-day']){
+  if ('start_date-day' in reqBody){
     data[StartDateKey] = mapFieldsToDataObject(reqBody, StartDateKeys, InputDateKeys);
   }
-  if (reqBody['is_still_mo']){
+  if ('is_still_mo' in reqBody){
     data[ResignedOnDateKey] = reqBody["is_still_mo"] === '0' ? mapFieldsToDataObject(reqBody, ResignedOnDateKeys, InputDateKeys) : {};
   }
 

--- a/src/utils/managing.officer.corporate.ts
+++ b/src/utils/managing.officer.corporate.ts
@@ -4,8 +4,9 @@ import { v4 as uuidv4 } from 'uuid';
 
 import { logger } from "./logger";
 import { saveAndContinue } from "./save.and.continue";
-import { ApplicationDataType } from "../model";
+import { ApplicationData, ApplicationDataType } from "../model";
 import {
+  getApplicationData,
   getFromApplicationData,
   mapDataObjectToFields,
   mapFieldsToDataObject,
@@ -16,6 +17,7 @@ import {
 import { ManagingOfficerCorporateKey, ManagingOfficerCorporateKeys } from "../model/managing.officer.corporate.model";
 import {
   AddressKeys,
+  EntityNumberKey,
   HasSamePrincipalAddressKey,
   ID,
   IsOnRegisterInCountryFormedInKey,
@@ -27,9 +29,12 @@ import { PrincipalAddressKey, PrincipalAddressKeys, ServiceAddressKey, ServiceAd
 export const getManagingOfficerCorporate = (req: Request, res: Response, backLinkUrl: string, templateName: string) => {
   logger.debugRequest(req, `${req.method} ${req.route.path}`);
 
+  const appData: ApplicationData = getApplicationData(req.session as Session);
+
   return res.render(templateName, {
     backLinkUrl: backLinkUrl,
-    templateName: templateName
+    templateName: templateName,
+    entity_number: appData[EntityNumberKey]
   });
 };
 

--- a/src/utils/managing.officer.individual.ts
+++ b/src/utils/managing.officer.individual.ts
@@ -3,8 +3,9 @@ import { Session } from "@companieshouse/node-session-handler";
 
 import { logger } from "../utils/logger";
 import { saveAndContinue } from "../utils/save.and.continue";
-import { ApplicationDataType } from "../model";
+import { ApplicationData, ApplicationDataType } from "../model";
 import {
+  getApplicationData,
   getFromApplicationData,
   mapDataObjectToFields,
   mapFieldsToDataObject,
@@ -15,6 +16,7 @@ import {
 
 import {
   AddressKeys,
+  EntityNumberKey,
   HasFormerNames,
   HasSameResidentialAddressKey,
   ID,
@@ -28,9 +30,12 @@ import { v4 as uuidv4 } from 'uuid';
 export const getManagingOfficer = (req: Request, res: Response, backLinkUrl: string, templateName: string) => {
   logger.debugRequest(req, `${req.method} ${req.route.path}`);
 
+  const appData: ApplicationData = getApplicationData(req.session as Session);
+
   return res.render(templateName, {
     backLinkUrl: backLinkUrl,
-    templateName: templateName
+    templateName: templateName,
+    entity_number: appData[EntityNumberKey]
   });
 };
 

--- a/src/utils/managing.officer.individual.ts
+++ b/src/utils/managing.officer.individual.ts
@@ -141,10 +141,10 @@ const setOfficerData = (reqBody: any, id: string): ApplicationDataType => {
   }
 
   // only set start_date and resigned_on keys for Update journey
-  if (reqBody['start_date-day']){
+  if ('start_date-day' in reqBody){
     data[StartDateKey] = mapFieldsToDataObject(reqBody, StartDateKeys, InputDateKeys);
   }
-  if (reqBody['is_still_mo']){
+  if ('is_still_mo' in reqBody){
     data[ResignedOnDateKey] = reqBody["is_still_mo"] === '0' ? mapFieldsToDataObject(reqBody, ResignedOnDateKeys, InputDateKeys) : {};
   }
   data[ID] = id;

--- a/src/utils/managing.officer.individual.ts
+++ b/src/utils/managing.officer.individual.ts
@@ -22,7 +22,14 @@ import {
   ID,
   InputDateKeys
 } from "../model/data.types.model";
-import { DateOfBirthKey, DateOfBirthKeys } from "../model/date.model";
+import {
+  DateOfBirthKey,
+  DateOfBirthKeys,
+  ResignedOnDateKey,
+  ResignedOnDateKeys,
+  StartDateKey,
+  StartDateKeys
+} from "../model/date.model";
 import { ServiceAddressKey, ServiceAddressKeys, UsualResidentialAddressKey, UsualResidentialAddressKeys } from "../model/address.model";
 import { FormerNamesKey, ManagingOfficerKey, ManagingOfficerKeys } from "../model/managing.officer.model";
 import { v4 as uuidv4 } from 'uuid';
@@ -133,6 +140,13 @@ const setOfficerData = (reqBody: any, id: string): ApplicationDataType => {
     data[FormerNamesKey] = "";
   }
 
+  // only set start_date and resigned_on keys for Update journey
+  if (reqBody['start_date-day']){
+    data[StartDateKey] = mapFieldsToDataObject(reqBody, StartDateKeys, InputDateKeys);
+  }
+  if (reqBody['is_still_mo']){
+    data[ResignedOnDateKey] = reqBody["is_still_mo"] === '0' ? mapFieldsToDataObject(reqBody, ResignedOnDateKeys, InputDateKeys) : {};
+  }
   data[ID] = id;
 
   return data;

--- a/src/validation/custom.validation.ts
+++ b/src/validation/custom.validation.ts
@@ -233,13 +233,14 @@ export const checkMoreThanOneDateFieldIsNotMissing = (dayStr: string = "", month
 
 export const checkCeasedDateOnOrAfterStartDate = (
   ceaseDayStr: string = "", ceaseMonthStr: string = "", ceaseYearStr: string = "",
-  startDayStr: string = "", startMonthStr: string = "", startYearStr: string = ""
+  startDayStr: string = "", startMonthStr: string = "", startYearStr: string = "",
+  errorMessage: string = ""
 ): boolean => {
   const ceaseDate = DateTime.utc(Number(ceaseYearStr), Number(ceaseMonthStr), Number(ceaseDayStr));
   const startDate = DateTime.utc(Number(startYearStr), Number(startMonthStr), Number(startDayStr));
 
   if (startDate > ceaseDate) {
-    throw new Error(ErrorMessages.CEASED_DATE_BEFORE_START_DATE);
+    throw new Error(errorMessage);
   }
 
   return true;

--- a/src/validation/custom.validation.ts
+++ b/src/validation/custom.validation.ts
@@ -234,7 +234,7 @@ export const checkMoreThanOneDateFieldIsNotMissing = (dayStr: string = "", month
 export const checkCeasedDateOnOrAfterStartDate = (
   ceaseDayStr: string = "", ceaseMonthStr: string = "", ceaseYearStr: string = "",
   startDayStr: string = "", startMonthStr: string = "", startYearStr: string = "",
-  errorMessage: string = ""
+  errorMessage: string = ErrorMessages.DATE_BEFORE_START_DATE
 ): boolean => {
   const ceaseDate = DateTime.utc(Number(ceaseYearStr), Number(ceaseMonthStr), Number(ceaseDayStr));
   const startDate = DateTime.utc(Number(startYearStr), Number(startMonthStr), Number(startDayStr));

--- a/src/validation/error.messages.ts
+++ b/src/validation/error.messages.ts
@@ -147,6 +147,7 @@ export enum ErrorMessages {
   END_DAY_LENGTH_HISTORICAL_BO = "The date they stopped being a beneficial owner day must include 1 or 2 numbers",
   END_MONTH_LENGTH_HISTORICAL_BO = "The date they stopped being a beneficial owner month must include 1 or 2 numbers",
   END_YEAR_LENGTH_HISTORICAL_BO = "The date they stopped being a beneficial owner year must include 4 numbers",
+  DATE_BEFORE_START_DATE = "Date must be on or after the appointed date",
   CEASED_DATE_BEFORE_START_DATE = "Ceased date must be on or after the appointed date",
   RESIGNED_ON_BEFORE_START_DATE = "Resigned on date must be on or after the appointed date",
 

--- a/src/validation/error.messages.ts
+++ b/src/validation/error.messages.ts
@@ -148,6 +148,7 @@ export enum ErrorMessages {
   END_MONTH_LENGTH_HISTORICAL_BO = "The date they stopped being a beneficial owner month must include 1 or 2 numbers",
   END_YEAR_LENGTH_HISTORICAL_BO = "The date they stopped being a beneficial owner year must include 4 numbers",
   CEASED_DATE_BEFORE_START_DATE = "Ceased date must be on or after the appointed date",
+  RESIGNED_ON_BEFORE_START_DATE = "Resigned on date must be on or after the appointed date",
 
   // No radio selected
   SELECT_IF_ENTITY_HAS_SOLD_LAND = "Select yes if the entity has disposed of UK property or land since 28 February 2022",

--- a/src/validation/error.messages.ts
+++ b/src/validation/error.messages.ts
@@ -178,6 +178,7 @@ export enum ErrorMessages {
   SELECT_IF_REGISTRABLE_BENEFICIAL_OWNER = "Select if anyone has become or ceased to be a registrable beneficial owner during the update period",
   UPDATE_SELECT_IF_CONTINUE_SAVED_FILING = "Select yes if you want to continue with a saved filing",
   SELECT_IF_STILL_BENEFICIAL_OWNER = "Select yes if they are still a registrable beneficial owner",
+  SELECT_IF_STILL_MANAGING_OFFICER = "Select yes if they are still a managing officer",
   // MAX Lengths
   MAX_FIRST_NAME_LENGTH = "First name must be 50 characters or less",
   MAX_FIRST_NAME_LENGTH_INDIVIDUAL_BO = MAX_FIRST_NAME_LENGTH,

--- a/src/validation/fields/date.validation.ts
+++ b/src/validation/fields/date.validation.ts
@@ -35,45 +35,29 @@ export const start_date_validations = [
     .custom((value, { req }) => checkDate(req.body["start_date-day"], req.body["start_date-month"], req.body["start_date-year"])),
 ];
 
-export const ceased_date_validations = [
-  body("ceased_date-day")
-    .if(body('is_still_bo').equals('0'))
-    .custom((value, { req }) => checkDateFieldDay(req.body["ceased_date-day"], req.body["ceased_date-month"], req.body["ceased_date-year"])),
-  body("ceased_date-month")
-    .if(body('is_still_bo').equals('0'))
-    .custom((value, { req }) => checkDateFieldMonth(ErrorMessages.MONTH, ErrorMessages.MONTH_AND_YEAR, req.body["ceased_date-day"], req.body["ceased_date-month"], req.body["ceased_date-year"])),
-  body("ceased_date-year")
-    .if(body('is_still_bo').equals('0'))
-    .custom((value, { req }) => checkDateFieldYear(ErrorMessages.YEAR, ErrorMessages.YEAR_LENGTH, req.body["ceased_date-day"], req.body["ceased_date-month"], req.body["ceased_date-year"])),
-  body("ceased_date")
-    .if(body('is_still_bo').equals('0'))
-    .custom((value, { req }) => checkDate(req.body["ceased_date-day"], req.body["ceased_date-month"], req.body["ceased_date-year"]))
+const is_still_active_validations = (date_field_id: string, radio_button_id: string, error_message: string) => [
+  body(date_field_id + "-day")
+    .if(body(radio_button_id).equals('0'))
+    .custom((value, { req }) => checkDateFieldDay(req.body[date_field_id + "-day"], req.body[date_field_id + "-month"], req.body[date_field_id + "-year"])),
+  body(date_field_id + "-month")
+    .if(body(radio_button_id).equals('0'))
+    .custom((value, { req }) => checkDateFieldMonth(ErrorMessages.MONTH, ErrorMessages.MONTH_AND_YEAR, req.body[date_field_id + "-day"], req.body[date_field_id + "-month"], req.body[date_field_id + "-year"])),
+  body(date_field_id + "-year")
+    .if(body(radio_button_id).equals('0'))
+    .custom((value, { req }) => checkDateFieldYear(ErrorMessages.YEAR, ErrorMessages.YEAR_LENGTH, req.body[date_field_id + "-day"], req.body[date_field_id + "-month"], req.body[date_field_id + "-year"])),
+  body(date_field_id)
+    .if(body(radio_button_id).equals('0'))
+    .custom((value, { req }) => checkDate(req.body[date_field_id + "-day"], req.body[date_field_id + "-month"], req.body[date_field_id + "-year"]))
     .custom((value, { req }) => checkCeasedDateOnOrAfterStartDate(
-      req.body["ceased_date-day"], req.body["ceased_date-month"], req.body["ceased_date-year"],
+      req.body[date_field_id + "-day"], req.body[date_field_id + "-month"], req.body[date_field_id + "-year"],
       req.body["start_date-day"], req.body["start_date-month"], req.body["start_date-year"],
-      ErrorMessages.CEASED_DATE_BEFORE_START_DATE
+      error_message
     )),
 ];
 
-export const resigned_on_validations = [
-  body("resigned_on-day")
-    .if(body('is_still_mo').equals('0'))
-    .custom((value, { req }) => checkDateFieldDay(req.body["resigned_on-day"], req.body["resigned_on-month"], req.body["resigned_on-year"])),
-  body("resigned_on-month")
-    .if(body('is_still_mo').equals('0'))
-    .custom((value, { req }) => checkDateFieldMonth(ErrorMessages.MONTH, ErrorMessages.MONTH_AND_YEAR, req.body["resigned_on-day"], req.body["resigned_on-month"], req.body["resigned_on-year"])),
-  body("resigned_on-year")
-    .if(body('is_still_mo').equals('0'))
-    .custom((value, { req }) => checkDateFieldYear(ErrorMessages.YEAR, ErrorMessages.YEAR_LENGTH, req.body["resigned_on-day"], req.body["resigned_on-month"], req.body["resigned_on-year"])),
-  body("resigned_on")
-    .if(body('is_still_mo').equals('0'))
-    .custom((value, { req }) => checkDate(req.body["resigned_on-day"], req.body["resigned_on-month"], req.body["resigned_on-year"]))
-    .custom((value, { req }) => checkCeasedDateOnOrAfterStartDate(
-      req.body["resigned_on-day"], req.body["resigned_on-month"], req.body["resigned_on-year"],
-      req.body["start_date-day"], req.body["start_date-month"], req.body["start_date-year"],
-      ErrorMessages.RESIGNED_ON_BEFORE_START_DATE
-    )),
-];
+export const ceased_date_validations = is_still_active_validations("ceased_date", "is_still_bo", ErrorMessages.CEASED_DATE_BEFORE_START_DATE);
+
+export const resigned_on_validations = is_still_active_validations("resigned_on", "is_still_mo", ErrorMessages.RESIGNED_ON_BEFORE_START_DATE);
 
 // to prevent more than 1 error reported on the date fields we check if the year is valid before doing some checks.
 // This means that the year check is checked before some others

--- a/src/validation/fields/date.validation.ts
+++ b/src/validation/fields/date.validation.ts
@@ -50,7 +50,28 @@ export const ceased_date_validations = [
     .custom((value, { req }) => checkDate(req.body["ceased_date-day"], req.body["ceased_date-month"], req.body["ceased_date-year"]))
     .custom((value, { req }) => checkCeasedDateOnOrAfterStartDate(
       req.body["ceased_date-day"], req.body["ceased_date-month"], req.body["ceased_date-year"],
-      req.body["start_date-day"], req.body["start_date-month"], req.body["start_date-year"]
+      req.body["start_date-day"], req.body["start_date-month"], req.body["start_date-year"],
+      ErrorMessages.CEASED_DATE_BEFORE_START_DATE
+    )),
+];
+
+export const resigned_on_validations = [
+  body("resigned_on-day")
+    .if(body('is_still_mo').equals('0'))
+    .custom((value, { req }) => checkDateFieldDay(req.body["resigned_on-day"], req.body["resigned_on-month"], req.body["resigned_on-year"])),
+  body("resigned_on-month")
+    .if(body('is_still_mo').equals('0'))
+    .custom((value, { req }) => checkDateFieldMonth(ErrorMessages.MONTH, ErrorMessages.MONTH_AND_YEAR, req.body["resigned_on-day"], req.body["resigned_on-month"], req.body["resigned_on-year"])),
+  body("resigned_on-year")
+    .if(body('is_still_mo').equals('0'))
+    .custom((value, { req }) => checkDateFieldYear(ErrorMessages.YEAR, ErrorMessages.YEAR_LENGTH, req.body["resigned_on-day"], req.body["resigned_on-month"], req.body["resigned_on-year"])),
+  body("resigned_on")
+    .if(body('is_still_mo').equals('0'))
+    .custom((value, { req }) => checkDate(req.body["resigned_on-day"], req.body["resigned_on-month"], req.body["resigned_on-year"]))
+    .custom((value, { req }) => checkCeasedDateOnOrAfterStartDate(
+      req.body["resigned_on-day"], req.body["resigned_on-month"], req.body["resigned_on-year"],
+      req.body["start_date-day"], req.body["start_date-month"], req.body["start_date-year"],
+      ErrorMessages.RESIGNED_ON_BEFORE_START_DATE
     )),
 ];
 

--- a/src/validation/index.ts
+++ b/src/validation/index.ts
@@ -7,7 +7,7 @@ import { confirmToRemove } from "./confirm.to.remove.validation";
 import { beneficialOwnersType, updateBeneficialOwnerAndManagingOfficerType } from "./beneficial.owner.type.validation";
 import { soldLandFilter } from "./sold.land.filter.validation";
 import { entity } from "./entity.validation";
-import { managingOfficerCorporate } from "./managing.officer.corporate.validation";
+import { managingOfficerCorporate, updateManagingOfficerCorporate } from "./managing.officer.corporate.validation";
 import { managingOfficerIndividual, updateManagingOfficerIndividual } from "./managing.officer.validation";
 import { presenter } from "./presenter.validation";
 import { overseasEntityQuery } from "./overseas.entity.query.validation";
@@ -44,6 +44,7 @@ export const validator = {
   managingOfficerIndividual,
   updateManagingOfficerIndividual,
   managingOfficerCorporate,
+  updateManagingOfficerCorporate,
   beneficialOwnerIndividual,
   beneficialOwnerOther,
   beneficialOwnerGov,

--- a/src/validation/index.ts
+++ b/src/validation/index.ts
@@ -8,7 +8,7 @@ import { beneficialOwnersType, updateBeneficialOwnerAndManagingOfficerType } fro
 import { soldLandFilter } from "./sold.land.filter.validation";
 import { entity } from "./entity.validation";
 import { managingOfficerCorporate } from "./managing.officer.corporate.validation";
-import { managingOfficerIndividual } from "./managing.officer.validation";
+import { managingOfficerIndividual, updateManagingOfficerIndividual } from "./managing.officer.validation";
 import { presenter } from "./presenter.validation";
 import { overseasEntityQuery } from "./overseas.entity.query.validation";
 import { secureRegisterFilter } from "./secure.register.filter.validation";
@@ -42,6 +42,7 @@ export const validator = {
   beneficialOwnersType,
   beneficialOwnersTypeSubmission,
   managingOfficerIndividual,
+  updateManagingOfficerIndividual,
   managingOfficerCorporate,
   beneficialOwnerIndividual,
   beneficialOwnerOther,

--- a/src/validation/managing.officer.corporate.validation.ts
+++ b/src/validation/managing.officer.corporate.validation.ts
@@ -5,6 +5,7 @@ import { principal_address_validations, principal_service_address_validations } 
 import { public_register_validations } from "./fields/public-register.validation";
 import { VALID_CHARACTERS, VALID_CHARACTERS_FOR_TEXT_BOX } from "./regex/regex.validation";
 import { contact_email_validations } from "./fields/email.validation";
+import { resigned_on_validations } from "./fields/date.validation";
 
 export const managingOfficerCorporate = [
   body("name").not()
@@ -37,6 +38,8 @@ export const managingOfficerCorporate = [
     .not().isEmpty({ ignore_whitespace: true }).withMessage(ErrorMessages.ROLE_AND_RESPONSIBILITIES_CORPORATE)
     .isLength({ max: 256 }).withMessage(ErrorMessages.MAX_ROLE_LENGTH)
     .matches(VALID_CHARACTERS_FOR_TEXT_BOX).withMessage(ErrorMessages.ROLES_AND_RESPONSIBILITIES_INVALID_CHARACTERS),
+
+  ...resigned_on_validations,
 
   body("contact_full_name")
     .not().isEmpty({ ignore_whitespace: true }).withMessage(ErrorMessages.FULL_NAME)

--- a/src/validation/managing.officer.corporate.validation.ts
+++ b/src/validation/managing.officer.corporate.validation.ts
@@ -5,7 +5,16 @@ import { principal_address_validations, principal_service_address_validations } 
 import { public_register_validations } from "./fields/public-register.validation";
 import { VALID_CHARACTERS, VALID_CHARACTERS_FOR_TEXT_BOX } from "./regex/regex.validation";
 import { contact_email_validations } from "./fields/email.validation";
-import { resigned_on_validations } from "./fields/date.validation";
+import { resigned_on_validations, start_date_validations } from "./fields/date.validation";
+
+const contact_name_and_email_validations = [
+  body("contact_full_name")
+    .not().isEmpty({ ignore_whitespace: true }).withMessage(ErrorMessages.FULL_NAME)
+    .isLength({ max: 160 }).withMessage(ErrorMessages.MAX_FULL_NAME_LENGTH)
+    .matches(VALID_CHARACTERS).withMessage(ErrorMessages.CONTACT_NAME_INVALID_CHARACTERS),
+
+  ...contact_email_validations
+];
 
 export const managingOfficerCorporate = [
   body("name").not()
@@ -39,12 +48,13 @@ export const managingOfficerCorporate = [
     .isLength({ max: 256 }).withMessage(ErrorMessages.MAX_ROLE_LENGTH)
     .matches(VALID_CHARACTERS_FOR_TEXT_BOX).withMessage(ErrorMessages.ROLES_AND_RESPONSIBILITIES_INVALID_CHARACTERS),
 
+  ...contact_name_and_email_validations
+];
+
+export const updateManagingOfficerCorporate = [
+  ...managingOfficerCorporate,
+  ...start_date_validations,
+  body("is_still_mo").not().isEmpty().withMessage(ErrorMessages.SELECT_IF_STILL_MANAGING_OFFICER),
   ...resigned_on_validations,
-
-  body("contact_full_name")
-    .not().isEmpty({ ignore_whitespace: true }).withMessage(ErrorMessages.FULL_NAME)
-    .isLength({ max: 160 }).withMessage(ErrorMessages.MAX_FULL_NAME_LENGTH)
-    .matches(VALID_CHARACTERS).withMessage(ErrorMessages.CONTACT_NAME_INVALID_CHARACTERS),
-
-  ...contact_email_validations
+  ...contact_name_and_email_validations
 ];

--- a/src/validation/managing.officer.validation.ts
+++ b/src/validation/managing.officer.validation.ts
@@ -9,7 +9,7 @@ import { ErrorMessages } from "./error.messages";
 import { usual_residential_service_address_validations, usual_residential_address_validations } from "./fields/address.validation";
 import { second_nationality_validations } from "./fields/second-nationality.validation";
 import { VALID_CHARACTERS, VALID_CHARACTERS_FOR_TEXT_BOX } from "./regex/regex.validation";
-import { date_of_birth_validations, resigned_on_validations } from "./fields/date.validation";
+import { date_of_birth_validations, resigned_on_validations, start_date_validations } from "./fields/date.validation";
 
 export const managingOfficerIndividual = [
   body("first_name").not().isEmpty({ ignore_whitespace: true })
@@ -47,6 +47,11 @@ export const managingOfficerIndividual = [
     .not().isEmpty({ ignore_whitespace: true }).withMessage(ErrorMessages.ROLE_AND_RESPONSIBILITIES_INDIVIDUAL)
     .isLength({ max: 256 }).withMessage(ErrorMessages.MAX_ROLE_LENGTH)
     .matches(VALID_CHARACTERS_FOR_TEXT_BOX).withMessage(ErrorMessages.ROLES_AND_RESPONSIBILITIES_INVALID_CHARACTERS),
+];
 
+export const updateManagingOfficerIndividual = [
+  ...managingOfficerIndividual,
+  ...start_date_validations,
+  body("is_still_mo").not().isEmpty().withMessage(ErrorMessages.SELECT_IF_STILL_MANAGING_OFFICER),
   ...resigned_on_validations
 ];

--- a/src/validation/managing.officer.validation.ts
+++ b/src/validation/managing.officer.validation.ts
@@ -9,7 +9,7 @@ import { ErrorMessages } from "./error.messages";
 import { usual_residential_service_address_validations, usual_residential_address_validations } from "./fields/address.validation";
 import { second_nationality_validations } from "./fields/second-nationality.validation";
 import { VALID_CHARACTERS, VALID_CHARACTERS_FOR_TEXT_BOX } from "./regex/regex.validation";
-import { date_of_birth_validations } from "./fields/date.validation";
+import { date_of_birth_validations, resigned_on_validations } from "./fields/date.validation";
 
 export const managingOfficerIndividual = [
   body("first_name").not().isEmpty({ ignore_whitespace: true })
@@ -46,5 +46,7 @@ export const managingOfficerIndividual = [
   body("role_and_responsibilities")
     .not().isEmpty({ ignore_whitespace: true }).withMessage(ErrorMessages.ROLE_AND_RESPONSIBILITIES_INDIVIDUAL)
     .isLength({ max: 256 }).withMessage(ErrorMessages.MAX_ROLE_LENGTH)
-    .matches(VALID_CHARACTERS_FOR_TEXT_BOX).withMessage(ErrorMessages.ROLES_AND_RESPONSIBILITIES_INVALID_CHARACTERS)
+    .matches(VALID_CHARACTERS_FOR_TEXT_BOX).withMessage(ErrorMessages.ROLES_AND_RESPONSIBILITIES_INVALID_CHARACTERS),
+
+  ...resigned_on_validations
 ];

--- a/test/__mocks__/fields/date.mock.ts
+++ b/test/__mocks__/fields/date.mock.ts
@@ -20,7 +20,13 @@ export const DATE_OF_BIRTH = {
     "filing_date-day": "1",
     "filing_date-month": "1",
     "filing_date-year": "2022",
-  }, DATE = { day: "1", month: "1", year: "2000" }, EMPTY_DATE = { day: "", month: "", year: "" },
+  }, RESIGNED_ON_DATE = {
+    "resigned_on-day": "1",
+    "resigned_on-month": "1",
+    "resigned_on-year": "2023",
+  },
+
+  DATE = { day: "1", month: "1", year: "2000" }, EMPTY_DATE = { day: "", month: "", year: "" },
   getTwoMonthOldDate = (): DateTime => {
     const now = DateTime.now();
     return DateTime.utc(now.year, now.month, now.day).minus({ months: 2 });

--- a/test/__mocks__/fields/date.mock.ts
+++ b/test/__mocks__/fields/date.mock.ts
@@ -25,8 +25,8 @@ export const DATE_OF_BIRTH = {
     "resigned_on-month": "1",
     "resigned_on-year": "2023",
   },
-
-  DATE = { day: "1", month: "1", year: "2000" }, EMPTY_DATE = { day: "", month: "", year: "" },
+  DATE = { day: "1", month: "1", year: "2000" },
+  EMPTY_DATE = { day: "", month: "", year: "" },
   getTwoMonthOldDate = (): DateTime => {
     const now = DateTime.now();
     return DateTime.utc(now.year, now.month, now.day).minus({ months: 2 });

--- a/test/__mocks__/session.mock.ts
+++ b/test/__mocks__/session.mock.ts
@@ -899,20 +899,13 @@ export const MANAGING_OFFICER_CORPORATE_OBJECT_MOCK: managingOfficerCorporateTyp
 };
 
 export const UPDATE_MANAGING_OFFICER_CORPORATE_OBJECT_MOCK: managingOfficerCorporateType.ManagingOfficerCorporate = {
-  id: MO_CORP_ID,
-  ch_reference: "testchreference",
-  name: "Joe Bloggs Ltd",
-  principal_address: ADDRESS,
-  service_address: ADDRESS,
-  is_service_address_same_as_principal_address: yesNoResponse.Yes,
-  legal_form: "legalForm",
-  law_governed: "LegAuth",
-  is_on_register_in_country_formed_in: yesNoResponse.Yes,
-  public_register_name: "register",
-  registration_number: "123456789",
-  role_and_responsibilities: "role and responsibilities text",
-  contact_full_name: "Joe Bloggs",
-  contact_email: "jbloggs@bloggs.co.ru"
+  ...MANAGING_OFFICER_CORPORATE_OBJECT_MOCK,
+  start_date: { day: "1", month: "1", year: "2022" }
+};
+
+export const UPDATE_MANAGING_OFFICER_CORPORATE_OBJECT_MOCK_WITH_CH_REF: managingOfficerCorporateType.ManagingOfficerCorporate = {
+  ...MANAGING_OFFICER_CORPORATE_OBJECT_MOCK,
+  ch_reference: "testchreference"
 };
 
 export const REQ_BODY_MANAGING_OFFICER_CORPORATE_OBJECT_EMPTY = {
@@ -945,6 +938,19 @@ export const REQ_BODY_MANAGING_OFFICER_CORPORATE_MOCK_WITH_ADDRESS = {
   ...START_DATE
 };
 
+export const REQ_BODY_UPDATE_MANAGING_OFFICER_CORPORATE_MOCK_ACTIVE = {
+  ...REQ_BODY_MANAGING_OFFICER_CORPORATE_MOCK_WITH_ADDRESS,
+  ...START_DATE,
+  is_still_mo: '1'
+};
+
+export const REQ_BODY_UPDATE_MANAGING_OFFICER_CORPORATE_MOCK_INACTIVE = {
+  ...REQ_BODY_MANAGING_OFFICER_CORPORATE_MOCK_WITH_ADDRESS,
+  ...START_DATE,
+  is_still_mo: '0',
+  ...RESIGNED_ON_DATE
+};
+
 export const MANAGING_OFFICER_CORPORATE_MOCK_WITH_EMAIL_CONTAINING_LEADING_AND_TRAILING_SPACES = {
   name: "Joe Bloggs Ltd",
   is_service_address_same_as_principal_address: "0",
@@ -959,6 +965,11 @@ export const MANAGING_OFFICER_CORPORATE_MOCK_WITH_EMAIL_CONTAINING_LEADING_AND_T
   ...PRINCIPAL_ADDRESS_MOCK,
   ...SERVICE_ADDRESS_MOCK,
   ...START_DATE
+};
+
+export const UPDATE_MANAGING_OFFICER_CORPORATE_MOCK_WITH_EMAIL_CONTAINING_LEADING_AND_TRAILING_SPACES = {
+  ...MANAGING_OFFICER_CORPORATE_MOCK_WITH_EMAIL_CONTAINING_LEADING_AND_TRAILING_SPACES,
+  is_still_mo: '1'
 };
 
 export const MANAGING_OFFICER_INDIVIDUAL_OBJECT_MOCK_WITH_SERVICE_ADDRESS_YES: managingOfficerType.ManagingOfficerIndividual = {
@@ -1412,7 +1423,7 @@ export const APPLICATION_DATA_CH_REF_UPDATE_MOCK: ApplicationData = {
   [beneficialOwnerOtherType.BeneficialOwnerOtherKey]: [ BENEFICIAL_OWNER_OTHER_OBJECT_MOCK_WITH_CH_REF ],
   [beneficialOwnerGovType.BeneficialOwnerGovKey]: [ BENEFICIAL_OWNER_GOV_OBJECT_MOCK_WITH_CH_REF ],
   [managingOfficerType.ManagingOfficerKey]: [ UPDATE_MANAGING_OFFICER_OBJECT_MOCK_WITH_CH_REF ],
-  [managingOfficerCorporateType.ManagingOfficerCorporateKey]: [ UPDATE_MANAGING_OFFICER_CORPORATE_OBJECT_MOCK ],
+  [managingOfficerCorporateType.ManagingOfficerCorporateKey]: [ UPDATE_MANAGING_OFFICER_CORPORATE_OBJECT_MOCK_WITH_CH_REF ],
   [WhoIsRegisteringKey]: WhoIsRegisteringType.AGENT,
   [PaymentKey]: PAYMENT_OBJECT_MOCK,
   [OverseasEntityKey]: OVERSEAS_ENTITY_ID,

--- a/test/__mocks__/session.mock.ts
+++ b/test/__mocks__/session.mock.ts
@@ -51,7 +51,7 @@ import { TrustKey, Trust } from "../../src/model/trust.model";
 import { WhoIsRegisteringKey, WhoIsRegisteringType } from "../../src/model/who.is.making.filing.model";
 import { DUE_DILIGENCE_OBJECT_MOCK } from "./due.diligence.mock";
 import { ADDRESS } from "./fields/address.mock";
-import { DATE_OF_BIRTH, EMPTY_DATE, START_DATE } from "./fields/date.mock";
+import { DATE_OF_BIRTH, EMPTY_DATE, RESIGNED_ON_DATE, START_DATE } from "./fields/date.mock";
 import { ANY_MESSAGE_ERROR } from "./text.mock";
 
 export const BO_GOV_ID = "10722c3c-9301-4f46-ad8b-b30f5dcd76a0";
@@ -818,19 +818,13 @@ export const MANAGING_OFFICER_OBJECT_MOCK: managingOfficerType.ManagingOfficerIn
 };
 
 export const UPDATE_MANAGING_OFFICER_OBJECT_MOCK: managingOfficerType.ManagingOfficerIndividual = {
-  id: MO_IND_ID,
-  ch_reference: "testchreference",
-  first_name: "Joe",
-  last_name: "Bloggs",
-  has_former_names: yesNoResponse.Yes,
-  former_names: "Some name",
-  date_of_birth: { day: "21", month: "3", year: "1947" },
-  nationality: "Malawian",
-  usual_residential_address: ADDRESS,
-  service_address: ADDRESS,
-  is_service_address_same_as_usual_residential_address: yesNoResponse.Yes,
-  occupation: "Some Occupation",
-  role_and_responsibilities: "Some role and responsibilities"
+  ...MANAGING_OFFICER_OBJECT_MOCK,
+  start_date: { day: "1", month: "1", year: "2022" }
+};
+
+export const UPDATE_MANAGING_OFFICER_OBJECT_MOCK_WITH_CH_REF: managingOfficerType.ManagingOfficerIndividual = {
+  ...MANAGING_OFFICER_OBJECT_MOCK,
+  ch_reference: "testchreference"
 };
 
 export const REQ_BODY_MANAGING_OFFICER_OBJECT_EMPTY = {
@@ -859,6 +853,19 @@ export const REQ_BODY_MANAGING_OFFICER_MOCK_WITH_ADDRESS = {
   ...RESIDENTIAL_ADDRESS_MOCK,
   ...SERVICE_ADDRESS_MOCK,
   ...DATE_OF_BIRTH
+};
+
+export const REQ_BODY_UPDATE_MANAGING_OFFICER_ACTIVE = {
+  ...REQ_BODY_MANAGING_OFFICER_MOCK_WITH_ADDRESS,
+  ...START_DATE,
+  is_still_mo: '1'
+};
+
+export const REQ_BODY_UPDATE_MANAGING_OFFICER_INACTIVE = {
+  ...REQ_BODY_MANAGING_OFFICER_MOCK_WITH_ADDRESS,
+  ...START_DATE,
+  is_still_mo: '0',
+  ...RESIGNED_ON_DATE
 };
 
 export const REQ_BODY_MANAGING_OFFICER_FOR_DATE_VALIDATION = {
@@ -1404,7 +1411,7 @@ export const APPLICATION_DATA_CH_REF_UPDATE_MOCK: ApplicationData = {
   [beneficialOwnerIndividualType.BeneficialOwnerIndividualKey]: [ BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK_WITH_CH_REF ],
   [beneficialOwnerOtherType.BeneficialOwnerOtherKey]: [ BENEFICIAL_OWNER_OTHER_OBJECT_MOCK_WITH_CH_REF ],
   [beneficialOwnerGovType.BeneficialOwnerGovKey]: [ BENEFICIAL_OWNER_GOV_OBJECT_MOCK_WITH_CH_REF ],
-  [managingOfficerType.ManagingOfficerKey]: [ UPDATE_MANAGING_OFFICER_OBJECT_MOCK ],
+  [managingOfficerType.ManagingOfficerKey]: [ UPDATE_MANAGING_OFFICER_OBJECT_MOCK_WITH_CH_REF ],
   [managingOfficerCorporateType.ManagingOfficerCorporateKey]: [ UPDATE_MANAGING_OFFICER_CORPORATE_OBJECT_MOCK ],
   [WhoIsRegisteringKey]: WhoIsRegisteringType.AGENT,
   [PaymentKey]: PAYMENT_OBJECT_MOCK,

--- a/test/controllers/managing.officer.controller.spec.ts
+++ b/test/controllers/managing.officer.controller.spec.ts
@@ -19,6 +19,7 @@ import {
   REMOVE
 } from "../../src/config";
 import {
+  getApplicationData,
   getFromApplicationData,
   mapFieldsToDataObject,
   prepareData,
@@ -26,6 +27,7 @@ import {
   setApplicationData
 } from '../../src/utils/application.data';
 import {
+  APPLICATION_DATA_MOCK,
   MANAGING_OFFICER_INDIVIDUAL_OBJECT_MOCK_WITH_FORMER_NAMES_NO,
   MANAGING_OFFICER_INDIVIDUAL_OBJECT_MOCK_WITH_FORMER_NAMES_YES,
   MANAGING_OFFICER_INDIVIDUAL_OBJECT_MOCK_WITH_SERVICE_ADDRESS_NO,
@@ -77,6 +79,7 @@ const mockAuthenticationMiddleware = authentication as jest.Mock;
 mockAuthenticationMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => next() );
 
 const mockLoggerDebugRequest = logger.debugRequest as jest.Mock;
+const mockGetApplicationData = getApplicationData as jest.Mock;
 const mockGetFromApplicationData = getFromApplicationData as jest.Mock;
 const mockSaveAndContinue = saveAndContinue as jest.Mock;
 const mockSetApplicationData = setApplicationData as jest.Mock;
@@ -98,6 +101,7 @@ describe("MANAGING_OFFICER controller", () => {
   describe("GET tests", () => {
 
     test(`renders the ${MANAGING_OFFICER_PAGE} page`, async () => {
+      mockGetApplicationData.mockReturnValueOnce(APPLICATION_DATA_MOCK);
       const resp = await request(app).get(MANAGING_OFFICER_URL);
 
       expect(resp.status).toEqual(200);

--- a/test/controllers/managing.officer.corporate.controller.spec.ts
+++ b/test/controllers/managing.officer.corporate.controller.spec.ts
@@ -28,7 +28,8 @@ import {
   MO_CORP_ID_URL,
   REQ_BODY_MANAGING_OFFICER_CORPORATE_MOCK_WITH_ADDRESS,
   REQ_BODY_MANAGING_OFFICER_CORPORATE_OBJECT_EMPTY,
-  RR_CARRIAGE_RETURN
+  RR_CARRIAGE_RETURN,
+  APPLICATION_DATA_MOCK
 } from "../__mocks__/session.mock";
 import { authentication } from "../../src/middleware/authentication.middleware";
 import {
@@ -50,6 +51,7 @@ import {
   SHOW_INFORMATION_ON_PUBLIC_REGISTER
 } from "../__mocks__/text.mock";
 import {
+  getApplicationData,
   getFromApplicationData,
   mapFieldsToDataObject,
   prepareData,
@@ -75,6 +77,7 @@ mockHasBeneficialOwnersStatementMiddleware.mockImplementation((req: Request, res
 const mockAuthenticationMiddleware = authentication as jest.Mock;
 mockAuthenticationMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => next());
 
+const mockGetApplicationData = getApplicationData as jest.Mock;
 const mockGetFromApplicationData = getFromApplicationData as jest.Mock;
 const mockSetApplicationData = setApplicationData as jest.Mock;
 const mockPrepareData = prepareData as jest.Mock;
@@ -97,6 +100,7 @@ describe("MANAGING_OFFICER CORPORATE controller", () => {
   describe("GET tests", () => {
 
     test(`renders the ${MANAGING_OFFICER_CORPORATE_PAGE} page`, async () => {
+      mockGetApplicationData.mockReturnValueOnce(APPLICATION_DATA_MOCK);
       const resp = await request(app).get(MANAGING_OFFICER_CORPORATE_URL);
 
       expect(resp.status).toEqual(200);
@@ -109,6 +113,7 @@ describe("MANAGING_OFFICER CORPORATE controller", () => {
     });
 
     test(`renders the ${MANAGING_OFFICER_CORPORATE_PAGE} page without public register jurisdiction field`, async () => {
+      mockGetApplicationData.mockReturnValueOnce(APPLICATION_DATA_MOCK);
       const resp = await request(app).get(MANAGING_OFFICER_CORPORATE_URL);
 
       expect(resp.status).toEqual(200);

--- a/test/controllers/update/update.managing.officer.controller.spec.ts
+++ b/test/controllers/update/update.managing.officer.controller.spec.ts
@@ -44,7 +44,8 @@ import {
   MO_IND_ID,
   MO_IND_ID_URL,
   APPLICATION_DATA_CH_REF_UPDATE_MOCK,
-  APPLICATION_DATA_MOCK
+  APPLICATION_DATA_MOCK,
+  REQ_BODY_UPDATE_MANAGING_OFFICER_INACTIVE
 } from "../../__mocks__/session.mock";
 import {
   ALL_THE_OTHER_INFORMATION_ON_PUBLIC_REGISTER,
@@ -142,19 +143,40 @@ describe("UPDATE MANAGING OFFICER controller", () => {
       expect(mockSaveAndContinue).toHaveBeenCalledTimes(1);
     });
 
-    test(`sets session data and renders the ${UPDATE_BENEFICIAL_OWNER_TYPE_PAGE} page after all mandatory fields for ${UPDATE_MANAGING_OFFICER_PAGE} have been populated`, async () => {
+    test(`sets session data and renders the ${UPDATE_BENEFICIAL_OWNER_TYPE_PAGE} page for valid active MO`, async () => {
       mockPrepareData.mockImplementationOnce( () => MANAGING_OFFICER_OBJECT_MOCK );
 
       const resp = await request(app)
         .post(UPDATE_MANAGING_OFFICER_URL)
         .send(REQ_BODY_UPDATE_MANAGING_OFFICER_ACTIVE);
 
-      const beneficialOwnerIndividual = mockSetApplicationData.mock.calls[0][1];
+      const managingOfficer = mockSetApplicationData.mock.calls[0][1];
 
-      expect(beneficialOwnerIndividual).toEqual(MANAGING_OFFICER_OBJECT_MOCK);
-      expect(beneficialOwnerIndividual.first_name).toEqual("Joe");
-      expect(beneficialOwnerIndividual.nationality).toEqual("Malawian");
-      expect(beneficialOwnerIndividual.occupation).toEqual("Some Occupation");
+      expect(managingOfficer).toEqual(MANAGING_OFFICER_OBJECT_MOCK);
+      expect(managingOfficer.first_name).toEqual("Joe");
+      expect(managingOfficer.nationality).toEqual("Malawian");
+      expect(managingOfficer.occupation).toEqual("Some Occupation");
+      expect(mockSetApplicationData.mock.calls[0][2]).toEqual(managingOfficerType.ManagingOfficerKey);
+      expect(resp.status).toEqual(302);
+      expect(resp.header.location).toEqual(UPDATE_BENEFICIAL_OWNER_TYPE_URL);
+      expect(mockSaveAndContinue).toHaveBeenCalledTimes(1);
+    });
+
+    test(`sets session data and renders the ${UPDATE_BENEFICIAL_OWNER_TYPE_PAGE} page for valid inactive MO`, async () => {
+      mockPrepareData.mockImplementationOnce( () => MANAGING_OFFICER_OBJECT_MOCK );
+
+      const resp = await request(app)
+        .post(UPDATE_MANAGING_OFFICER_URL)
+        .send(REQ_BODY_UPDATE_MANAGING_OFFICER_INACTIVE);
+
+      const managingOfficer = mockSetApplicationData.mock.calls[0][1];
+
+      expect(managingOfficer).toEqual(MANAGING_OFFICER_OBJECT_MOCK);
+      expect(managingOfficer.first_name).toEqual("Joe");
+      expect(managingOfficer.nationality).toEqual("Malawian");
+      expect(managingOfficer.occupation).toEqual("Some Occupation");
+      expect(managingOfficer.start_date).toEqual(DUMMY_DATA_OBJECT);
+      expect(managingOfficer.resigned_on).toEqual(DUMMY_DATA_OBJECT);
       expect(mockSetApplicationData.mock.calls[0][2]).toEqual(managingOfficerType.ManagingOfficerKey);
       expect(resp.status).toEqual(302);
       expect(resp.header.location).toEqual(UPDATE_BENEFICIAL_OWNER_TYPE_URL);

--- a/test/controllers/update/update.managing.officer.controller.spec.ts
+++ b/test/controllers/update/update.managing.officer.controller.spec.ts
@@ -38,7 +38,7 @@ import {
   MANAGING_OFFICER_INDIVIDUAL_OBJECT_MOCK_WITH_SERVICE_ADDRESS_YES,
   MANAGING_OFFICER_OBJECT_MOCK,
   REQ_BODY_MANAGING_OFFICER_FOR_DATE_VALIDATION,
-  REQ_BODY_MANAGING_OFFICER_MOCK_WITH_ADDRESS,
+  REQ_BODY_UPDATE_MANAGING_OFFICER_ACTIVE,
   REQ_BODY_MANAGING_OFFICER_OBJECT_EMPTY,
   RR_CARRIAGE_RETURN,
   MO_IND_ID,
@@ -135,7 +135,7 @@ describe("UPDATE MANAGING OFFICER controller", () => {
 
       const resp = await request(app)
         .post(UPDATE_MANAGING_OFFICER_URL)
-        .send(REQ_BODY_MANAGING_OFFICER_MOCK_WITH_ADDRESS);
+        .send(REQ_BODY_UPDATE_MANAGING_OFFICER_ACTIVE);
 
       expect(resp.status).toEqual(302);
       expect(resp.header.location).toEqual(UPDATE_BENEFICIAL_OWNER_TYPE_URL);
@@ -147,7 +147,7 @@ describe("UPDATE MANAGING OFFICER controller", () => {
 
       const resp = await request(app)
         .post(UPDATE_MANAGING_OFFICER_URL)
-        .send(REQ_BODY_MANAGING_OFFICER_MOCK_WITH_ADDRESS);
+        .send(REQ_BODY_UPDATE_MANAGING_OFFICER_ACTIVE);
 
       const beneficialOwnerIndividual = mockSetApplicationData.mock.calls[0][1];
 
@@ -166,7 +166,7 @@ describe("UPDATE MANAGING OFFICER controller", () => {
 
       const resp = await request(app)
         .post(UPDATE_MANAGING_OFFICER_URL)
-        .send(REQ_BODY_MANAGING_OFFICER_MOCK_WITH_ADDRESS);
+        .send(REQ_BODY_UPDATE_MANAGING_OFFICER_ACTIVE);
 
       expect(resp.status).toEqual(302);
       expect(resp.header.location).toEqual(UPDATE_BENEFICIAL_OWNER_TYPE_URL);
@@ -178,7 +178,7 @@ describe("UPDATE MANAGING OFFICER controller", () => {
 
       const resp = await request(app)
         .post(UPDATE_MANAGING_OFFICER_URL)
-        .send(REQ_BODY_MANAGING_OFFICER_MOCK_WITH_ADDRESS);
+        .send(REQ_BODY_UPDATE_MANAGING_OFFICER_ACTIVE);
 
       expect(resp.status).toEqual(500);
       expect(resp.text).toContain(SERVICE_UNAVAILABLE);
@@ -321,7 +321,7 @@ describe("UPDATE MANAGING OFFICER controller", () => {
       mockPrepareData.mockImplementationOnce( () => MANAGING_OFFICER_INDIVIDUAL_OBJECT_MOCK_WITH_SERVICE_ADDRESS_NO);
       await request(app)
         .post(UPDATE_MANAGING_OFFICER_URL)
-        .send(REQ_BODY_MANAGING_OFFICER_MOCK_WITH_ADDRESS);
+        .send(REQ_BODY_UPDATE_MANAGING_OFFICER_ACTIVE);
       expect(mapFieldsToDataObject).toHaveBeenCalledWith(expect.anything(), ServiceAddressKeys, AddressKeys);
       const data: ApplicationDataType = mockSetApplicationData.mock.calls[0][1];
       expect(data[ServiceAddressKey]).toEqual(DUMMY_DATA_OBJECT);
@@ -331,7 +331,7 @@ describe("UPDATE MANAGING OFFICER controller", () => {
       mockPrepareData.mockImplementationOnce( () => MANAGING_OFFICER_INDIVIDUAL_OBJECT_MOCK_WITH_SERVICE_ADDRESS_YES);
       await request(app)
         .post(UPDATE_MANAGING_OFFICER_URL)
-        .send(REQ_BODY_MANAGING_OFFICER_MOCK_WITH_ADDRESS);
+        .send(REQ_BODY_UPDATE_MANAGING_OFFICER_ACTIVE);
 
       expect(mapFieldsToDataObject).not.toHaveBeenCalledWith(expect.anything(), ServiceAddressKeys, AddressKeys);
       const data: ApplicationDataType = mockSetApplicationData.mock.calls[0][1];
@@ -342,7 +342,7 @@ describe("UPDATE MANAGING OFFICER controller", () => {
       mockPrepareData.mockImplementationOnce( () => MANAGING_OFFICER_INDIVIDUAL_OBJECT_MOCK_WITH_FORMER_NAMES_YES);
       await request(app)
         .post(UPDATE_MANAGING_OFFICER_URL)
-        .send(REQ_BODY_MANAGING_OFFICER_MOCK_WITH_ADDRESS);
+        .send(REQ_BODY_UPDATE_MANAGING_OFFICER_ACTIVE);
       const data: ApplicationDataType = mockSetApplicationData.mock.calls[0][1];
       expect(data[FormerNamesKey]).toEqual("John Doe");
     });
@@ -351,7 +351,7 @@ describe("UPDATE MANAGING OFFICER controller", () => {
       mockPrepareData.mockImplementationOnce( () => MANAGING_OFFICER_INDIVIDUAL_OBJECT_MOCK_WITH_FORMER_NAMES_NO);
       await request(app)
         .post(UPDATE_MANAGING_OFFICER_URL)
-        .send(REQ_BODY_MANAGING_OFFICER_MOCK_WITH_ADDRESS);
+        .send(REQ_BODY_UPDATE_MANAGING_OFFICER_ACTIVE);
       const data: ApplicationDataType = mockSetApplicationData.mock.calls[0][1];
       expect(data[FormerNamesKey]).toEqual("");
     });
@@ -663,7 +663,7 @@ describe("UPDATE MANAGING OFFICER controller", () => {
 
   describe("GET BY ID tests", () => {
     test(`renders ${UPDATE_MANAGING_OFFICER_PAGE} page`, async () => {
-      mockGetFromApplicationData.mockReturnValueOnce(REQ_BODY_MANAGING_OFFICER_MOCK_WITH_ADDRESS);
+      mockGetFromApplicationData.mockReturnValueOnce(REQ_BODY_UPDATE_MANAGING_OFFICER_ACTIVE);
       mockGetApplicationData.mockReturnValueOnce({ ...APPLICATION_DATA_CH_REF_UPDATE_MOCK });
 
       const resp = await request(app).get(UPDATE_MANAGING_OFFICER_URL + MO_IND_ID_URL);
@@ -687,7 +687,7 @@ describe("UPDATE MANAGING OFFICER controller", () => {
       mockPrepareData.mockReturnValueOnce(MANAGING_OFFICER_OBJECT_MOCK);
       const resp = await request(app)
         .post(UPDATE_MANAGING_OFFICER_URL + MO_IND_ID_URL)
-        .send(REQ_BODY_MANAGING_OFFICER_MOCK_WITH_ADDRESS);
+        .send(REQ_BODY_UPDATE_MANAGING_OFFICER_ACTIVE);
 
       expect(resp.status).toEqual(302);
       expect(resp.header.location).toEqual(UPDATE_BENEFICIAL_OWNER_TYPE_URL);
@@ -698,7 +698,7 @@ describe("UPDATE MANAGING OFFICER controller", () => {
       mockLoggerDebugRequest.mockImplementationOnce( () => { throw new Error(ANY_MESSAGE_ERROR); });
       const resp = await request(app)
         .post(UPDATE_MANAGING_OFFICER_URL + MO_IND_ID_URL)
-        .send(REQ_BODY_MANAGING_OFFICER_MOCK_WITH_ADDRESS);
+        .send(REQ_BODY_UPDATE_MANAGING_OFFICER_ACTIVE);
 
       expect(resp.status).toEqual(500);
       expect(resp.text).toContain(SERVICE_UNAVAILABLE);
@@ -710,7 +710,7 @@ describe("UPDATE MANAGING OFFICER controller", () => {
       mockPrepareData.mockReturnValueOnce(newMoData);
       const resp = await request(app)
         .post(UPDATE_MANAGING_OFFICER_URL + MO_IND_ID_URL)
-        .send(REQ_BODY_MANAGING_OFFICER_MOCK_WITH_ADDRESS);
+        .send(REQ_BODY_UPDATE_MANAGING_OFFICER_ACTIVE);
 
       expect(mockRemoveFromApplicationData.mock.calls[0][1]).toEqual(ManagingOfficerKey);
       expect(mockRemoveFromApplicationData.mock.calls[0][2]).toEqual(MO_IND_ID);
@@ -727,7 +727,7 @@ describe("UPDATE MANAGING OFFICER controller", () => {
       mockPrepareData.mockImplementationOnce( () => MANAGING_OFFICER_INDIVIDUAL_OBJECT_MOCK_WITH_SERVICE_ADDRESS_NO);
       await request(app)
         .post(UPDATE_MANAGING_OFFICER_URL)
-        .send(REQ_BODY_MANAGING_OFFICER_MOCK_WITH_ADDRESS);
+        .send(REQ_BODY_UPDATE_MANAGING_OFFICER_ACTIVE);
       expect(mapFieldsToDataObject).toHaveBeenCalledWith(expect.anything(), ServiceAddressKeys, AddressKeys);
       const data: ApplicationDataType = mockSetApplicationData.mock.calls[0][1];
       expect(data[ServiceAddressKey]).toEqual(DUMMY_DATA_OBJECT);
@@ -738,7 +738,7 @@ describe("UPDATE MANAGING OFFICER controller", () => {
       mockPrepareData.mockImplementationOnce( () => MANAGING_OFFICER_INDIVIDUAL_OBJECT_MOCK_WITH_SERVICE_ADDRESS_YES );
       await request(app)
         .post(UPDATE_MANAGING_OFFICER_URL)
-        .send(REQ_BODY_MANAGING_OFFICER_MOCK_WITH_ADDRESS);
+        .send(REQ_BODY_UPDATE_MANAGING_OFFICER_ACTIVE);
 
       expect(mapFieldsToDataObject).not.toHaveBeenCalledWith(expect.anything(), ServiceAddressKeys, AddressKeys);
       const data: ApplicationDataType = mockSetApplicationData.mock.calls[0][1];
@@ -750,7 +750,7 @@ describe("UPDATE MANAGING OFFICER controller", () => {
       mockPrepareData.mockImplementationOnce( () => MANAGING_OFFICER_INDIVIDUAL_OBJECT_MOCK_WITH_FORMER_NAMES_YES);
       await request(app)
         .post(UPDATE_MANAGING_OFFICER_URL)
-        .send(REQ_BODY_MANAGING_OFFICER_MOCK_WITH_ADDRESS);
+        .send(REQ_BODY_UPDATE_MANAGING_OFFICER_ACTIVE);
       const data: ApplicationDataType = mockSetApplicationData.mock.calls[0][1];
       expect(data[FormerNamesKey]).toEqual("John Doe");
       expect(mockSaveAndContinue).toHaveBeenCalledTimes(1);
@@ -760,7 +760,7 @@ describe("UPDATE MANAGING OFFICER controller", () => {
       mockPrepareData.mockImplementationOnce( () => MANAGING_OFFICER_INDIVIDUAL_OBJECT_MOCK_WITH_FORMER_NAMES_NO);
       await request(app)
         .post(UPDATE_MANAGING_OFFICER_URL)
-        .send(REQ_BODY_MANAGING_OFFICER_MOCK_WITH_ADDRESS);
+        .send(REQ_BODY_UPDATE_MANAGING_OFFICER_ACTIVE);
       const data: ApplicationDataType = mockSetApplicationData.mock.calls[0][1];
       expect(data[FormerNamesKey]).toEqual("");
       expect(mockSaveAndContinue).toHaveBeenCalledTimes(1);

--- a/test/controllers/update/update.managing.officer.controller.spec.ts
+++ b/test/controllers/update/update.managing.officer.controller.spec.ts
@@ -43,7 +43,8 @@ import {
   RR_CARRIAGE_RETURN,
   MO_IND_ID,
   MO_IND_ID_URL,
-  APPLICATION_DATA_CH_REF_UPDATE_MOCK
+  APPLICATION_DATA_CH_REF_UPDATE_MOCK,
+  APPLICATION_DATA_MOCK
 } from "../../__mocks__/session.mock";
 import {
   ALL_THE_OTHER_INFORMATION_ON_PUBLIC_REGISTER,
@@ -112,6 +113,7 @@ describe("UPDATE MANAGING OFFICER controller", () => {
 
   describe("GET tests", () => {
     test(`renders the ${UPDATE_MANAGING_OFFICER_PAGE} page`, async () => {
+      mockGetApplicationData.mockReturnValueOnce(APPLICATION_DATA_MOCK);
       const resp = await request(app).get(UPDATE_MANAGING_OFFICER_URL);
 
       expect(resp.status).toEqual(200);

--- a/test/controllers/update/update.managing.officer.corporate.spec.ts
+++ b/test/controllers/update/update.managing.officer.corporate.spec.ts
@@ -55,7 +55,8 @@ import {
   MO_CORP_ID_URL,
   MO_CORP_ID,
   APPLICATION_DATA_CH_REF_UPDATE_MOCK,
-  MO_IND_ID_URL
+  MO_IND_ID_URL,
+  APPLICATION_DATA_MOCK
 } from "../../__mocks__/session.mock";
 import {
   MANAGING_OFFICER_CORPORATE_WITH_INVALID_CHARS_MOCK,
@@ -114,6 +115,7 @@ describe("UPDATE MANAGING OFFICER CORPORATE controller", () => {
 
   describe("GET tests", () => {
     test(`renders the ${UPDATE_MANAGING_OFFICER_CORPORATE_PAGE} page`, async () => {
+      mockGetApplicationData.mockReturnValueOnce(APPLICATION_DATA_MOCK);
       const resp = await request(app).get(UPDATE_MANAGING_OFFICER_CORPORATE_URL);
 
       expect(resp.status).toEqual(200);

--- a/test/controllers/update/update.managing.officer.corporate.spec.ts
+++ b/test/controllers/update/update.managing.officer.corporate.spec.ts
@@ -42,13 +42,12 @@ import {
   SHOW_INFORMATION_ON_PUBLIC_REGISTER,
 } from "../../__mocks__/text.mock";
 import {
-  MANAGING_OFFICER_CORPORATE_OBJECT_MOCK,
-  MANAGING_OFFICER_CORPORATE_MOCK_WITH_EMAIL_CONTAINING_LEADING_AND_TRAILING_SPACES,
+  UPDATE_MANAGING_OFFICER_CORPORATE_OBJECT_MOCK,
   MANAGING_OFFICER_CORPORATE_OBJECT_MOCK_WITH_PUBLIC_REGISTER_DATA_NO,
   MANAGING_OFFICER_CORPORATE_OBJECT_MOCK_WITH_PUBLIC_REGISTER_DATA_YES,
   MANAGING_OFFICER_CORPORATE_OBJECT_MOCK_WITH_SERVICE_ADDRESS_NO,
   MANAGING_OFFICER_CORPORATE_OBJECT_MOCK_WITH_SERVICE_ADDRESS_YES,
-  REQ_BODY_MANAGING_OFFICER_CORPORATE_MOCK_WITH_ADDRESS,
+  REQ_BODY_UPDATE_MANAGING_OFFICER_CORPORATE_MOCK_ACTIVE,
   REQ_BODY_MANAGING_OFFICER_CORPORATE_OBJECT_EMPTY,
   RR_CARRIAGE_RETURN,
   EMAIL_ADDRESS,
@@ -56,7 +55,8 @@ import {
   MO_CORP_ID,
   APPLICATION_DATA_CH_REF_UPDATE_MOCK,
   MO_IND_ID_URL,
-  APPLICATION_DATA_MOCK
+  APPLICATION_DATA_MOCK,
+  UPDATE_MANAGING_OFFICER_CORPORATE_MOCK_WITH_EMAIL_CONTAINING_LEADING_AND_TRAILING_SPACES
 } from "../../__mocks__/session.mock";
 import {
   MANAGING_OFFICER_CORPORATE_WITH_INVALID_CHARS_MOCK,
@@ -138,17 +138,17 @@ describe("UPDATE MANAGING OFFICER CORPORATE controller", () => {
 
   describe("POST tests", () => {
     test(`sets session data and renders the ${UPDATE_BENEFICIAL_OWNER_TYPE_PAGE} page`, async () => {
-      mockPrepareData.mockImplementationOnce( () => MANAGING_OFFICER_CORPORATE_OBJECT_MOCK);
+      mockPrepareData.mockImplementationOnce( () => UPDATE_MANAGING_OFFICER_CORPORATE_OBJECT_MOCK);
 
       const resp = await request(app)
         .post(UPDATE_MANAGING_OFFICER_CORPORATE_URL)
-        .send(REQ_BODY_MANAGING_OFFICER_CORPORATE_MOCK_WITH_ADDRESS);
+        .send(REQ_BODY_UPDATE_MANAGING_OFFICER_CORPORATE_MOCK_ACTIVE);
 
       const managingOfficerCorporate = mockSetApplicationData.mock.calls[0][1];
 
       expect(resp.status).toEqual(302);
       expect(resp.header.location).toEqual(UPDATE_BENEFICIAL_OWNER_TYPE_URL);
-      expect(managingOfficerCorporate).toEqual(MANAGING_OFFICER_CORPORATE_OBJECT_MOCK);
+      expect(managingOfficerCorporate).toEqual(UPDATE_MANAGING_OFFICER_CORPORATE_OBJECT_MOCK);
       expect(managingOfficerCorporate.name).toEqual("Joe Bloggs Ltd");
       expect(managingOfficerCorporate.legal_form).toEqual("legalForm");
       expect(managingOfficerCorporate.law_governed).toEqual("LegAuth");
@@ -165,7 +165,7 @@ describe("UPDATE MANAGING OFFICER CORPORATE controller", () => {
 
       const resp = await request(app)
         .post(UPDATE_MANAGING_OFFICER_CORPORATE_URL)
-        .send(REQ_BODY_MANAGING_OFFICER_CORPORATE_MOCK_WITH_ADDRESS);
+        .send(REQ_BODY_UPDATE_MANAGING_OFFICER_CORPORATE_MOCK_ACTIVE);
 
       expect(resp.status).toEqual(302);
       expect(resp.header.location).toEqual(UPDATE_BENEFICIAL_OWNER_TYPE_URL);
@@ -173,9 +173,9 @@ describe("UPDATE MANAGING OFFICER CORPORATE controller", () => {
     });
 
     test("Test email is valid with long email address", async () => {
-      mockPrepareData.mockImplementationOnce( () => MANAGING_OFFICER_CORPORATE_OBJECT_MOCK);
+      mockPrepareData.mockImplementationOnce( () => UPDATE_MANAGING_OFFICER_CORPORATE_OBJECT_MOCK);
       const managingOfficerCorporate = {
-        ...REQ_BODY_MANAGING_OFFICER_CORPORATE_MOCK_WITH_ADDRESS,
+        ...REQ_BODY_UPDATE_MANAGING_OFFICER_CORPORATE_MOCK_ACTIVE,
         contact_email: "vsocarroll@QQQQQQQT123465798U123456789V123456789W123456789X123456789Y123456.companieshouse.gov.uk" };
 
       const resp = await request(app)
@@ -188,9 +188,9 @@ describe("UPDATE MANAGING OFFICER CORPORATE controller", () => {
     });
 
     test("Test email is valid with long email name and address", async () => {
-      mockPrepareData.mockImplementationOnce( () => MANAGING_OFFICER_CORPORATE_OBJECT_MOCK);
+      mockPrepareData.mockImplementationOnce( () => UPDATE_MANAGING_OFFICER_CORPORATE_OBJECT_MOCK);
       const managingOfficerCorporate = {
-        ...REQ_BODY_MANAGING_OFFICER_CORPORATE_MOCK_WITH_ADDRESS,
+        ...REQ_BODY_UPDATE_MANAGING_OFFICER_CORPORATE_MOCK_ACTIVE,
         contact_email: "socarrollA123456789B132456798C123456798D123456789@T123465798U123456789V123456789W123456789X123456789Y123456.companieshouse.gov.uk" };
 
       const resp = await request(app)
@@ -203,9 +203,9 @@ describe("UPDATE MANAGING OFFICER CORPORATE controller", () => {
     });
 
     test("Test email is valid with very long email name and address", async () => {
-      mockPrepareData.mockImplementationOnce( () => MANAGING_OFFICER_CORPORATE_OBJECT_MOCK);
+      mockPrepareData.mockImplementationOnce( () => UPDATE_MANAGING_OFFICER_CORPORATE_OBJECT_MOCK);
       const managingOfficerCorporate = {
-        ...REQ_BODY_MANAGING_OFFICER_CORPORATE_MOCK_WITH_ADDRESS,
+        ...REQ_BODY_UPDATE_MANAGING_OFFICER_CORPORATE_MOCK_ACTIVE,
         contact_email: "socarrollA123456789B132456798C123456798D123456789E123456789F123XX@T123465798U123456789V123456789W123456789X123456789Y123456.companieshouse.gov.uk" };
 
       const resp = await request(app)
@@ -222,7 +222,7 @@ describe("UPDATE MANAGING OFFICER CORPORATE controller", () => {
 
       const resp = await request(app)
         .post(UPDATE_MANAGING_OFFICER_CORPORATE_URL)
-        .send(REQ_BODY_MANAGING_OFFICER_CORPORATE_MOCK_WITH_ADDRESS);
+        .send(REQ_BODY_UPDATE_MANAGING_OFFICER_CORPORATE_MOCK_ACTIVE);
 
       expect(resp.status).toEqual(500);
       expect(resp.text).toContain(SERVICE_UNAVAILABLE);
@@ -364,7 +364,7 @@ describe("UPDATE MANAGING OFFICER CORPORATE controller", () => {
       mockPrepareData.mockImplementation( () => MANAGING_OFFICER_CORPORATE_OBJECT_MOCK_WITH_SERVICE_ADDRESS_NO);
       await request(app)
         .post(UPDATE_MANAGING_OFFICER_CORPORATE_URL)
-        .send(REQ_BODY_MANAGING_OFFICER_CORPORATE_MOCK_WITH_ADDRESS);
+        .send(REQ_BODY_UPDATE_MANAGING_OFFICER_CORPORATE_MOCK_ACTIVE);
       expect(mapFieldsToDataObject).toHaveBeenCalledWith(expect.anything(), ServiceAddressKeys, AddressKeys);
       const data: ApplicationDataType = mockSetApplicationData.mock.calls[0][1];
       expect(data[ServiceAddressKey]).toEqual(DUMMY_DATA_OBJECT);
@@ -374,7 +374,7 @@ describe("UPDATE MANAGING OFFICER CORPORATE controller", () => {
       mockPrepareData.mockImplementation( () => MANAGING_OFFICER_CORPORATE_OBJECT_MOCK_WITH_SERVICE_ADDRESS_YES);
       await request(app)
         .post(UPDATE_MANAGING_OFFICER_CORPORATE_URL)
-        .send(REQ_BODY_MANAGING_OFFICER_CORPORATE_MOCK_WITH_ADDRESS);
+        .send(REQ_BODY_UPDATE_MANAGING_OFFICER_CORPORATE_MOCK_ACTIVE);
       expect(mapFieldsToDataObject).not.toHaveBeenCalledWith(expect.anything(), ServiceAddressKeys, AddressKeys);
       const data: ApplicationDataType = mockSetApplicationData.mock.calls[0][1];
       expect(data[ServiceAddressKey]).toEqual({});
@@ -384,7 +384,7 @@ describe("UPDATE MANAGING OFFICER CORPORATE controller", () => {
       mockPrepareData.mockImplementation( () => MANAGING_OFFICER_CORPORATE_OBJECT_MOCK_WITH_PUBLIC_REGISTER_DATA_YES);
       await request(app)
         .post(UPDATE_MANAGING_OFFICER_CORPORATE_URL)
-        .send(REQ_BODY_MANAGING_OFFICER_CORPORATE_MOCK_WITH_ADDRESS);
+        .send(REQ_BODY_UPDATE_MANAGING_OFFICER_CORPORATE_MOCK_ACTIVE);
       const data: ApplicationDataType = mockSetApplicationData.mock.calls[0][1];
       expect(data[PublicRegisterNameKey]).toEqual("Reg");
       expect(data[RegistrationNumberKey]).toEqual("123456");
@@ -394,17 +394,18 @@ describe("UPDATE MANAGING OFFICER CORPORATE controller", () => {
       mockPrepareData.mockImplementation( () => MANAGING_OFFICER_CORPORATE_OBJECT_MOCK_WITH_PUBLIC_REGISTER_DATA_NO);
       await request(app)
         .post(UPDATE_MANAGING_OFFICER_CORPORATE_URL)
-        .send(REQ_BODY_MANAGING_OFFICER_CORPORATE_MOCK_WITH_ADDRESS);
+        .send(REQ_BODY_UPDATE_MANAGING_OFFICER_CORPORATE_MOCK_ACTIVE);
       const data: ApplicationDataType = mockSetApplicationData.mock.calls[0][1];
       expect(data[PublicRegisterNameKey]).toEqual("");
       expect(data[RegistrationNumberKey]).toEqual("");
     });
 
     test(`renders the next page ${UPDATE_BENEFICIAL_OWNER_TYPE_PAGE} and no errors are reported if email has leading and trailing spaces`, async () => {
-      mockPrepareData.mockReturnValueOnce(MANAGING_OFFICER_CORPORATE_OBJECT_MOCK);
+      mockPrepareData.mockReturnValueOnce(UPDATE_MANAGING_OFFICER_CORPORATE_OBJECT_MOCK);
+
       const resp = await request(app)
         .post(UPDATE_MANAGING_OFFICER_CORPORATE_URL)
-        .send(MANAGING_OFFICER_CORPORATE_MOCK_WITH_EMAIL_CONTAINING_LEADING_AND_TRAILING_SPACES);
+        .send(UPDATE_MANAGING_OFFICER_CORPORATE_MOCK_WITH_EMAIL_CONTAINING_LEADING_AND_TRAILING_SPACES);
 
       expect(resp.status).toEqual(302);
       expect(resp.header.location).toEqual(UPDATE_BENEFICIAL_OWNER_TYPE_URL);
@@ -417,7 +418,7 @@ describe("UPDATE MANAGING OFFICER CORPORATE controller", () => {
 
   describe("GET BY ID tests", () => {
     test(`renders ${UPDATE_MANAGING_OFFICER_CORPORATE_PAGE} page`, async () => {
-      mockGetFromApplicationData.mockReturnValueOnce(REQ_BODY_MANAGING_OFFICER_CORPORATE_MOCK_WITH_ADDRESS);
+      mockGetFromApplicationData.mockReturnValueOnce(REQ_BODY_UPDATE_MANAGING_OFFICER_CORPORATE_MOCK_ACTIVE);
       mockGetApplicationData.mockReturnValueOnce({ ...APPLICATION_DATA_CH_REF_UPDATE_MOCK });
 
       const resp = await request(app).get(UPDATE_MANAGING_OFFICER_CORPORATE_URL + MO_IND_ID_URL);
@@ -439,10 +440,10 @@ describe("UPDATE MANAGING OFFICER CORPORATE controller", () => {
 
   describe("UPDATE tests", () => {
     test(`redirects to the ${UPDATE_BENEFICIAL_OWNER_TYPE_URL} page`, async () => {
-      mockPrepareData.mockReturnValueOnce(MANAGING_OFFICER_CORPORATE_OBJECT_MOCK);
+      mockPrepareData.mockReturnValueOnce(UPDATE_MANAGING_OFFICER_CORPORATE_OBJECT_MOCK);
       const resp = await request(app)
         .post(UPDATE_MANAGING_OFFICER_CORPORATE_URL + MO_CORP_ID_URL)
-        .send(REQ_BODY_MANAGING_OFFICER_CORPORATE_MOCK_WITH_ADDRESS);
+        .send(REQ_BODY_UPDATE_MANAGING_OFFICER_CORPORATE_MOCK_ACTIVE);
 
       expect(resp.status).toEqual(302);
       expect(resp.header.location).toEqual(UPDATE_BENEFICIAL_OWNER_TYPE_URL);
@@ -453,7 +454,7 @@ describe("UPDATE MANAGING OFFICER CORPORATE controller", () => {
       mockLoggerDebugRequest.mockImplementationOnce( () => { throw new Error(MESSAGE_ERROR); });
       const resp = await request(app)
         .post(UPDATE_MANAGING_OFFICER_CORPORATE_URL + MO_CORP_ID_URL)
-        .send(REQ_BODY_MANAGING_OFFICER_CORPORATE_MOCK_WITH_ADDRESS);
+        .send(REQ_BODY_UPDATE_MANAGING_OFFICER_CORPORATE_MOCK_ACTIVE);
 
       expect(resp.status).toEqual(500);
       expect(resp.text).toContain(SERVICE_UNAVAILABLE);
@@ -465,7 +466,7 @@ describe("UPDATE MANAGING OFFICER CORPORATE controller", () => {
       mockPrepareData.mockReturnValueOnce(newMoData);
       const resp = await request(app)
         .post(UPDATE_MANAGING_OFFICER_CORPORATE_URL + MO_CORP_ID_URL)
-        .send(REQ_BODY_MANAGING_OFFICER_CORPORATE_MOCK_WITH_ADDRESS);
+        .send(REQ_BODY_UPDATE_MANAGING_OFFICER_CORPORATE_MOCK_ACTIVE);
 
       expect(mockRemoveFromApplicationData.mock.calls[0][1]).toEqual(ManagingOfficerCorporateKey);
       expect(mockRemoveFromApplicationData.mock.calls[0][2]).toEqual(MO_CORP_ID);
@@ -482,7 +483,7 @@ describe("UPDATE MANAGING OFFICER CORPORATE controller", () => {
       mockPrepareData.mockImplementation( () => MANAGING_OFFICER_CORPORATE_OBJECT_MOCK_WITH_SERVICE_ADDRESS_NO);
       await request(app)
         .post(UPDATE_MANAGING_OFFICER_CORPORATE_URL + MO_CORP_ID_URL)
-        .send(REQ_BODY_MANAGING_OFFICER_CORPORATE_MOCK_WITH_ADDRESS);
+        .send(REQ_BODY_UPDATE_MANAGING_OFFICER_CORPORATE_MOCK_ACTIVE);
       expect(mapFieldsToDataObject).toHaveBeenCalledWith(expect.anything(), ServiceAddressKeys, AddressKeys);
       const data: ApplicationDataType = mockSetApplicationData.mock.calls[0][1];
       expect(data[ServiceAddressKey]).toEqual(DUMMY_DATA_OBJECT);
@@ -493,7 +494,7 @@ describe("UPDATE MANAGING OFFICER CORPORATE controller", () => {
       mockPrepareData.mockImplementation( () => MANAGING_OFFICER_CORPORATE_OBJECT_MOCK_WITH_SERVICE_ADDRESS_YES);
       await request(app)
         .post(UPDATE_MANAGING_OFFICER_CORPORATE_URL + MO_CORP_ID_URL)
-        .send(REQ_BODY_MANAGING_OFFICER_CORPORATE_MOCK_WITH_ADDRESS);
+        .send(REQ_BODY_UPDATE_MANAGING_OFFICER_CORPORATE_MOCK_ACTIVE);
       expect(mapFieldsToDataObject).not.toHaveBeenCalledWith(expect.anything(), ServiceAddressKeys, AddressKeys);
       const data: ApplicationDataType = mockSetApplicationData.mock.calls[0][1];
       expect(data[ServiceAddressKey]).toEqual({});
@@ -504,7 +505,7 @@ describe("UPDATE MANAGING OFFICER CORPORATE controller", () => {
       mockPrepareData.mockImplementation( () => MANAGING_OFFICER_CORPORATE_OBJECT_MOCK_WITH_PUBLIC_REGISTER_DATA_YES);
       await request(app)
         .post(UPDATE_MANAGING_OFFICER_CORPORATE_URL + MO_CORP_ID_URL)
-        .send(REQ_BODY_MANAGING_OFFICER_CORPORATE_MOCK_WITH_ADDRESS);
+        .send(REQ_BODY_UPDATE_MANAGING_OFFICER_CORPORATE_MOCK_ACTIVE);
       const data: ApplicationDataType = mockSetApplicationData.mock.calls[0][1];
       expect(data[PublicRegisterNameKey]).toEqual("Reg");
       expect(data[RegistrationNumberKey]).toEqual("123456");
@@ -515,7 +516,7 @@ describe("UPDATE MANAGING OFFICER CORPORATE controller", () => {
       mockPrepareData.mockImplementation( () => MANAGING_OFFICER_CORPORATE_OBJECT_MOCK_WITH_PUBLIC_REGISTER_DATA_NO);
       await request(app)
         .post(UPDATE_MANAGING_OFFICER_CORPORATE_URL + MO_CORP_ID_URL)
-        .send(REQ_BODY_MANAGING_OFFICER_CORPORATE_MOCK_WITH_ADDRESS);
+        .send(REQ_BODY_UPDATE_MANAGING_OFFICER_CORPORATE_MOCK_ACTIVE);
       const data: ApplicationDataType = mockSetApplicationData.mock.calls[0][1];
       expect(data[PublicRegisterNameKey]).toEqual("");
       expect(data[RegistrationNumberKey]).toEqual("");
@@ -525,7 +526,7 @@ describe("UPDATE MANAGING OFFICER CORPORATE controller", () => {
 
   describe("REMOVE tests", () => {
     test(`redirects to the ${UPDATE_BENEFICIAL_OWNER_TYPE_URL} page`, async () => {
-      mockPrepareData.mockReturnValueOnce(MANAGING_OFFICER_CORPORATE_OBJECT_MOCK);
+      mockPrepareData.mockReturnValueOnce(UPDATE_MANAGING_OFFICER_CORPORATE_OBJECT_MOCK);
       const resp = await request(app).get(UPDATE_MANAGING_OFFICER_CORPORATE_URL + REMOVE + MO_CORP_ID_URL);
 
       expect(resp.status).toEqual(302);

--- a/test/controllers/update/update.managing.officer.corporate.spec.ts
+++ b/test/controllers/update/update.managing.officer.corporate.spec.ts
@@ -56,7 +56,8 @@ import {
   APPLICATION_DATA_CH_REF_UPDATE_MOCK,
   MO_IND_ID_URL,
   APPLICATION_DATA_MOCK,
-  UPDATE_MANAGING_OFFICER_CORPORATE_MOCK_WITH_EMAIL_CONTAINING_LEADING_AND_TRAILING_SPACES
+  UPDATE_MANAGING_OFFICER_CORPORATE_MOCK_WITH_EMAIL_CONTAINING_LEADING_AND_TRAILING_SPACES,
+  REQ_BODY_UPDATE_MANAGING_OFFICER_CORPORATE_MOCK_INACTIVE
 } from "../../__mocks__/session.mock";
 import {
   MANAGING_OFFICER_CORPORATE_WITH_INVALID_CHARS_MOCK,
@@ -137,7 +138,7 @@ describe("UPDATE MANAGING OFFICER CORPORATE controller", () => {
   });
 
   describe("POST tests", () => {
-    test(`sets session data and renders the ${UPDATE_BENEFICIAL_OWNER_TYPE_PAGE} page`, async () => {
+    test(`sets session data and renders the ${UPDATE_BENEFICIAL_OWNER_TYPE_PAGE} page for active MO`, async () => {
       mockPrepareData.mockImplementationOnce( () => UPDATE_MANAGING_OFFICER_CORPORATE_OBJECT_MOCK);
 
       const resp = await request(app)
@@ -156,6 +157,31 @@ describe("UPDATE MANAGING OFFICER CORPORATE controller", () => {
       expect(managingOfficerCorporate.role_and_responsibilities).toEqual("role and responsibilities text");
       expect(managingOfficerCorporate.contact_full_name).toEqual("Joe Bloggs");
       expect(managingOfficerCorporate.contact_email).toEqual("jbloggs@bloggs.co.ru");
+      expect(mockSetApplicationData.mock.calls[0][2]).toEqual(managingOfficerCorporateType.ManagingOfficerCorporateKey);
+      expect(mockSaveAndContinue).toHaveBeenCalledTimes(1);
+    });
+
+    test(`sets session data and renders the ${UPDATE_BENEFICIAL_OWNER_TYPE_PAGE} page for inactive MO`, async () => {
+      mockPrepareData.mockImplementationOnce( () => UPDATE_MANAGING_OFFICER_CORPORATE_OBJECT_MOCK);
+
+      const resp = await request(app)
+        .post(UPDATE_MANAGING_OFFICER_CORPORATE_URL)
+        .send(REQ_BODY_UPDATE_MANAGING_OFFICER_CORPORATE_MOCK_INACTIVE);
+
+      const managingOfficerCorporate = mockSetApplicationData.mock.calls[0][1];
+
+      expect(resp.status).toEqual(302);
+      expect(resp.header.location).toEqual(UPDATE_BENEFICIAL_OWNER_TYPE_URL);
+      expect(managingOfficerCorporate).toEqual(UPDATE_MANAGING_OFFICER_CORPORATE_OBJECT_MOCK);
+      expect(managingOfficerCorporate.name).toEqual("Joe Bloggs Ltd");
+      expect(managingOfficerCorporate.legal_form).toEqual("legalForm");
+      expect(managingOfficerCorporate.law_governed).toEqual("LegAuth");
+      expect(managingOfficerCorporate.registration_number).toEqual("123456789");
+      expect(managingOfficerCorporate.role_and_responsibilities).toEqual("role and responsibilities text");
+      expect(managingOfficerCorporate.contact_full_name).toEqual("Joe Bloggs");
+      expect(managingOfficerCorporate.contact_email).toEqual("jbloggs@bloggs.co.ru");
+      expect(managingOfficerCorporate.start_date).toEqual(DUMMY_DATA_OBJECT);
+      expect(managingOfficerCorporate.resigned_on).toEqual(DUMMY_DATA_OBJECT);
       expect(mockSetApplicationData.mock.calls[0][2]).toEqual(managingOfficerCorporateType.ManagingOfficerCorporateKey);
       expect(mockSaveAndContinue).toHaveBeenCalledTimes(1);
     });

--- a/test/validation/custom.validation.spec.ts
+++ b/test/validation/custom.validation.spec.ts
@@ -12,7 +12,7 @@ describe('checkCeasedDateOnOrAfterStartDate', () => {
     const ceaseDate = ["2", "2", "2023"];
     const startDate = ["3", "3", "2023"];
 
-    expect(() => custom.checkCeasedDateOnOrAfterStartDate(...ceaseDate, ...startDate)).toThrowError(ErrorMessages.CEASED_DATE_BEFORE_START_DATE);
+    expect(() => custom.checkCeasedDateOnOrAfterStartDate(...ceaseDate, ...startDate, ErrorMessages.CEASED_DATE_BEFORE_START_DATE)).toThrowError(ErrorMessages.CEASED_DATE_BEFORE_START_DATE);
   });
 
   test('should return true if ceased date after start date', () => {

--- a/views/includes/ceased-date-details-summary-new-bo.html
+++ b/views/includes/ceased-date-details-summary-new-bo.html
@@ -1,11 +1,7 @@
-{{ govukInsetText({
-  html: "You'll need to tell us if it's still a registrable beneficial owner."
-}) }}
-
 {% if beneficialOwnerPronoun == "they" %}
-  {% set boTense = "are" %}
+  {% set boTense = "have" %}
 {% else %}
-  {% set boTense = "is" %}
+  {% set boTense = "has" %}
 {% endif %}
 
 <details class="govuk-details" data-module="govuk-details" data-event-id="protected-personal-information-details" >
@@ -15,6 +11,6 @@
     </span>
   </summary>
   <div class="govuk-details__text">
-    <p class="govuk-body">If {{ beneficialOwnerPronoun }} {{ boTense }} no longer a registrable beneficial owner, you need to make sure this information is correct as at the ceased date, and update it if needed.</p>
+    <p class="govuk-body">If {{ beneficialOwnerPronoun }} {{ boTense }} become and then ceased to be a registrable beneficial owner during this update period, you need to enter information that is correct as at the ceased date.</p>
   </div>
 </details>

--- a/views/includes/ceased-date-details-summary-review-bo.html
+++ b/views/includes/ceased-date-details-summary-review-bo.html
@@ -1,0 +1,16 @@
+{% if beneficialOwnerPronoun == "they" %}
+  {% set boTense = "are" %}
+{% else %}
+  {% set boTense = "is" %}
+{% endif %}
+
+<details class="govuk-details" data-module="govuk-details" data-event-id="protected-personal-information-details" >
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">
+      How to complete this section for a ceased beneficial owner
+    </span>
+  </summary>
+  <div class="govuk-details__text">
+    <p class="govuk-body">If {{ beneficialOwnerPronoun }} {{ boTense }} no longer a registrable beneficial owner, you need to make sure this information is correct as at the ceased date, and update it if needed.</p>
+  </div>
+</details>

--- a/views/includes/inputs/date/resigned-on-input.html
+++ b/views/includes/inputs/date/resigned-on-input.html
@@ -1,0 +1,93 @@
+{% set resignedOnErrorMessage = '' %}
+{% set isResignedOnDayError = false %}
+{% set isResignedOnMonthError = false %}
+{% set isResignedOnYearError = false %}
+
+{# We are constrained by the generic validation handling so have to manipulate the error data in the template rather than the controller #}
+{# We need to loop through the errors returned to pick out the first resigned_on error #}
+{# to prevent duplicate messages on the same field. #}
+{# We can use its message text and then work out which of the day/month/year fields #}
+{# to mark as 'red' using the error style class #}
+
+{% if errors %}
+  {% for key, value in errors %}
+
+    {# only look at first matching error #}
+    {% if not resignedOnErrorMessage %}
+      {% if "resigned_on" == key|string %}
+        {# if the matching error is for the whole date field, look at the data to see what has not been populated in the date #}
+        {% set resignedOnErrorMessage = value %}
+        {% if resigned_on %}
+          {% if not resigned_on["resigned_on-day"] %}
+            {% set isResignedOnDayError = true %}
+          {% endif %}
+          {% if not resigned_on["resigned_on-month"] %}
+            {% set isResignedOnMonthError = true %}
+          {% endif %}
+          {% if not resigned_on["resigned_on-year"] %}
+            {% set isResignedOnYearError = true %}
+          {% endif %}
+        {% endif %}
+      {% elif "resigned_on" in key|string %}
+        {# if the matching error is for a -day,-month,-year field, set the flag to mark that field as in error #}
+        {% set resignedOnErrorMessage = value %}
+        {% if "-day" in key|string %}
+          {% set isResignedOnDayError = true %}
+        {% elif "-month" in key|string %}
+          {% set isResignedOnMonthError = true %}
+        {% elif "-year" in key|string %}
+          {% set isResignedOnYearError = true %}
+        {% endif %}
+      {% endif %}
+    {% endif %}
+  {% endfor %}
+{% endif %}
+
+
+{% set resigned_on_classes_year = "govuk-input--width-4 govuk-input" %}
+{% set resigned_on_classes_month = "govuk-input--width-2 govuk-input" %}
+{% set resigned_on_classes_day = "govuk-input--width-2 govuk-input" %}
+
+{% if isResignedOnDayError %}
+  {% set resigned_on_classes_day = resigned_on_classes_day + "--error" %}
+{% endif %}
+{% if isResignedOnMonthError %}
+  {% set resigned_on_classes_month = resigned_on_classes_month + "--error" %}
+{% endif %}
+{% if isResignedOnYearError %}
+  {% set resigned_on_classes_year = resigned_on_classes_year + "--error" %}
+{% endif %}
+
+
+{{ govukDateInput({
+  errorMessage: resignedOnErrorMessage,
+  id: "resigned_on",
+  namePrefix: "resigned_on",
+  fieldset: {
+    legend: {
+      text: dateText,
+      isPageHeading: false,
+      classes: "govuk-fieldset__legend--m"
+    }
+  },
+  hint: {
+    text: "For example, 27 3 2007"
+  },
+  items: [
+    {
+      classes: resigned_on_classes_day,
+      name: "day",
+      value: resigned_on["resigned_on-day"] if resigned_on
+    },
+    {
+      classes: resigned_on_classes_month,
+      name: "month",
+      value: resigned_on["resigned_on-month"] if resigned_on
+    },
+    {
+      classes: resigned_on_classes_year,
+      name: "year",
+      value: resigned_on["resigned_on-year"] if resigned_on
+    }
+  ]
+}) }}

--- a/views/includes/inputs/fields/is-still-a-managing-officer-input.html
+++ b/views/includes/inputs/fields/is-still-a-managing-officer-input.html
@@ -1,0 +1,46 @@
+{% if managingOfficerPronoun == "they" %}
+  {% set dateText = "Date they stopped being a managing officer" %}
+  {% set stillMoText = "Are they still a managing officer for the overseas entity?" %}
+{% else %}
+  {% set dateText = "Date it stopped being a managing officer" %}
+  {% set stillMoText = "Is it still a managing officer for the overseas entity?" %}
+{% endif %}
+
+{% set resignedOnHtml %}
+  {% include "includes/inputs/date/resigned-on-input.html" %}
+{% endset %}
+
+{{ govukRadios({
+  errorMessage: errors.is_still_mo if errors,
+  classes: "govuk-radios",
+  idPrefix: "is_still_mo",
+  name: "is_still_mo",
+  fieldset: {
+    legend: {
+      text: stillMoText,
+      isPageHeading: false,
+      classes: "govuk-fieldset__legend--m"
+    }
+  },
+  items: [
+    {
+      value: 1,
+      text: "Yes",
+      checked: is_still_mo == 1,
+      attributes: {
+        "data-event-id": "is-still-mo-yes"
+      }
+    },
+    {
+      value: 0,
+      text: "No",
+      checked: is_still_mo == 0,
+      attributes: {
+        "data-event-id": "is-still-mo-no"
+      },
+      conditional: {
+        html: resignedOnHtml
+      }
+    }
+  ]
+}) }}

--- a/views/includes/page-templates/beneficial-owner-gov.html
+++ b/views/includes/page-templates/beneficial-owner-gov.html
@@ -1,3 +1,5 @@
+{% set beneficialOwnerPronoun = "it" %}
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     {% include "includes/list/errors.html" %}
@@ -6,8 +8,11 @@
     <h1 class="govuk-heading-xl govuk-!-margin-0">{{ title }}</h1>
     <p class="govuk-caption-l  govuk-!-margin-bottom-5 govuk-!-margin-top-5">You can add more later.</p>
 
+    {% if entity_number %}
+      {% include "includes/ceased-date-details-summary-new-bo.html" %}
+    {% endif %}
+
     <form class="form" method="post">
-      {% set beneficialOwnerPronoun = "it" %}
       {% include "includes/inputs/fields/name-input.html" %}
 
       {% include "includes/inputs/address/principal-address-input.html" %}
@@ -34,8 +39,8 @@
 
       {% include "includes/save-and-continue-button.html" %}
       {% set nameToBeRemoved = name %}
-      
-      {% if not entity_number %} 
+
+      {% if not entity_number %}
         {% include "includes/remove-button.html" %}
       {% endif %}
     </form>

--- a/views/includes/page-templates/beneficial-owner-individual.html
+++ b/views/includes/page-templates/beneficial-owner-individual.html
@@ -1,3 +1,5 @@
+{% set beneficialOwnerPronoun = "they" %}
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     {% include "includes/list/errors.html" %}
@@ -7,8 +9,11 @@
     <h1 class="govuk-heading-xl govuk-!-margin-0">{{ title }}</h1>
     <br> <p class="govuk-body">You can add more later.</p> <br>
 
+    {% if entity_number %}
+      {% include "includes/ceased-date-details-summary-new-bo.html" %}
+    {% endif %}
+
     <form method="post">
-      {% set beneficialOwnerPronoun = "they" %}
       {% include "includes/inputs/fields/first-name-input.html" %}
 
       {% set hintLastNameText = "This is also known as your family name." %}
@@ -40,7 +45,7 @@
       {% include "includes/save-and-continue-button.html" %}
       {% set nameToBeRemoved = first_name + " " + last_name %}
 
-      {% if not entity_number %} 
+      {% if not entity_number %}
         {% include "includes/remove-button.html" %}
       {% endif %}
     </form>

--- a/views/includes/page-templates/beneficial-owner-other.html
+++ b/views/includes/page-templates/beneficial-owner-other.html
@@ -1,3 +1,5 @@
+{% set beneficialOwnerPronoun = "it" %}
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
@@ -9,8 +11,11 @@
     <p class="govuk-body">You can add more later.</p>
     <br>
 
+    {% if entity_number %}
+      {% include "includes/ceased-date-details-summary-new-bo.html" %}
+    {% endif %}
+
     <form class="form" method="post">
-      {% set beneficialOwnerPronoun = "it" %}
       {% include "includes/inputs/fields/name-input.html" %}
 
       {% include "includes/inputs/address/principal-address-input.html" %}
@@ -44,7 +49,7 @@
 
       {% include "includes/save-and-continue-button.html" %}
       {% set nameToBeRemoved = name %}
-      {% if not entity_number %} 
+      {% if not entity_number %}
         {% include "includes/remove-button.html" %}
       {% endif %}
     </form>

--- a/views/includes/page-templates/managing-officer-corporate.html
+++ b/views/includes/page-templates/managing-officer-corporate.html
@@ -1,3 +1,5 @@
+{% set managingOfficerPronoun = "it" %}
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
@@ -6,6 +8,10 @@
     <span class="govuk-caption-xl">Managing officer</span>
     <h1 class="govuk-heading-xl govuk-!-margin-0">{{ title }}</h1>
     <br> <p class="govuk-body">You can add more later.</p> <br>
+
+    {% if entity_number %}
+      {% include "includes/resigned-on-details-summary-new-mo.html" %}
+    {% endif %}
 
     <form class="form" method="post">
       {% include "includes/inputs/fields/name-input.html" %}
@@ -36,6 +42,12 @@
         name: "role_and_responsibilities",
         value: role_and_responsibilities
       }) }}
+
+      {% if entity_number %}
+        {% set dateText = "When did it become a managing officer for the overseas entity?" %}
+        {% include "includes/inputs/date/start-date-input.html" %}
+        {% include "includes/inputs/fields/is-still-a-managing-officer-input.html" %}
+      {% endif %}
 
       <h2 class="govuk-heading-l">Who can we contact about this managing officer?</h2>
 

--- a/views/includes/page-templates/managing-officer.html
+++ b/views/includes/page-templates/managing-officer.html
@@ -1,3 +1,5 @@
+{% set managingOfficerPronoun = "they" %}
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
@@ -5,6 +7,10 @@
     <span class="govuk-caption-xl">Managing officer</span>
     <h1 class="govuk-heading-xl govuk-!-margin-0">{{ title }}</h1>
     <br> <p class="govuk-body">You can add more later.</p> <br>
+
+    {% if entity_number %}
+      {% include "includes/resigned-on-details-summary-new-mo.html" %}
+    {% endif %}
 
     <form class="form" method="post">
       {% include "includes/inputs/fields/first-name-input.html" %}
@@ -88,6 +94,12 @@
         name: "role_and_responsibilities",
         value: role_and_responsibilities
       }) }}
+
+      {% if entity_number %}
+        {% set dateText = "When did they become a managing officer for the overseas entity?" %}
+        {% include "includes/inputs/date/start-date-input.html" %}
+        {% include "includes/inputs/fields/is-still-a-managing-officer-input.html" %}
+      {% endif %}
 
       {% set paragraphOne = '<p>We will not show the managing officer’s home address unless it is the same as their correspondence address. We’ll only show the month and year of their date of birth.</p>' %}
       {% include "includes/inset-text.html" %}

--- a/views/includes/resigned-on-details-summary-new-mo.html
+++ b/views/includes/resigned-on-details-summary-new-mo.html
@@ -1,0 +1,18 @@
+{% if managingOfficerPronoun == "they" %}
+  {% set moDetailsTense = "have" %}
+  {% set moSummaryTense = "are" %}
+{% else %}
+  {% set moDetailsTense = "had" %}
+  {% set moSummaryTense = "is" %}
+{% endif %}
+
+<details class="govuk-details" data-module="govuk-details" data-event-id="protected-personal-information-details" >
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">
+      How to complete this section if {{ managingOfficerPronoun }} {{ moSummaryTense }} no longer a managing officer
+    </span>
+  </summary>
+  <div class="govuk-details__text">
+    <p class="govuk-body">If {{ managingOfficerPronoun }} {{ moDetailsTense }} become and then stopped being a managing officer during this update period, you need to enter information that is correct as at the date it stopped being one.</p>
+  </div>
+</details>

--- a/views/update/review-beneficial-owner-gov.html
+++ b/views/update/review-beneficial-owner-gov.html
@@ -2,6 +2,7 @@
 {% import "includes/date-macros.html" as dateMacros %}
 
 {% set title = "Review the government or public authority (NOT LIVE)" %}
+{% set beneficialOwnerPronoun = "it" %}
 
 {% block pageTitle %}
   {% include "includes/page-title.html" %}
@@ -20,13 +21,12 @@
    <h1 class="govuk-heading-xl govuk-!-margin-0">Review the government or public authority</h1>
    <br> <p class="govuk-body">If you need to update this beneficial owner's information, you can change the answers here.</p>
 
-   {% include "includes/ceased-date-details-summary.html" %}
+   {% include "includes/ceased-date-details-summary-review-bo.html" %}
 
    <form class="form" method="post">
     <input type="hidden" name="id" value="{{ id }}" />
     <input type="hidden" name="ch_reference" value="{{ ch_reference }}" />
 
-    {% set beneficialOwnerPronoun = "it" %}
     {% include "includes/inputs/fields/name-input.html" %}
 
     {% include "includes/inputs/address/principal-address-input.html" %}

--- a/views/update/review-beneficial-owner-individual.html
+++ b/views/update/review-beneficial-owner-individual.html
@@ -2,6 +2,7 @@
 {% import "includes/date-macros.html" as dateMacros %}
 
 {% set title = "Review the individual beneficial owner (NOT LIVE)" %}
+{% set beneficialOwnerPronoun = "they" %}
 
 {% block pageTitle %}
   {% include "includes/page-title.html" %}
@@ -25,20 +26,9 @@
     <span class="govuk-caption-xl govuk-!-padding-bottom-1">{{ first_name }} {{ last_name }} - born {{ dob }}</span>
     <h1 class="govuk-heading-xl govuk-!-margin-0">Review the individual beneficial owner</h1>
     <br> <p class="govuk-body">If you need to update this beneficial owner's information, you can change the answers here.</p>
-    {{ govukInsetText({
-      html: "You'll need to <strong>enter their home address</strong>, and tell us if they're still a registrable beneficial owner."
-    }) }}
 
-    <details class="govuk-details" data-module="govuk-details" data-event-id="protected-personal-information-details" >
-      <summary class="govuk-details__summary">
-        <span class="govuk-details__summary-text">
-          How to complete this section for a ceased beneficial owner
-        </span>
-      </summary>
-      <div class="govuk-details__text">
-        <p class="govuk-body">If they are no longer a registrable beneficial owner, you need to make sure this information is correct as at the ceased date, and update it if needed.</p>
-      </div>
-    </details>
+    {% include "includes/ceased-date-details-summary-review-bo.html" %}
+
     <form method="post">
       <input type="hidden" name="id" value="{{ id }}" />
       <input type="hidden" name="ch_reference" value="{{ ch_reference }}" />
@@ -75,7 +65,6 @@
 
       {% include "includes/uneditable-start-date.html" %}
 
-      {% set beneficialOwnerPronoun = "they" %}
       {% include "includes/inputs/fields/is-still-a-beneficial-owner-input.html" %}
 
       {% set isBeneficialOwnerGov = false %}

--- a/views/update/review-beneficial-owner-other.html
+++ b/views/update/review-beneficial-owner-other.html
@@ -20,7 +20,7 @@
     <h1 class="govuk-heading-xl govuk-!-margin-0">{{ title }}</h1>
     <br> <p class="govuk-body">If you need to update this beneficial owner's information, you can change the answers here.</p>
 
-    {% include "includes/ceased-date-details-summary.html" %}
+    {% include "includes/ceased-date-details-summary-review-bo.html" %}
 
     <form class="form" method="post">
       {% include "includes/inputs/fields/name-input.html" %}


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/UAR-486

### Change description

- Added date inputs to capture the start date and resigned on dates for new Managing Officers added in the update journey. Does not impact adding new MOs in registration journey.

- Also added summary/dropdown text on ceased/resignedOn BOs/MOs.

- Add mapping of start_date and resigned_on information from form data into model.

- Create new ValidationChain specific to Update journey's add new MO routes, as we don't want to validate start_date and resigned_on date in Registration journey.

![Screenshot 2023-05-18 at 11 50 03](https://github.com/companieshouse/overseas-entities-web/assets/117734784/da514a74-f039-4de3-9aaf-95702a6aaed8)

![Screenshot 2023-05-18 at 11 50 45](https://github.com/companieshouse/overseas-entities-web/assets/117734784/3190a181-6622-41b4-8ddb-9f907de3e232)

![Screenshot 2023-05-18 at 11 50 54](https://github.com/companieshouse/overseas-entities-web/assets/117734784/c4e595e8-6aed-4cbc-89b4-590ce5ba9688)

### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
