### PR TITLE
Fix/uar 775 address displaying incorrectly

### DIFF
--- a/src/controllers/update/update.review.beneficial.owner.gov.ts
+++ b/src/controllers/update/update.review.beneficial.owner.gov.ts
@@ -22,7 +22,13 @@ export const get = (req: Request, res: Response) => {
   if (appData?.beneficial_owners_government_or_public_authority){
     dataToReview = appData?.beneficial_owners_government_or_public_authority[Number(index)];
     principalAddress = (dataToReview) ? mapDataObjectToFields(dataToReview[PrincipalAddressKey], PrincipalAddressKeys, AddressKeys) : {};
-    serviceAddress = (dataToReview) ? mapDataObjectToFields(dataToReview[ServiceAddressKey], ServiceAddressKeys, AddressKeys) : {};
+    let undefinedPrincipalAddressProperties;
+    if (principalAddress !== undefined) {
+      undefinedPrincipalAddressProperties = Object.values(principalAddress).every(value => value === undefined);
+    }
+    if (!undefinedPrincipalAddressProperties) {
+      serviceAddress = (dataToReview) ? mapDataObjectToFields(dataToReview[ServiceAddressKey], ServiceAddressKeys, AddressKeys) : {};
+    }
   }
 
   const templateOptions = {

--- a/src/controllers/update/update.review.beneficial.owner.other.ts
+++ b/src/controllers/update/update.review.beneficial.owner.other.ts
@@ -33,7 +33,13 @@ export const get = (req: Request, res: Response, next: NextFunction) => {
     if (appData?.beneficial_owners_corporate){
       dataToReview = appData?.beneficial_owners_corporate[Number(index)];
       principalAddress = (dataToReview) ? mapDataObjectToFields(dataToReview[PrincipalAddressKey], PrincipalAddressKeys, AddressKeys) : {};
-      serviceAddress = (dataToReview) ? mapDataObjectToFields(dataToReview[ServiceAddressKey], ServiceAddressKeys, AddressKeys) : {};
+      let undefinedPrincipalAddressProperties;
+      if (principalAddress !== undefined) {
+        undefinedPrincipalAddressProperties = Object.values(principalAddress).every(value => value === undefined);
+      }
+      if (!undefinedPrincipalAddressProperties) {
+        serviceAddress = (dataToReview) ? mapDataObjectToFields(dataToReview[ServiceAddressKey], ServiceAddressKeys, AddressKeys) : {};
+      }
     }
 
     const templateOptions = {

--- a/src/controllers/update/update.review.managing.officer.corporate.controller.ts
+++ b/src/controllers/update/update.review.managing.officer.corporate.controller.ts
@@ -27,7 +27,13 @@ export const get = (req: Request, res: Response, next: NextFunction) => {
     if (appData?.managing_officers_corporate){
       dataToReview = appData?.managing_officers_corporate[Number(index)];
       principalAddress = (dataToReview) ? mapDataObjectToFields(dataToReview[PrincipalAddressKey], PrincipalAddressKeys, AddressKeys) : {};
-      serviceAddress = (dataToReview) ? mapDataObjectToFields(dataToReview[ServiceAddressKey], ServiceAddressKeys, AddressKeys) : {};
+      let undefinedPrincipalAddressProperties;
+      if (principalAddress !== undefined) {
+        undefinedPrincipalAddressProperties = Object.values(principalAddress).every(value => value === undefined);
+      }
+      if (!undefinedPrincipalAddressProperties) {
+        serviceAddress = (dataToReview) ? mapDataObjectToFields(dataToReview[ServiceAddressKey], ServiceAddressKeys, AddressKeys) : {};
+      }
     }
 
     const templateOptions = {

--- a/views/includes/inputs/address/principal-address-input.html
+++ b/views/includes/inputs/address/principal-address-input.html
@@ -90,69 +90,69 @@
 {% endset -%}
 
 {% if principal_address | length %}
-{{ govukRadios({
-  errorMessage: errors.is_service_address_same_as_principal_address if errors,
-  classes: "govuk-radios",
-  idPrefix: "is_service_address_same_as_principal_address",
-  name: "is_service_address_same_as_principal_address",
-  fieldset: {
-    legend: {
-      text: "Is the correspondence address the same as the principal or registered office address?",
-      isPageHeading: false,
-      classes: "govuk-fieldset__legend--m"
-    }
-  },
-  items: [
-    {
-      value: 1,
-      text: "Yes",
-      checked: is_service_address_same_as_principal_address == 1,
-      attributes: {
-        "data-event-id": "is-service-address-same-as-principal-address-yes-radio-option"
+  {{ govukRadios({
+    errorMessage: errors.is_service_address_same_as_principal_address if errors,
+    classes: "govuk-radios",
+    idPrefix: "is_service_address_same_as_principal_address",
+    name: "is_service_address_same_as_principal_address",
+    fieldset: {
+      legend: {
+        text: "Is the correspondence address the same as the principal or registered office address?",
+        isPageHeading: false,
+        classes: "govuk-fieldset__legend--m"
       }
-    },   {
-      value: 0,
-      text: "No",
-      checked: is_service_address_same_as_principal_address == 0,
-      attributes: {
-        "data-event-id": "is-service-address-same-as-principal-address-no-radio-option"
-      },
-      conditional: {
-        html: serviceAddressHtml
+    },
+    items: [
+      {
+        value: 1,
+        text: "Yes",
+        checked: is_service_address_same_as_principal_address == 1,
+        attributes: {
+          "data-event-id": "is-service-address-same-as-principal-address-yes-radio-option"
+        }
+      },   {
+        value: 0,
+        text: "No",
+        checked: is_service_address_same_as_principal_address == 0,
+        attributes: {
+          "data-event-id": "is-service-address-same-as-principal-address-no-radio-option"
+        },
+        conditional: {
+          html: serviceAddressHtml
+        }
       }
-    }
-  ]
-}) }}
+    ]
+  }) }}
 {% else %}
-{{ govukRadios({
-  errorMessage: errors.is_service_address_same_as_principal_address if errors,
-  classes: "govuk-radios",
-  idPrefix: "is_service_address_same_as_principal_address",
-  name: "is_service_address_same_as_principal_address",
-  fieldset: {
-    legend: {
-      text: "Is the correspondence address the same as the principal or registered office address?",
-      isPageHeading: false,
-      classes: "govuk-fieldset__legend--m"
-    }
-  },
-  items: [
-    {
-      value: 1,
-      text: "Yes",
-      attributes: {
-        "data-event-id": "is-service-address-same-as-principal-address-yes-radio-option"
+  {{ govukRadios({
+    errorMessage: errors.is_service_address_same_as_principal_address if errors,
+    classes: "govuk-radios",
+    idPrefix: "is_service_address_same_as_principal_address",
+    name: "is_service_address_same_as_principal_address",
+    fieldset: {
+      legend: {
+        text: "Is the correspondence address the same as the principal or registered office address?",
+        isPageHeading: false,
+        classes: "govuk-fieldset__legend--m"
       }
-    },   {
-      value: 0,
-      text: "No",
-      attributes: {
-        "data-event-id": "is-service-address-same-as-principal-address-no-radio-option"
-      },
-      conditional: {
-        html: serviceAddressHtml
+    },
+    items: [
+      {
+        value: 1,
+        text: "Yes",
+        attributes: {
+          "data-event-id": "is-service-address-same-as-principal-address-yes-radio-option"
+        }
+      },   {
+        value: 0,
+        text: "No",
+        attributes: {
+          "data-event-id": "is-service-address-same-as-principal-address-no-radio-option"
+        },
+        conditional: {
+          html: serviceAddressHtml
+        }
       }
-    }
-  ]
-}) }}
+    ]
+  }) }}
 {% endif %}

--- a/views/includes/inputs/address/principal-address-input.html
+++ b/views/includes/inputs/address/principal-address-input.html
@@ -89,6 +89,7 @@
   {% include "includes/inputs/address/service-address-input.html" %}
 {% endset -%}
 
+{% if principal_address | length %}
 {{ govukRadios({
   errorMessage: errors.is_service_address_same_as_principal_address if errors,
   classes: "govuk-radios",
@@ -122,3 +123,36 @@
     }
   ]
 }) }}
+{% else %}
+{{ govukRadios({
+  errorMessage: errors.is_service_address_same_as_principal_address if errors,
+  classes: "govuk-radios",
+  idPrefix: "is_service_address_same_as_principal_address",
+  name: "is_service_address_same_as_principal_address",
+  fieldset: {
+    legend: {
+      text: "Is the correspondence address the same as the principal or registered office address?",
+      isPageHeading: false,
+      classes: "govuk-fieldset__legend--m"
+    }
+  },
+  items: [
+    {
+      value: 1,
+      text: "Yes",
+      attributes: {
+        "data-event-id": "is-service-address-same-as-principal-address-yes-radio-option"
+      }
+    },   {
+      value: 0,
+      text: "No",
+      attributes: {
+        "data-event-id": "is-service-address-same-as-principal-address-no-radio-option"
+      },
+      conditional: {
+        html: serviceAddressHtml
+      }
+    }
+  ]
+}) }}
+{% endif %}


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/jira/software/c/projects/UAR/boards/531?modal=detail&selectedIssue=UAR-775&sprint=2901

### Change description

Deselects radio button for 'Is correspondence address same as principle office address' and does not populate the fields for correspondence address. As principle address cannot be pulled in at this time, this is a temporary workaround.

### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
