### PR TITLE
UAR-151: Fix logic to split managing officer name by comma

### DIFF
--- a/src/utils/update/managing.officer.mapper.ts
+++ b/src/utils/update/managing.officer.mapper.ts
@@ -54,19 +54,8 @@ export const splitNames = (officerName: string): string[] => {
   if (officerName === undefined) {
     return ["", ""];
   } else {
-    const names = officerName.split(" ");
-    if (names.length > 2) {
-      let firstNames = "";
-      for (let loop = 0; loop < names.length - 1; loop++) {
-        firstNames += names[loop];
-        if (loop !== names.length - 1) {
-          firstNames += " ";
-        }
-      }
-      return [firstNames.trim(), names[names.length - 1].trim()];
-    } else {
-      return names;
-    }
+    const names = officerName.split(/\s*,\s*/);
+    return [names[1], names[0]];
   }
 };
 

--- a/test/utils/update/mocks.ts
+++ b/test/utils/update/mocks.ts
@@ -171,7 +171,7 @@ export const managingOfficerMock: CompanyOfficer = {
       appointments: ""
     }
   },
-  name: "Jimmy John Wabb",
+  name: "Wabb, Jimmy John",
   nationality: "country1",
   occupation: "occupation",
   officerRole: "role",
@@ -211,7 +211,7 @@ export const managingOfficerMockDualNationality: CompanyOfficer = {
       appointments: ""
     }
   },
-  name: "Jimmy John Wabb",
+  name: "Wabb, Jimmy John",
   nationality: "country1, country2",
   occupation: "occupation",
   officerRole: "role",


### PR DESCRIPTION
### JIRA link

[UAR-151](https://companieshouse.atlassian.net/browse/UAR-151)
[Comment detailing issue](https://companieshouse.atlassian.net/browse/UAR-151?focusedCommentId=213949)

### Change description

Splitting the surname and forenames of the individual MO by a comma instead of a space.

### Work checklist

- [x] Tests added where applicable
- [x] UI changes meet accessibility criteria

[UAR-151]: https://companieshouse.atlassian.net/browse/UAR-151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ