### PR TITLE
[ROE-2238]: Update conditional to cover entity_number = null 

### DIFF
--- a/src/utils/beneficial.owner.gov.ts
+++ b/src/utils/beneficial.owner.gov.ts
@@ -59,7 +59,7 @@ export const getBeneficialOwnerGovById = (req: Request, res: Response, next: Nex
     };
     const appData = getApplicationData(req.session);
 
-    if (EntityNumberKey in appData && !!appData[EntityNumberKey]) {
+    if (EntityNumberKey in appData && appData[EntityNumberKey]) {
       return res.render(templateName, addCeasedDateToTemplateOptions(templateOptions, appData, data));
     } else {
       return res.render(templateName, templateOptions);

--- a/src/utils/beneficial.owner.gov.ts
+++ b/src/utils/beneficial.owner.gov.ts
@@ -57,10 +57,9 @@ export const getBeneficialOwnerGovById = (req: Request, res: Response, next: Nex
       ...serviceAddress,
       [StartDateKey]: startDate
     };
-
     const appData = getApplicationData(req.session);
 
-    if (EntityNumberKey in appData && appData[EntityNumberKey] !== undefined) {
+    if (EntityNumberKey in appData && appData[EntityNumberKey] !== undefined && appData[EntityNumberKey] !== null) {
       return res.render(templateName, addCeasedDateToTemplateOptions(templateOptions, appData, data));
     } else {
       return res.render(templateName, templateOptions);

--- a/src/utils/beneficial.owner.gov.ts
+++ b/src/utils/beneficial.owner.gov.ts
@@ -59,7 +59,7 @@ export const getBeneficialOwnerGovById = (req: Request, res: Response, next: Nex
     };
     const appData = getApplicationData(req.session);
 
-    if (EntityNumberKey in appData && appData[EntityNumberKey] !== undefined && appData[EntityNumberKey] !== null) {
+    if (EntityNumberKey in appData && !!appData[EntityNumberKey]) {
       return res.render(templateName, addCeasedDateToTemplateOptions(templateOptions, appData, data));
     } else {
       return res.render(templateName, templateOptions);

--- a/src/utils/beneficial.owner.individual.ts
+++ b/src/utils/beneficial.owner.individual.ts
@@ -74,7 +74,7 @@ export const getBeneficialOwnerIndividualById = (req: Request, res: Response, ne
 
     const appData = getApplicationData(req.session);
 
-    if (EntityNumberKey in appData && !!appData[EntityNumberKey]) {
+    if (EntityNumberKey in appData && appData[EntityNumberKey]) {
       return res.render(templateName, addCeasedDateToTemplateOptions(templateOptions, appData, data));
     } else {
       return res.render(templateName, templateOptions);

--- a/src/utils/beneficial.owner.individual.ts
+++ b/src/utils/beneficial.owner.individual.ts
@@ -74,7 +74,7 @@ export const getBeneficialOwnerIndividualById = (req: Request, res: Response, ne
 
     const appData = getApplicationData(req.session);
 
-    if (EntityNumberKey in appData && appData[EntityNumberKey] !== undefined) {
+    if (EntityNumberKey in appData && !!appData[EntityNumberKey]) {
       return res.render(templateName, addCeasedDateToTemplateOptions(templateOptions, appData, data));
     } else {
       return res.render(templateName, templateOptions);

--- a/src/utils/beneficial.owner.other.ts
+++ b/src/utils/beneficial.owner.other.ts
@@ -62,7 +62,7 @@ export const getBeneficialOwnerOtherById = (req: Request, res: Response, next: N
 
     const appData = getApplicationData(req.session);
 
-    if (EntityNumberKey in appData && !!appData[EntityNumberKey]) {
+    if (EntityNumberKey in appData && appData[EntityNumberKey]) {
       return res.render(templateName, addCeasedDateToTemplateOptions(templateOptions, appData, data));
     } else {
       return res.render(templateName, templateOptions);

--- a/src/utils/beneficial.owner.other.ts
+++ b/src/utils/beneficial.owner.other.ts
@@ -62,7 +62,7 @@ export const getBeneficialOwnerOtherById = (req: Request, res: Response, next: N
 
     const appData = getApplicationData(req.session);
 
-    if (EntityNumberKey in appData && appData[EntityNumberKey] !== undefined) {
+    if (EntityNumberKey in appData && !!appData[EntityNumberKey]) {
       return res.render(templateName, addCeasedDateToTemplateOptions(templateOptions, appData, data));
     } else {
       return res.render(templateName, templateOptions);


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/ROE-2238


### Change description
With existing changes, whenever resuming a saved registration filling, the sdk endpoint `getOverseasEntity` returns `entity_number = null `as part of the resource.
And the existing conditional checks for setting up template options for the BO views, was considering this as an update journey and trying to setup Update specific data.

<img width="1361" alt="Screenshot 2023-06-02 at 15 12 16" src="https://github.com/companieshouse/overseas-entities-web/assets/117734784/86f74a5b-d133-461f-b4cf-5f97f5aaed2b">


### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
