### PR TITLE
ROE-2274 Wording of entity email address key wrong order

### DIFF
--- a/views/includes/entity.html
+++ b/views/includes/entity.html
@@ -96,7 +96,7 @@
       },
       {
         key: {
-          text: "Email address at the overseas entity should we send communications to"
+          text: "Email address at the overseas entity we should send communications to"
         },
         value: {
           text: appData.entity.email


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/ROE-2274


### Change description

Word order of email address key text did not read correctly, so updated it with the wording in ac.

### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
