### PR TITLE
[UAR-828] no paper redirect when trusts flag enabled

### DIFF
--- a/src/controllers/update/confirm.overseas.entity.details.controller.ts
+++ b/src/controllers/update/confirm.overseas.entity.details.controller.ts
@@ -7,6 +7,7 @@ import { Update } from "../../model/update.type.model";
 import { Session } from "@companieshouse/node-session-handler";
 import { BeneficialOwnerIndividual } from "../../model/beneficial.owner.individual.model";
 import { BeneficialOwnerCorporate } from "@companieshouse/api-sdk-node/dist/services/overseas-entities";
+import { isActiveFeature } from "../../utils/feature.flag";
 
 export const get = (req: Request, res: Response, next: NextFunction) => {
   try {
@@ -34,7 +35,7 @@ export const post = (req: Request, res: Response, next: NextFunction) => {
 
     const appData: ApplicationData = getApplicationData(req.session as Session);
 
-    if (hasTrustsInvolved(appData)) {
+    if (!isActiveFeature(config.FEATURE_FLAG_ENABLE_UPDATE_TRUSTS) && hasTrustsInvolved(appData)) {
       return res.redirect(config.UPDATE_TRUSTS_SUBMIT_BY_PAPER_URL);
     }
 

--- a/src/controllers/update/secure.update.filter.controller.ts
+++ b/src/controllers/update/secure.update.filter.controller.ts
@@ -2,11 +2,14 @@ import { NextFunction, Request, Response } from "express";
 
 import * as config from "../../config";
 import { getFilterPage, postFilterPage } from "../../utils/secure.filter";
+import { isActiveFeature } from "../../utils/feature.flag";
 
 export const get = (req: Request, res: Response, next: NextFunction) => {
   getFilterPage(req, res, next, config.SECURE_UPDATE_FILTER_PAGE, config.UPDATE_LANDING_PAGE_URL);
 };
 
 export const post = (req: Request, res: Response, next: NextFunction) => {
-  postFilterPage(req, res, next, config.UPDATE_USE_PAPER_URL, config.UPDATE_ANY_TRUSTS_INVOLVED_URL);
+  postFilterPage(req, res, next, config.UPDATE_USE_PAPER_URL, getNextPage());
 };
+
+const getNextPage = () => isActiveFeature(config.FEATURE_FLAG_ENABLE_UPDATE_TRUSTS) ? config.UPDATE_INTERRUPT_CARD_URL : config.UPDATE_ANY_TRUSTS_INVOLVED_URL;

--- a/src/controllers/update/update.interrupt.card.controller.ts
+++ b/src/controllers/update/update.interrupt.card.controller.ts
@@ -2,13 +2,14 @@ import { NextFunction, Request, Response } from "express";
 
 import { logger } from "../../utils/logger";
 import * as config from "../../config";
+import { isActiveFeature } from "../../utils/feature.flag";
 
 export const get = (req: Request, res: Response, next: NextFunction) => {
   try {
     logger.debugRequest(req, `${req.method} ${req.route.path}`);
 
     return res.render(config.UPDATE_INTERRUPT_CARD_PAGE, {
-      backLinkUrl: config.UPDATE_ANY_TRUSTS_INVOLVED_URL,
+      backLinkUrl: isActiveFeature(config.FEATURE_FLAG_ENABLE_UPDATE_TRUSTS) ? config.SECURE_UPDATE_FILTER_URL : config.UPDATE_ANY_TRUSTS_INVOLVED_URL,
       templateName: config.UPDATE_INTERRUPT_CARD_PAGE,
     });
   } catch (error) {

--- a/src/middleware/is.feature.disabled.middleware.ts
+++ b/src/middleware/is.feature.disabled.middleware.ts
@@ -1,0 +1,14 @@
+import { NextFunction, Request, Response } from "express";
+import { constants } from 'http2';
+import { isActiveFeature } from "../utils/feature.flag";
+import { NOT_FOUND_PAGE } from '../config';
+
+export const isFeatureDisabled = (featureFlagValue: string) => {
+  return (req: Request, res: Response, next: NextFunction) => {
+    if (!isActiveFeature(featureFlagValue)) {
+      return next();
+    }
+
+    return res.status(constants.HTTP_STATUS_NOT_FOUND).render(NOT_FOUND_PAGE);
+  };
+};

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -90,6 +90,7 @@ import { authentication } from "../middleware/authentication.middleware";
 import { navigation } from "../middleware/navigation";
 import { checkTrustValidations, checkValidations } from "../middleware/validation.middleware";
 import { isFeatureEnabled } from '../middleware/is.feature.enabled.middleware';
+import { isFeatureDisabled } from '../middleware/is.feature.disabled.middleware';
 import { validator } from "../validation";
 import { companyAuthentication } from "../middleware/company.authentication.middleware";
 
@@ -721,11 +722,17 @@ router.route(config.UPDATE_CONTINUE_WITH_SAVED_FILING_URL)
   .post(...validator.updateContinueSavedFiling, checkValidations, updateContinueSavedFiling.post);
 
 router.route(config.UPDATE_TRUSTS_SUBMIT_BY_PAPER_URL)
-  .all(authentication)
+  .all(
+    isFeatureDisabled(config.FEATURE_FLAG_ENABLE_UPDATE_TRUSTS),
+    authentication
+  )
   .get(updateTrustsSubmitByPaper.get);
 
 router.route(config.UPDATE_ANY_TRUSTS_INVOLVED_URL)
-  .all(authentication)
+  .all(
+    isFeatureDisabled(config.FEATURE_FLAG_ENABLE_UPDATE_TRUSTS),
+    authentication
+  )
   .get(updateAnyTrustsInvolved.get)
   .post(...validator.anyTrustsInvolved, checkValidations, updateAnyTrustsInvolved.post);
 

--- a/test/controllers/update/update.any.trusts.involved.spec.ts
+++ b/test/controllers/update/update.any.trusts.involved.spec.ts
@@ -5,6 +5,7 @@ jest.mock('../../../src/middleware/company.authentication.middleware');
 jest.mock('../../../src/utils/application.data');
 jest.mock('../../../src/middleware/service.availability.middleware');
 jest.mock('../../../src/middleware/navigation/update/has.overseas.entity.middleware');
+jest.mock("../../../src/utils/feature.flag" );
 
 import { NextFunction, Request, Response } from "express";
 import { beforeEach, expect, jest, test, describe } from "@jest/globals";
@@ -28,6 +29,10 @@ import { authentication } from "../../../src/middleware/authentication.middlewar
 import { serviceAvailabilityMiddleware } from "../../../src/middleware/service.availability.middleware";
 import { logger } from "../../../src/utils/logger";
 import { AnyTrustsInvolvedKey } from "../../../src/model/data.types.model";
+import { isActiveFeature } from "../../../src/utils/feature.flag";
+
+const mockIsActiveFeature = isActiveFeature as jest.Mock;
+mockIsActiveFeature.mockReturnValue(false);
 
 const mockAuthenticationMiddleware = authentication as jest.Mock;
 mockAuthenticationMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => next() );
@@ -51,6 +56,13 @@ describe("Update any trusts involved controller tests", () => {
       expect(resp.text).not.toContain(RADIO_BUTTON_YES_SELECTED);
       expect(resp.text).not.toContain(RADIO_BUTTON_NO_SELECTED);
       expect(resp.text).not.toContain(PAGE_TITLE_ERROR);
+    });
+
+    test(`renders page not found if FEATURE_FLAG_ENABLE_UPDATE_TRUSTS = true`, async () => {
+      mockIsActiveFeature.mockReturnValueOnce(true);
+
+      const resp = await request(app).get(UPDATE_ANY_TRUSTS_INVOLVED_URL);
+      expect(resp.status).toEqual(404);
     });
 
     test("catch error when rendering the page", async () => {
@@ -87,6 +99,13 @@ describe("Update any trusts involved controller tests", () => {
       expect(resp.text).toContain(PAGE_TITLE_ERROR);
       expect(resp.text).toContain(UPDATE_ANY_TRUSTS_INVOLVED_HEADING);
       expect(resp.text).toContain(ErrorMessages.SELECT_IF_ANY_TRUSTS_INVOLVED);
+    });
+
+    test("POST with FEATURE_FLAG_ENABLE_UPDATE_TRUSTS = true returns 404", async () => {
+      mockIsActiveFeature.mockReturnValueOnce(true);
+
+      const resp = await request(app).post(UPDATE_ANY_TRUSTS_INVOLVED_URL);
+      expect(resp.status).toEqual(404);
     });
 
     test("catch error when posting the page", async () => {

--- a/test/controllers/update/update.trusts.submit.by.paper.controller.spec.ts
+++ b/test/controllers/update/update.trusts.submit.by.paper.controller.spec.ts
@@ -2,6 +2,7 @@ jest.mock("ioredis");
 jest.mock('../../../src/middleware/authentication.middleware');
 jest.mock('../../../src/middleware/service.availability.middleware');
 jest.mock('../../../src/utils/application.data');
+jest.mock("../../../src/utils/feature.flag" );
 
 import { NextFunction, Request, Response } from "express";
 import { expect, test, describe, jest } from "@jest/globals";
@@ -19,6 +20,10 @@ import { authentication } from "../../../src/middleware/authentication.middlewar
 import { UPDATE_TRUSTS_SUBMIT_BY_PAPER_PAGE_HEADING } from "../../__mocks__/text.mock";
 import { serviceAvailabilityMiddleware } from "../../../src/middleware/service.availability.middleware";
 import { APPLICATION_DATA_UPDATE_BO_MO_MOCK } from "../../__mocks__/session.mock";
+import { isActiveFeature } from "../../../src/utils/feature.flag";
+
+const mockIsActiveFeature = isActiveFeature as jest.Mock;
+mockIsActiveFeature.mockReturnValue(false);
 
 const mockAuthenticationMiddleware = authentication as jest.Mock;
 mockAuthenticationMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => next() );
@@ -46,6 +51,13 @@ describe("Update trusts submit by paper controller", () => {
       expect(resp.status).toEqual(200);
       expect(resp.text).toContain(UPDATE_TRUSTS_SUBMIT_BY_PAPER_PAGE_HEADING);
       expect(resp.text).toContain(UPDATE_OVERSEAS_ENTITY_CONFIRM_URL);
+    });
+
+    test(`renders page not found if FEATURE_FLAG_ENABLE_UPDATE_TRUSTS = true`, async () => {
+      mockIsActiveFeature.mockReturnValueOnce(true);
+
+      const resp = await request(app).get(UPDATE_TRUSTS_SUBMIT_BY_PAPER_URL);
+      expect(resp.status).toEqual(404);
     });
   });
 });


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/UAR-828


### Change description
Skipping over the page that asks the user if any trusts are involved at the beginning of the journey. Also don't redirect the user if there are BOs with trustee nature of control types.


### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
