### PR TITLE
[UAR-486]: Refactor MO Corporate ValidationChains, so ...contact_name_and_email_validations not added twice

### DIFF
--- a/src/validation/managing.officer.corporate.validation.ts
+++ b/src/validation/managing.officer.corporate.validation.ts
@@ -16,7 +16,7 @@ const contact_name_and_email_validations = [
   ...contact_email_validations
 ];
 
-export const managingOfficerCorporate = [
+const managingOfficerCorporateValidations = [
   body("name").not()
     .isEmpty({ ignore_whitespace: true }).withMessage(ErrorMessages.MANAGING_OFFICER_CORPORATE_NAME)
     .isLength({ max: 160 }).withMessage(ErrorMessages.MAX_NAME_LENGTH)
@@ -47,12 +47,15 @@ export const managingOfficerCorporate = [
     .not().isEmpty({ ignore_whitespace: true }).withMessage(ErrorMessages.ROLE_AND_RESPONSIBILITIES_CORPORATE)
     .isLength({ max: 256 }).withMessage(ErrorMessages.MAX_ROLE_LENGTH)
     .matches(VALID_CHARACTERS_FOR_TEXT_BOX).withMessage(ErrorMessages.ROLES_AND_RESPONSIBILITIES_INVALID_CHARACTERS),
+];
 
+export const managingOfficerCorporate = [
+  ...managingOfficerCorporateValidations,
   ...contact_name_and_email_validations
 ];
 
 export const updateManagingOfficerCorporate = [
-  ...managingOfficerCorporate,
+  ...managingOfficerCorporateValidations,
   ...start_date_validations,
   body("is_still_mo").not().isEmpty().withMessage(ErrorMessages.SELECT_IF_STILL_MANAGING_OFFICER),
   ...resigned_on_validations,


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/UAR-486

### Change description
Newly added `updateManagingOfficerCorporate` validation in UAR-486 was adding `...contact_name_and_email_validations` twice to the ValidationChain, by including `...managingOfficerCorporate.` which itself already added `...contact_name_and_email_validations`.

Solution: create a base ValidationChain called `managingOfficerCorporateValidations` that both `managingOfficerCorporate` and `updateManagingOfficerCorporate` includes, add `...contact_name_and_email_validations` separately.


### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
