### PR TITLE
UAR-616: Overseas entity email displayed to user

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "@companieshouse/api-sdk-node": "^2.0.76",
+        "@companieshouse/api-sdk-node": "^2.0.83",
         "@companieshouse/node-session-handler": "^4.1.9",
         "@companieshouse/structured-logging-node": "^1.0.8",
         "@companieshouse/web-security-node": "^2.0.3",
@@ -634,9 +634,9 @@
       }
     },
     "node_modules/@companieshouse/api-sdk-node": {
-      "version": "2.0.76",
-      "resolved": "https://registry.npmjs.org/@companieshouse/api-sdk-node/-/api-sdk-node-2.0.76.tgz",
-      "integrity": "sha512-GOLmwf/4igTwO1yKPrUqcdjXcA07lKGeOujRwA8TtM3QcBP4qK0TjNp1OOYKC4PInc9V5qAOm5d3dikVd6XGeQ==",
+      "version": "2.0.83",
+      "resolved": "https://registry.npmjs.org/@companieshouse/api-sdk-node/-/api-sdk-node-2.0.83.tgz",
+      "integrity": "sha512-n2H02VGnkUeN+HHeVm1Q0WAFbGkZlFJyBENPq+2QdZrn+LJMoW7znitCJCaF5fby82ShmnEP0+sqKBfWYMp8QQ==",
       "dependencies": {
         "axios": "^0.21.4",
         "camelcase-keys": "~6.2.2",
@@ -8160,9 +8160,9 @@
       "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ=="
     },
     "@companieshouse/api-sdk-node": {
-      "version": "2.0.76",
-      "resolved": "https://registry.npmjs.org/@companieshouse/api-sdk-node/-/api-sdk-node-2.0.76.tgz",
-      "integrity": "sha512-GOLmwf/4igTwO1yKPrUqcdjXcA07lKGeOujRwA8TtM3QcBP4qK0TjNp1OOYKC4PInc9V5qAOm5d3dikVd6XGeQ==",
+      "version": "2.0.83",
+      "resolved": "https://registry.npmjs.org/@companieshouse/api-sdk-node/-/api-sdk-node-2.0.83.tgz",
+      "integrity": "sha512-n2H02VGnkUeN+HHeVm1Q0WAFbGkZlFJyBENPq+2QdZrn+LJMoW7znitCJCaF5fby82ShmnEP0+sqKBfWYMp8QQ==",
       "requires": {
         "axios": "^0.21.4",
         "camelcase-keys": "~6.2.2",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "license": "MIT",
   "homepage": "https://github.com/companieshouse/overseas-entities-web#readme",
   "dependencies": {
-    "@companieshouse/api-sdk-node": "^2.0.76",
+    "@companieshouse/api-sdk-node": "^2.0.83",
     "@companieshouse/node-session-handler": "^4.1.9",
     "@companieshouse/structured-logging-node": "^1.0.8",
     "@companieshouse/web-security-node": "^2.0.3",

--- a/src/controllers/update/update.filing.date.controller.ts
+++ b/src/controllers/update/update.filing.date.controller.ts
@@ -1,21 +1,38 @@
 import { NextFunction, Request, Response } from "express";
 import { Session } from "@companieshouse/node-session-handler";
 
-import { logger } from "../../utils/logger";
+import { createAndLogErrorRequest, logger } from "../../utils/logger";
 import * as config from "../../config";
 import { isActiveFeature } from "../../utils/feature.flag";
-import { getApplicationData, setExtraData, mapFieldsToDataObject, mapDataObjectToFields } from "../../utils/application.data";
+import { getApplicationData, setExtraData, mapFieldsToDataObject, mapDataObjectToFields, addPrivateOverseasEntityDetailsToAppData } from "../../utils/application.data";
 import { postTransaction } from "../../service/transaction.service";
 import { createOverseasEntity, updateOverseasEntity } from "../../service/overseas.entities.service";
-import { OverseasEntityKey, Transactionkey, InputDateKeys } from '../../model/data.types.model';
+import { OverseasEntityKey, Transactionkey, InputDateKeys, EntityNumberKey } from '../../model/data.types.model';
 import { FilingDateKey, FilingDateKeys } from '../../model/date.model';
 import { ApplicationData } from "../../model/application.model";
+import { getPrivateOeDetails, hasRetrievedPrivateOeDetails } from "../../service/private.overseas.entity.details";
 
-export const get = (req: Request, res: Response, next: NextFunction) => {
+const fetchAndSavePrivateOeData = async (req: Request, appData: ApplicationData): Promise<void> => {
+  const companyNumber = appData[EntityNumberKey] as string;
+  const privateOeDetails = await getPrivateOeDetails(req, companyNumber);
+
+  if (!privateOeDetails) {
+    throw createAndLogErrorRequest(req, "Request failed retrieving private OE data");
+  }
+
+  addPrivateOverseasEntityDetailsToAppData(req.session, appData, privateOeDetails);
+};
+
+export const get = async(req: Request, res: Response, next: NextFunction) => {
   try {
     logger.debugRequest(req, `${req.method} ${req.route.path}`);
+
     const appData = getApplicationData(req.session);
     const filingDate = appData.update?.[FilingDateKey] ? mapDataObjectToFields(appData.update[FilingDateKey], FilingDateKeys, InputDateKeys) : {};
+
+    if (!hasRetrievedPrivateOeDetails(appData)) {
+      await fetchAndSavePrivateOeData(req, appData);
+    }
 
     return res.render(config.UPDATE_FILING_DATE_PAGE, {
       backLinkUrl: config.UPDATE_OVERSEAS_ENTITY_CONFIRM_URL,

--- a/src/service/private.overseas.entity.details.ts
+++ b/src/service/private.overseas.entity.details.ts
@@ -1,0 +1,36 @@
+import { Session } from "@companieshouse/node-session-handler";
+import { Request } from "express";
+import { makeApiCallWithRetry } from "./retry.handler.service";
+import { createAndLogErrorRequest, logger } from "../utils/logger";
+import { OverseasEntityExtraDetails } from "@companieshouse/api-sdk-node/dist/services/overseas-entities/types";
+import { ApplicationData } from "../model/application.model";
+
+export const hasRetrievedPrivateOeDetails = (appData: ApplicationData): boolean =>
+  !!appData.entity?.email;
+
+export const getPrivateOeDetails = async (
+  req: Request,
+  oeNumber: string,
+): Promise<OverseasEntityExtraDetails | undefined> => {
+  const response = await makeApiCallWithRetry(
+    "overseasEntity",
+    "getOverseasEntityDetails",
+    req,
+    req.session as Session,
+    oeNumber,
+  );
+
+  if (response.httpStatusCode !== 200 && response.httpStatusCode !== 404) {
+    const errorMsg = `Something went wrong fetching company details = ${JSON.stringify(response)}`;
+    throw createAndLogErrorRequest(req, errorMsg);
+  }
+
+  if (response.httpStatusCode === 404) {
+    logger.debugRequest(req, `No company data found for ${oeNumber}`);
+    return undefined;
+  }
+
+  const infoMsg = `OE NUMBER ID: ${oeNumber}`;
+  logger.debugRequest(req, `Overseas Entity Data Retrieved - ${infoMsg}`);
+  return response.resource;
+};

--- a/src/utils/application.data.ts
+++ b/src/utils/application.data.ts
@@ -15,6 +15,8 @@ import { BeneficialOwnerOtherKey } from '../model/beneficial.owner.other.model';
 import { ManagingOfficerCorporateKey } from '../model/managing.officer.corporate.model';
 import { ManagingOfficerKey } from '../model/managing.officer.model';
 import { PARAM_BENEFICIAL_OWNER_GOV, PARAM_BENEFICIAL_OWNER_INDIVIDUAL, PARAM_BENEFICIAL_OWNER_OTHER, PARAM_MANAGING_OFFICER_CORPORATE, PARAM_MANAGING_OFFICER_INDIVIDUAL } from '../config';
+import { OverseasEntityExtraDetails } from '@companieshouse/api-sdk-node/dist/services/overseas-entities';
+import { EntityKey } from '../model/entity.model';
 
 export const getApplicationData = (session: Session | undefined): ApplicationData => {
   return session?.getExtraData(APPLICATION_DATA_KEY) || {} as ApplicationData;
@@ -59,6 +61,13 @@ export const checkBOsDetailsEntered = (appData: ApplicationData): boolean => {
 
 export const checkMOsDetailsEntered = (appData: ApplicationData): boolean => {
   return Boolean( appData[ManagingOfficerKey]?.length || appData[ManagingOfficerCorporateKey]?.length ) ;
+};
+
+export const addPrivateOverseasEntityDetailsToAppData = (session: Session | undefined, appData: ApplicationData, privateDetails: OverseasEntityExtraDetails) => {
+  if (appData[EntityKey]) {
+    appData[EntityKey].email = privateDetails.email_address;
+  }
+  setExtraData(session, appData);
 };
 
 export const findBoOrMo = (appData: ApplicationData, boMoType: string, id: string) => {

--- a/test/controllers/update/update.filing.date.controller.spec.ts
+++ b/test/controllers/update/update.filing.date.controller.spec.ts
@@ -6,6 +6,7 @@ jest.mock('../../../src/middleware/service.availability.middleware');
 jest.mock('../../../src/utils/application.data');
 jest.mock('../../../src/service/transaction.service');
 jest.mock('../../../src/service/overseas.entities.service');
+jest.mock("../../../src/service/private.overseas.entity.details");
 jest.mock("../../../src/utils/feature.flag" );
 jest.mock('../../../src/middleware/navigation/update/has.overseas.entity.middleware');
 
@@ -19,7 +20,8 @@ import { companyAuthentication } from "../../../src/middleware/company.authentic
 import { serviceAvailabilityMiddleware } from "../../../src/middleware/service.availability.middleware";
 import { createOverseasEntity, updateOverseasEntity } from "../../../src/service/overseas.entities.service";
 import { postTransaction } from "../../../src/service/transaction.service";
-import { getApplicationData } from "../../../src/utils/application.data";
+import { getPrivateOeDetails, hasRetrievedPrivateOeDetails } from "../../../src/service/private.overseas.entity.details";
+import { getApplicationData, addPrivateOverseasEntityDetailsToAppData } from "../../../src/utils/application.data";
 import { OverseasEntityKey, Transactionkey } from '../../../src/model/data.types.model';
 import { isActiveFeature } from "../../../src/utils/feature.flag";
 import { hasOverseasEntity } from "../../../src/middleware/navigation/update/has.overseas.entity.middleware";
@@ -56,6 +58,8 @@ const mockCreateOverseasEntity = createOverseasEntity as jest.Mock;
 mockCreateOverseasEntity.mockReturnValue( OVERSEAS_ENTITY_ID );
 
 const mockUpdateOverseasEntity = updateOverseasEntity as jest.Mock;
+const mockGetPrivateOeDetails = getPrivateOeDetails as jest.Mock;
+const mockHasRetrievedPrivateOeDetails = hasRetrievedPrivateOeDetails as jest.Mock;
 
 const mockGetApplicationData = getApplicationData as jest.Mock;
 mockGetApplicationData.mockReturnValue( APPLICATION_DATA_MOCK );
@@ -72,14 +76,20 @@ mockServiceAvailabilityMiddleware.mockImplementation((req: Request, res: Respons
 const mockIsActiveFeature = isActiveFeature as jest.Mock;
 mockIsActiveFeature.mockReturnValue(true);
 
+const mockAddPrivateOverseasEntityDetailsToAppData = addPrivateOverseasEntityDetailsToAppData as jest.Mock;
+
 describe("Update Filing Date controller", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockGetPrivateOeDetails.mockReset();
+    mockAddPrivateOverseasEntityDetailsToAppData.mockReset();
   });
 
   describe("GET tests", () => {
-    test(`renders the ${config.UPDATE_FILING_DATE_PAGE} page`, async () => {
+    test('renders the update-filing-date page', async () => {
+      mockGetPrivateOeDetails.mockReturnValueOnce({ email_address: 'private@overseasentities.test' });
+
       const resp = await request(app).get(config.UPDATE_FILING_DATE_URL);
 
       expect(resp.status).toEqual(200);
@@ -89,9 +99,11 @@ describe("Update Filing Date controller", () => {
       expect(resp.text).not.toContain(PAGE_TITLE_ERROR);
     });
 
-    test(`renders the ${config.UPDATE_FILING_DATE_PAGE} page with no update session data`, async () => {
-      const mockData = { ...UPDATE_ENTITY_BODY_OBJECT_MOCK_WITH_ADDRESS };
+    test('renders the update-filing-date page with no update session data', async () => {
+      const mockData = { ...UPDATE_ENTITY_BODY_OBJECT_MOCK_WITH_ADDRESS, entity_number: 'OE111129' };
       mockGetApplicationData.mockReturnValueOnce(mockData);
+      mockGetPrivateOeDetails.mockReturnValueOnce({ email_address: 'private@overseasentities.test' });
+
       const resp = await request(app).get(config.UPDATE_FILING_DATE_URL);
 
       expect(resp.status).toEqual(200);
@@ -101,9 +113,11 @@ describe("Update Filing Date controller", () => {
       expect(resp.text).not.toContain(PAGE_TITLE_ERROR);
     });
 
-    test(`renders the ${config.UPDATE_FILING_DATE_PAGE} page with update session data`, async () => {
+    test('renders the update-filing-date page with update session data', async () => {
       const mockData = { ...APPLICATION_DATA_MOCK };
       mockGetApplicationData.mockReturnValueOnce(mockData);
+      mockGetPrivateOeDetails.mockReturnValueOnce({ email_address: 'private@overseasentities.test' });
+
       const resp = await request(app).get(config.UPDATE_FILING_DATE_URL);
 
       expect(resp.status).toEqual(200);
@@ -111,6 +125,39 @@ describe("Update Filing Date controller", () => {
       expect(resp.text).toContain(BACK_LINK_FOR_UPDATE_FILING_DATE);
       expect(resp.text).toContain(saveAndContinueButtonText);
       expect(resp.text).not.toContain(PAGE_TITLE_ERROR);
+    });
+
+    test('saves private overseas entity data to app data if it does not exist', async () => {
+      const mockData = { ...APPLICATION_DATA_MOCK };
+      const mockPrivateOeDetails = { email_address: 'private@overseasentities.test' };
+      mockGetApplicationData.mockReturnValueOnce(mockData);
+      mockHasRetrievedPrivateOeDetails.mockReturnValueOnce(false);
+      mockGetPrivateOeDetails.mockReturnValueOnce({ email_address: 'private@overseasentities.test' });
+
+      const resp = await request(app).get(config.UPDATE_FILING_DATE_URL);
+
+      expect(resp.status).toEqual(200);
+      expect(resp.text).toContain("Date of the update statement (NOT LIVE)");
+      expect(resp.text).toContain(BACK_LINK_FOR_UPDATE_FILING_DATE);
+      expect(resp.text).toContain(saveAndContinueButtonText);
+      expect(resp.text).not.toContain(PAGE_TITLE_ERROR);
+      expect(mockAddPrivateOverseasEntityDetailsToAppData).toHaveBeenCalledWith(undefined, mockData, mockPrivateOeDetails);
+    });
+
+    test('does not fetch private overseas entity data to app data if already exists', async () => {
+      const mockData = { ...APPLICATION_DATA_MOCK };
+      mockGetApplicationData.mockReturnValueOnce(mockData);
+      mockHasRetrievedPrivateOeDetails.mockReturnValueOnce(true);
+
+      const resp = await request(app).get(config.UPDATE_FILING_DATE_URL);
+
+      expect(resp.status).toEqual(200);
+      expect(resp.text).toContain("Date of the update statement (NOT LIVE)");
+      expect(resp.text).toContain(BACK_LINK_FOR_UPDATE_FILING_DATE);
+      expect(resp.text).toContain(saveAndContinueButtonText);
+      expect(resp.text).not.toContain(PAGE_TITLE_ERROR);
+      expect(mockAddPrivateOverseasEntityDetailsToAppData).not.toHaveBeenCalled();
+      expect(mockGetPrivateOeDetails).not.toHaveBeenCalled();
     });
 
     test('catch error when rendering the page', async () => {

--- a/test/service/private.overseas.entity.details.spec.ts
+++ b/test/service/private.overseas.entity.details.spec.ts
@@ -1,0 +1,83 @@
+jest.mock("../../src/utils/logger");
+jest.mock("../../src/utils/application.data");
+jest.mock("../../src/service/retry.handler.service");
+
+import { Request } from "express";
+
+import { createAndLogErrorRequest } from "../../src/utils/logger";
+import { makeApiCallWithRetry } from "../../src/service/retry.handler.service";
+import { ERROR, getSessionRequestWithExtraData } from "../__mocks__/session.mock";
+import { getPrivateOeDetails, hasRetrievedPrivateOeDetails } from "../../src/service/private.overseas.entity.details";
+
+const mockCreateAndLogErrorRequest = createAndLogErrorRequest as jest.Mock;
+mockCreateAndLogErrorRequest.mockReturnValue(ERROR);
+
+const mockMakeApiCallWithRetry = makeApiCallWithRetry as jest.Mock;
+
+const session = getSessionRequestWithExtraData();
+const req = { session } as Request;
+
+const serviceName = 'overseasEntity';
+const functionName = 'getOverseasEntityDetails';
+const companyNumber = 'OE111129';
+const privateOeDetails = { email_address: 'private@overseasentities.test' };
+
+describe(`Get private overseas entity details service suite`, () => {
+  beforeEach (() => {
+    jest.clearAllMocks();
+  });
+
+  test('hasRetrievedPrivateOeDetails should return true when appData contains entity email address', () => {
+    const appData = { entity: { email: 'private@overseasentities.test' } };
+
+    const result = hasRetrievedPrivateOeDetails(appData);
+
+    expect(result).toBe(true);
+  });
+
+  test.each([
+    ['no entity exists', undefined ],
+    ['no email exists', {} ],
+    ['email is empty', { email: '' } ],
+  ])('hasRetrievedPrivateOeDetails should return false when %p', (_, entity) => {
+    const appData = { entity };
+
+    const result = hasRetrievedPrivateOeDetails(appData);
+
+    expect(result).toBe(false);
+  });
+
+  test('getPrivateOeDetails should return private OE details from response when api response status is 200', async () => {
+    const mockResponse = { httpStatusCode: 200, resource: privateOeDetails };
+
+    mockMakeApiCallWithRetry.mockResolvedValueOnce(mockResponse);
+
+    const response = await getPrivateOeDetails(req, companyNumber);
+
+    expect(mockMakeApiCallWithRetry).toBeCalledWith(serviceName, functionName, req, session, companyNumber);
+    expect(mockCreateAndLogErrorRequest).not.toHaveBeenCalled();
+    expect(response).toEqual(privateOeDetails);
+  });
+
+  test('getPrivateOeDetails should return undefined when api response status is 404', async () => {
+    const mockResponse = { httpStatusCode: 404, resource: privateOeDetails };
+
+    mockMakeApiCallWithRetry.mockResolvedValueOnce(mockResponse);
+
+    const response = await getPrivateOeDetails(req, companyNumber);
+
+    expect(mockMakeApiCallWithRetry).toBeCalledWith(serviceName, functionName, req, session, companyNumber);
+    expect(mockCreateAndLogErrorRequest).not.toHaveBeenCalled();
+    expect(response).toEqual(undefined);
+  });
+
+  test('getPrivateOeDetails should throw when api response status is 500', async () => {
+    const mockResponse = { httpStatusCode: 500, resource: {} };
+
+    mockMakeApiCallWithRetry.mockResolvedValueOnce( mockResponse);
+
+    await expect(getPrivateOeDetails(req, companyNumber)).rejects.toThrow(ERROR);
+
+    expect(mockCreateAndLogErrorRequest).toHaveBeenCalled();
+  });
+});

--- a/test/utils/application.data.spec.ts
+++ b/test/utils/application.data.spec.ts
@@ -13,7 +13,8 @@ import {
   checkBOsDetailsEntered,
   checkMOsDetailsEntered,
   findBoOrMo,
-  checkGivenBoOrMoDetailsExist
+  checkGivenBoOrMoDetailsExist,
+  addPrivateOverseasEntityDetailsToAppData,
 } from "../../src/utils/application.data";
 import {
   APPLICATION_DATA_UPDATE_BO_MOCK,
@@ -340,5 +341,25 @@ describe("Application data utils", () => {
     req.session = session;
     const bo: BeneficialOwnerGov = getFromApplicationData(req, BeneficialOwnerGovKey, undefined as unknown as string, false);
     expect(bo).toBeUndefined;
+  });
+
+  test('addPrivateOverseasEntityDetailsToAppData should store the private details into the session', () => {
+    const appData = { entity: {} };
+    const session = getSessionRequestWithExtraData(appData);
+
+    addPrivateOverseasEntityDetailsToAppData(session, appData, { email_address: 'private@overseasentities.test' });
+
+    const resultAppData = getApplicationData(session);
+    expect(resultAppData.entity?.email).toBe('private@overseasentities.test');
+  });
+
+  test('addPrivateOverseasEntityDetailsToAppData should leave appData unchanged if no entity present in appData', () => {
+    const appData = { entity_number: 'OE123444' };
+    const session = getSessionRequestWithExtraData(appData);
+
+    addPrivateOverseasEntityDetailsToAppData(session, appData, { email_address: 'private@overseasentities.test' });
+
+    const resultAppData = getApplicationData(session);
+    expect(resultAppData).toEqual(appData);
   });
 });

--- a/views/update/update-review-overseas-entity-information.html
+++ b/views/update/update-review-overseas-entity-information.html
@@ -15,13 +15,9 @@
   <div class="govuk-grid-column-two-thirds">
     <span class="govuk-caption-xl govuk-!-padding-bottom-1">{{ appData.entity_name }} - {{ appData.entity_number }}</span>
     <h1 class="govuk-heading-xl">You're about to review overseas entity information</h1>
+    <p class="govuk-body">We'll show you the information we hold about the overseas entity.</p>
+    <p class="govuk-body govuk-!-margin-bottom-7">You'll need to check the information is correct, and update it if needed.</p>
     <form method="post">
-      <p class="govuk-body">We'll show you the information we hold about the overseas entity.</p>
-      <p class="govuk-body">You'll need to:</p>
-      <ul class="govuk-list govuk-list--bullet">
-        <li>check the information is correct, and update it if needed</li>
-        <li>enter the overseas entity's email address</li>
-      </ul>
       {% include "includes/continue-button.html" %}
     </form>
   </div>


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/UAR-616

### Change description

- Added API call to retrieve Private OE details
- Populated email field on OE Query page

### Associated PRs:
- https://github.com/companieshouse/overseas-entities-api/pull/277
- https://github.com/companieshouse/api-sdk-node/pull/571

TODO: Should a failure to retrieve private details result in a Service Unavailable error or a Company Not Found validation error (which is already there for a failure to get `companyProfile` info)?

### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
