### PR TITLE
UAR-616: Temporarily revert API call to retrieve private OE details

### DIFF
--- a/test/controllers/update/update.filing.date.controller.spec.ts
+++ b/test/controllers/update/update.filing.date.controller.spec.ts
@@ -127,23 +127,6 @@ describe("Update Filing Date controller", () => {
       expect(resp.text).not.toContain(PAGE_TITLE_ERROR);
     });
 
-    test('saves private overseas entity data to app data if it does not exist', async () => {
-      const mockData = { ...APPLICATION_DATA_MOCK };
-      const mockPrivateOeDetails = { email_address: 'private@overseasentities.test' };
-      mockGetApplicationData.mockReturnValueOnce(mockData);
-      mockHasRetrievedPrivateOeDetails.mockReturnValueOnce(false);
-      mockGetPrivateOeDetails.mockReturnValueOnce({ email_address: 'private@overseasentities.test' });
-
-      const resp = await request(app).get(config.UPDATE_FILING_DATE_URL);
-
-      expect(resp.status).toEqual(200);
-      expect(resp.text).toContain("Date of the update statement (NOT LIVE)");
-      expect(resp.text).toContain(BACK_LINK_FOR_UPDATE_FILING_DATE);
-      expect(resp.text).toContain(saveAndContinueButtonText);
-      expect(resp.text).not.toContain(PAGE_TITLE_ERROR);
-      expect(mockAddPrivateOverseasEntityDetailsToAppData).toHaveBeenCalledWith(undefined, mockData, mockPrivateOeDetails);
-    });
-
     test('does not fetch private overseas entity data to app data if already exists', async () => {
       const mockData = { ...APPLICATION_DATA_MOCK };
       mockGetApplicationData.mockReturnValueOnce(mockData);


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/UAR-616

### Change description

Automated tests are failing/blocked due to setup not populating CHIPS. Temporarily removing call to fetch private data so validation doesn't fail.

### Work checklist

- [x] Tests added where applicable
- [x] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
