### PR TITLE
UAR-616: Reinstate web API call to fetch private OE details

### DIFF
--- a/src/service/private.overseas.entity.details.ts
+++ b/src/service/private.overseas.entity.details.ts
@@ -10,27 +10,26 @@ export const hasRetrievedPrivateOeDetails = (appData: ApplicationData): boolean 
 
 export const getPrivateOeDetails = async (
   req: Request,
-  oeNumber: string,
-): Promise<OverseasEntityExtraDetails | undefined> => {
+  overseasEntityId: string,
+): Promise<OverseasEntityExtraDetails> => {
   const response = await makeApiCallWithRetry(
     "overseasEntity",
     "getOverseasEntityDetails",
     req,
     req.session as Session,
-    oeNumber,
+    overseasEntityId,
   );
 
-  if (response.httpStatusCode !== 200 && response.httpStatusCode !== 404) {
-    const errorMsg = `Something went wrong fetching company details = ${JSON.stringify(response)}`;
-    throw createAndLogErrorRequest(req, errorMsg);
+  const status = response.httpStatusCode;
+
+  if (status !== 200 && status !== 404) {
+    throw createAndLogErrorRequest(req, `Something went wrong fetching private overseas entity data for entity ${overseasEntityId} - ${JSON.stringify(response)}`);
   }
 
-  if (response.httpStatusCode === 404) {
-    logger.debugRequest(req, `No company data found for ${oeNumber}`);
-    return undefined;
+  if (status === 404 || !response.resource) {
+    throw createAndLogErrorRequest(req, `No private overseas entity data found for entity ${overseasEntityId}`);
   }
 
-  const infoMsg = `OE NUMBER ID: ${oeNumber}`;
-  logger.debugRequest(req, `Overseas Entity Data Retrieved - ${infoMsg}`);
+  logger.debugRequest(req, `Private overseas entity data retrieved for entity ${overseasEntityId}`);
   return response.resource;
 };

--- a/test/controllers/update/update.filing.date.controller.spec.ts
+++ b/test/controllers/update/update.filing.date.controller.spec.ts
@@ -127,6 +127,23 @@ describe("Update Filing Date controller", () => {
       expect(resp.text).not.toContain(PAGE_TITLE_ERROR);
     });
 
+    test('saves private overseas entity data to app data if it does not exist', async () => {
+      const mockData = { ...APPLICATION_DATA_MOCK };
+      const mockPrivateOeDetails = { email_address: 'private@overseasentities.test' };
+      mockGetApplicationData.mockReturnValueOnce(mockData);
+      mockHasRetrievedPrivateOeDetails.mockReturnValueOnce(false);
+      mockGetPrivateOeDetails.mockReturnValueOnce({ email_address: 'private@overseasentities.test' });
+
+      const resp = await request(app).get(config.UPDATE_FILING_DATE_URL);
+
+      expect(resp.status).toEqual(200);
+      expect(resp.text).toContain("Date of the update statement");
+      expect(resp.text).toContain(BACK_LINK_FOR_UPDATE_FILING_DATE);
+      expect(resp.text).toContain(saveAndContinueButtonText);
+      expect(resp.text).not.toContain(PAGE_TITLE_ERROR);
+      expect(mockAddPrivateOverseasEntityDetailsToAppData).toHaveBeenCalledWith(undefined, mockData, mockPrivateOeDetails);
+    });
+
     test('does not fetch private overseas entity data to app data if already exists', async () => {
       const mockData = { ...APPLICATION_DATA_MOCK };
       mockGetApplicationData.mockReturnValueOnce(mockData);

--- a/test/service/private.overseas.entity.details.spec.ts
+++ b/test/service/private.overseas.entity.details.spec.ts
@@ -19,7 +19,7 @@ const req = { session } as Request;
 
 const serviceName = 'overseasEntity';
 const functionName = 'getOverseasEntityDetails';
-const companyNumber = 'OE111129';
+const overseasEntityId = '123123-123123-1231-123';
 const privateOeDetails = { email_address: 'private@overseasentities.test' };
 
 describe(`Get private overseas entity details service suite`, () => {
@@ -52,23 +52,31 @@ describe(`Get private overseas entity details service suite`, () => {
 
     mockMakeApiCallWithRetry.mockResolvedValueOnce(mockResponse);
 
-    const response = await getPrivateOeDetails(req, companyNumber);
+    const response = await getPrivateOeDetails(req, overseasEntityId);
 
-    expect(mockMakeApiCallWithRetry).toBeCalledWith(serviceName, functionName, req, session, companyNumber);
+    expect(mockMakeApiCallWithRetry).toBeCalledWith(serviceName, functionName, req, session, overseasEntityId);
     expect(mockCreateAndLogErrorRequest).not.toHaveBeenCalled();
     expect(response).toEqual(privateOeDetails);
   });
 
-  test('getPrivateOeDetails should return undefined when api response status is 404', async () => {
+  test('getPrivateOeDetails should throw an error when no data in response and status is 200', async () => {
+    const mockResponse = { httpStatusCode: 200 };
+
+    mockMakeApiCallWithRetry.mockResolvedValueOnce(mockResponse);
+
+    await expect(getPrivateOeDetails(req, overseasEntityId)).rejects.toThrow(ERROR);
+
+    expect(mockCreateAndLogErrorRequest).toHaveBeenCalled();
+  });
+
+  test('getPrivateOeDetails should throw when api response status is 404', async () => {
     const mockResponse = { httpStatusCode: 404, resource: privateOeDetails };
 
     mockMakeApiCallWithRetry.mockResolvedValueOnce(mockResponse);
 
-    const response = await getPrivateOeDetails(req, companyNumber);
+    await expect(getPrivateOeDetails(req, overseasEntityId)).rejects.toThrow(ERROR);
 
-    expect(mockMakeApiCallWithRetry).toBeCalledWith(serviceName, functionName, req, session, companyNumber);
-    expect(mockCreateAndLogErrorRequest).not.toHaveBeenCalled();
-    expect(response).toEqual(undefined);
+    expect(mockCreateAndLogErrorRequest).toHaveBeenCalled();
   });
 
   test('getPrivateOeDetails should throw when api response status is 500', async () => {
@@ -76,7 +84,7 @@ describe(`Get private overseas entity details service suite`, () => {
 
     mockMakeApiCallWithRetry.mockResolvedValueOnce( mockResponse);
 
-    await expect(getPrivateOeDetails(req, companyNumber)).rejects.toThrow(ERROR);
+    await expect(getPrivateOeDetails(req, overseasEntityId)).rejects.toThrow(ERROR);
 
     expect(mockCreateAndLogErrorRequest).toHaveBeenCalled();
   });


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/UAR-616

### Change description

Essentially a revert of:
- https://github.com/companieshouse/overseas-entities-web/pull/921

Should only be merged after API PR 285 is complete. This updates how the API fetches the data, enabling automated testing.
- https://github.com/companieshouse/overseas-entities-api/pull/285

### Work checklist

- [x] Tests added where applicable
- [x] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
