### PR TITLE
UAR-473: Read nationaliites from comma separated list

### DIFF
--- a/src/utils/update/managing.officer.mapper.ts
+++ b/src/utils/update/managing.officer.mapper.ts
@@ -1,4 +1,4 @@
-import { isSameAddress, mapBOMOAddress, mapDateOfBirth, mapInputDate } from "./mapper.utils";
+import { isSameAddress, mapBOMOAddress, mapDateOfBirth, mapInputDate, splitNationalities } from "./mapper.utils";
 import { CompanyOfficer, FormerNameResource } from "@companieshouse/api-sdk-node/dist/services/company-officers/types";
 import { ManagingOfficerIndividual } from "../../model/managing.officer.model";
 import { ManagingOfficerCorporate } from "../../model/managing.officer.corporate.model";
@@ -69,13 +69,6 @@ export const splitNames = (officerName: string): string[] => {
       return names;
     }
   }
-};
-
-export const splitNationalities = (officerNationalities: string | undefined): string[] => {
-  if (!officerNationalities) {
-    return [""];
-  }
-  return officerNationalities.split(/\s*,\s*/).slice(0, 2);
 };
 
 export const getFormerNames = (formerNames?: FormerNameResource[]): string => {

--- a/src/utils/update/mapper.utils.ts
+++ b/src/utils/update/mapper.utils.ts
@@ -84,6 +84,13 @@ export const mapBOMOAddress: BOMOAddressMapTypes = (address: any) => {
   };
 };
 
+export const splitNationalities = (officerNationalities: string | undefined): string[] => {
+  if (!officerNationalities) {
+    return [""];
+  }
+  return officerNationalities.split(/\s*,\s*/).slice(0, 2);
+};
+
 type AddressMatches = {
   (address1: Address, address2?: Address): boolean;
   (address1: OfficeAddress, address2?: OfficeAddress): boolean;

--- a/src/utils/update/psc.to.beneficial.owner.type.mapper.ts
+++ b/src/utils/update/psc.to.beneficial.owner.type.mapper.ts
@@ -3,17 +3,19 @@ import { BeneficialOwnerGov } from "../../model/beneficial.owner.gov.model";
 import { BeneficialOwnerIndividual } from "../../model/beneficial.owner.individual.model";
 import { BeneficialOwnerOther } from "../../model/beneficial.owner.other.model";
 import { NatureOfControlType, yesNoResponse } from "../../model/data.types.model";
-import { mapBOMOAddress, isSameAddress, mapDateOfBirth, mapSelfLink, mapInputDate } from "./mapper.utils";
+import { mapBOMOAddress, isSameAddress, mapDateOfBirth, mapSelfLink, mapInputDate, splitNationalities } from "./mapper.utils";
 import { logger } from "../../utils/logger";
 
 export const mapPscToBeneficialOwnerTypeIndividual = (psc: CompanyPersonWithSignificantControl): BeneficialOwnerIndividual => {
   const service_address = mapBOMOAddress(psc.address);
+  const nationalities = splitNationalities(psc.nationality);
   const result: BeneficialOwnerIndividual = {
     id: psc.links?.self,
     ch_reference: mapSelfLink(psc.links?.self),
     first_name: psc.nameElements?.forename,
     last_name: psc.nameElements?.surname,
-    nationality: psc.nationality,
+    nationality: nationalities[0],
+    second_nationality: nationalities[1],
     date_of_birth: mapDateOfBirth(psc.dateOfBirth),
     is_service_address_same_as_usual_residential_address: isSameAddress(service_address, undefined) ? yesNoResponse.Yes : yesNoResponse.No,
     usual_residential_address: undefined,

--- a/test/utils/update/mocks.ts
+++ b/test/utils/update/mocks.ts
@@ -97,6 +97,47 @@ export const pscMock: CompanyPersonWithSignificantControl = {
   isSanctioned: true,
 };
 
+export const pscDualNationalityMock: CompanyPersonWithSignificantControl = {
+  nameElements: {
+    forename: "Random",
+    surname: "Person"
+  },
+  name: "Mr Random Notreal Person",
+  notifiedOn: "2016-04-06",
+  nationality: "British, Italian",
+  address: {
+    country: "country1",
+    postalCode: "CF14 3UZ",
+    premises: "Companies House",
+    locality: "Limavady",
+    addressLine1: "",
+    addressLine2: "",
+  },
+  countryOfResidence: "Wales",
+  dateOfBirth: {
+    day: "1",
+    month: "2",
+    year: "1900"
+  },
+  etag: '',
+  links: {
+    self: "company/OE111129/persons-of-significant-control/dhjsabcdjhvdjhdf",
+    statement: ""
+  },
+  identification: {
+    legalAuthority: "",
+    legalForm: "",
+    placeRegistered: "",
+    registrationNumber: ""
+  },
+  naturesOfControl: [
+    'ownership-of-shares-more-than-25-percent-registered-overseas-entity',
+    'ownership-of-shares-more-than-25-percent-as-trust-registered-overseas-entity',
+    'ownership-of-shares-more-than-25-percent-as-firm-registered-overseas-entity'
+  ],
+  isSanctioned: true,
+};
+
 export const managingOfficerMock: CompanyOfficer = {
   address: {
     premises: "1",

--- a/test/utils/update/psc.to.benficial.owner.type.mapper.spec.ts
+++ b/test/utils/update/psc.to.benficial.owner.type.mapper.spec.ts
@@ -2,7 +2,7 @@ import { CompanyPersonWithSignificantControl } from '@companieshouse/api-sdk-nod
 import { NatureOfControlType, yesNoResponse } from '../../../src/model/data.types.model';
 import { mapPscToBeneficialOwnerGov, mapPscToBeneficialOwnerOther, mapPscToBeneficialOwnerTypeIndividual } from '../../../src/utils/update/psc.to.beneficial.owner.type.mapper';
 import { PSC_BENEFICIAL_OWNER_MOCK_DATA } from '../../__mocks__/session.mock';
-import { pscMock } from './mocks';
+import { pscDualNationalityMock, pscMock } from './mocks';
 
 describe("Test Mapping person of significant control to beneficial owner type", () => {
 
@@ -43,6 +43,41 @@ describe("Test Mapping person of significant control to beneficial owner type", 
       last_name: pscMock.nameElements.surname,
       nationality: pscMock.nationality,
       second_nationality: undefined,
+      start_date: {
+        "day": "6",
+        "month": "4",
+        "year": "2016",
+      },
+      non_legal_firm_members_nature_of_control_types: [NatureOfControlType.OVER_25_PERCENT_OF_SHARES],
+      trustees_nature_of_control_types: [NatureOfControlType.OVER_25_PERCENT_OF_SHARES],
+      beneficial_owner_nature_of_control_types: [NatureOfControlType.OVER_25_PERCENT_OF_SHARES],
+      is_service_address_same_as_usual_residential_address: yesNoResponse.Yes,
+      service_address: {
+        line_1: pscMock.address.addressLine1,
+        line_2: pscMock.address.addressLine2,
+        postcode: pscMock.address.postalCode,
+        property_name_number: pscMock.address.premises,
+        town: pscMock.address.locality,
+        country: pscMock.address.country,
+      },
+      usual_residential_address: undefined,
+      is_on_sanctions_list: pscMock.isSanctioned ? 1 : 0
+    });
+  });
+
+  test('map person of significant control to beneficial owner individual with dual nationalities should return object', () => {
+    expect(mapPscToBeneficialOwnerTypeIndividual(pscDualNationalityMock)).toEqual({
+      id: "company/OE111129/persons-of-significant-control/dhjsabcdjhvdjhdf",
+      ch_reference: "dhjsabcdjhvdjhdf",
+      date_of_birth: {
+        day: pscMock.dateOfBirth.day,
+        month: pscMock.dateOfBirth.month,
+        year: pscMock.dateOfBirth.year
+      },
+      first_name: pscMock.nameElements.forename,
+      last_name: pscMock.nameElements.surname,
+      nationality: "British",
+      second_nationality: "Italian",
       start_date: {
         "day": "6",
         "month": "4",


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/UAR-473


### Change description
Nationality information for BO/MO  ‘nationality and second nationality’  is stored as a comma separated list in CHIPs. This needs to be transformed to be shown on UI.



### Work checklist

- [x] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
