### PR TITLE
UAR-275: Update Trusts submission interrupt page implementation

### DIFF
--- a/src/controllers/update/check.your.answers.controller.ts
+++ b/src/controllers/update/check.your.answers.controller.ts
@@ -3,9 +3,14 @@ import * as config from "../../config";
 import { isActiveFeature } from "../../utils/feature.flag";
 
 import { getDataForReview, postDataForReview } from "../../utils/check.your.answers";
+import { getApplicationData } from '../../utils/application.data';
+import { checkEntityRequiresTrusts } from '../../utils/trusts';
 
 export const get = (req: Request, res: Response, next: NextFunction) => {
-  const backLinkUrl = isActiveFeature(config.FEATURE_FLAG_ENABLE_UPDATE_TRUSTS)
+  const updateTrustsEnabled = isActiveFeature(config.FEATURE_FLAG_ENABLE_UPDATE_TRUSTS);
+  const hasAnyBosWithTrusteeNocs = checkEntityRequiresTrusts(getApplicationData(req.session));
+
+  const backLinkUrl = updateTrustsEnabled && hasAnyBosWithTrusteeNocs
     ? config.UPDATE_TRUSTS_ASSOCIATED_WITH_THE_OVERSEAS_ENTITY_URL
     : config.UPDATE_BENEFICIAL_OWNER_TYPE_URL;
 

--- a/src/middleware/navigation/index.ts
+++ b/src/middleware/navigation/index.ts
@@ -16,6 +16,7 @@ import { hasEntityUpdateDetails } from "./update/has.entity.update.middleware";
 import { hasBOsOrMOsUpdate } from "./update/has.beneficial.owners.or.managing.officers.update.middleware";
 import { hasDueDiligenceDetails } from "./update/has.due.diligence.details.middleware";
 import { hasGivenValidBoMoDetails } from "./update/has.given.valid.bo.mo.details.middleware";
+import { hasAnyBosWithTrusteeNocs } from './update/has.any.bos.with.trustee.nocs.middleware';
 
 export const navigation = {
   hasSoldLand,
@@ -36,4 +37,5 @@ export const navigation = {
   hasBOsOrMOsUpdate,
   hasDueDiligenceDetails,
   hasGivenValidBoMoDetails,
+  hasAnyBosWithTrusteeNocs,
 };

--- a/src/middleware/navigation/update/has.any.bos.with.trustee.nocs.middleware.ts
+++ b/src/middleware/navigation/update/has.any.bos.with.trustee.nocs.middleware.ts
@@ -1,0 +1,19 @@
+import { Request, Response, NextFunction } from 'express';
+
+import { logger } from '../../../utils/logger';
+import { UPDATE_CHECK_YOUR_ANSWERS_URL } from '../../../config';
+import { getApplicationData } from '../../../utils/application.data';
+import { checkEntityRequiresTrusts } from '../../../utils/trusts';
+
+export const hasAnyBosWithTrusteeNocs = (req: Request, res: Response, next: NextFunction): void => {
+  try {
+    if (!checkEntityRequiresTrusts(getApplicationData(req.session))) {
+      logger.infoRequest(req, `No BOs with Trustee NOC. Redirecting to ${UPDATE_CHECK_YOUR_ANSWERS_URL}`);
+      return res.redirect(UPDATE_CHECK_YOUR_ANSWERS_URL);
+    }
+
+    next();
+  } catch (err) {
+    next(err);
+  }
+};

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -472,7 +472,7 @@ router.route(config.UPDATE_TRUSTS_SUBMISSION_INTERRUPT_URL)
     companyAuthentication,
     navigation.hasUpdatePresenter,
   )
-  .get(updateTrustsSubmissionInterrupt.get)
+  .get(navigation.hasAnyBosWithTrusteeNocs, updateTrustsSubmissionInterrupt.get)
   .post(updateTrustsSubmissionInterrupt.post);
 
 router.route(config.UPDATE_TRUSTS_TELL_US_ABOUT_IT_URL)

--- a/test/controllers/update/check.your.answers.controller.spec.ts
+++ b/test/controllers/update/check.your.answers.controller.spec.ts
@@ -129,7 +129,7 @@ describe("CHECK YOUR ANSWERS controller", () => {
   describe("GET tests", () => {
 
     test(`renders the ${UPDATE_CHECK_YOUR_ANSWERS_PAGE} page with contact details section`, async () => {
-      mockGetApplicationData.mockReturnValueOnce(APPLICATION_DATA_UPDATE_BO_MOCK);
+      mockGetApplicationData.mockReturnValue(APPLICATION_DATA_UPDATE_BO_MOCK);
       const resp = await request(app).get(UPDATE_CHECK_YOUR_ANSWERS_URL);
 
       expect(resp.status).toEqual(200);
@@ -151,7 +151,7 @@ describe("CHECK YOUR ANSWERS controller", () => {
     });
 
     test(`renders the ${UPDATE_CHECK_YOUR_ANSWERS_PAGE} page with contact details section with (ceased) existing BO`, async () => {
-      mockGetApplicationData.mockReturnValueOnce(APPLICATION_DATA_CH_REF_UPDATE_MOCK);
+      mockGetApplicationData.mockReturnValue(APPLICATION_DATA_CH_REF_UPDATE_MOCK);
       const resp = await request(app).get(UPDATE_CHECK_YOUR_ANSWERS_URL);
 
       expect(resp.status).toEqual(200);
@@ -171,7 +171,7 @@ describe("CHECK YOUR ANSWERS controller", () => {
     });
 
     test(`renders the ${UPDATE_CHECK_YOUR_ANSWERS_PAGE} page`, async () => {
-      mockGetApplicationData.mockReturnValueOnce(APPLICATION_DATA_UPDATE_BO_MOCK);
+      mockGetApplicationData.mockReturnValue(APPLICATION_DATA_UPDATE_BO_MOCK);
       const resp = await request(app).get(UPDATE_CHECK_YOUR_ANSWERS_URL);
 
       expect(resp.status).toEqual(200);
@@ -191,7 +191,7 @@ describe("CHECK YOUR ANSWERS controller", () => {
     });
 
     test(`renders the ${UPDATE_CHECK_YOUR_ANSWERS_PAGE} page with verification checks - Agent selected`, async () => {
-      mockGetApplicationData.mockReturnValueOnce(APPLICATION_DATA_UPDATE_BO_MOCK);
+      mockGetApplicationData.mockReturnValue(APPLICATION_DATA_UPDATE_BO_MOCK);
       const resp = await request(app).get(UPDATE_CHECK_YOUR_ANSWERS_URL);
 
       expect(resp.status).toEqual(200);
@@ -216,7 +216,7 @@ describe("CHECK YOUR ANSWERS controller", () => {
     });
 
     test(`renders the ${UPDATE_CHECK_YOUR_ANSWERS_PAGE} page with verification checks - OE (Someone else) selected`, async () => {
-      mockGetApplicationData.mockReturnValueOnce({
+      mockGetApplicationData.mockReturnValue({
         ...APPLICATION_DATA_UPDATE_BO_MOCK,
         [dueDiligenceType.DueDiligenceKey]: {},
         [overseasEntityDueDiligenceType.OverseasEntityDueDiligenceKey]: OVERSEAS_ENTITY_DUE_DILIGENCE_OBJECT_MOCK,
@@ -255,7 +255,7 @@ describe("CHECK YOUR ANSWERS controller", () => {
   describe("POST tests", () => {
     test(`redirect to ${PAYMENT_LINK_JOURNEY}, with transaction and OE id`, async () => {
       mockIsActiveFeature.mockReturnValueOnce(true);
-      mockGetApplicationData.mockReturnValueOnce(APPLICATION_DATA_UPDATE_BO_MOCK);
+      mockGetApplicationData.mockReturnValue(APPLICATION_DATA_UPDATE_BO_MOCK);
       mockPaymentsSession.mockReturnValueOnce(PAYMENT_LINK_JOURNEY);
       const resp = await request(app).post(UPDATE_CHECK_YOUR_ANSWERS_URL);
 
@@ -266,7 +266,7 @@ describe("CHECK YOUR ANSWERS controller", () => {
     test(`redirect to ${PAYMENT_LINK_JOURNEY}, if Save and Resume not enabled`, async () => {
       mockIsActiveFeature.mockReturnValueOnce(false);
       const mockData = { ...APPLICATION_DATA_UPDATE_BO_MOCK, [Transactionkey]: "", [OverseasEntityKey]: "" };
-      mockGetApplicationData.mockReturnValueOnce(mockData);
+      mockGetApplicationData.mockReturnValue(mockData);
       mockPaymentsSession.mockReturnValueOnce(PAYMENT_LINK_JOURNEY);
       const resp = await request(app).post(UPDATE_CHECK_YOUR_ANSWERS_URL);
 

--- a/views/includes/page-templates/trust-submission-interrupt.html
+++ b/views/includes/page-templates/trust-submission-interrupt.html
@@ -1,0 +1,40 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      {{ pageHeading }}
+    </h1>
+
+    <p class="govuk-body">
+      At least one individual or entity you've told us about is a beneficial owner of the overseas entity, due to being a trustee of a trust.
+    </p>
+
+    <p class="govuk-body">
+      In the next section, you'll need to tell us about the trust. This includes details about people or entities that are:
+    </p>
+
+    <ul class="govuk-body">
+      <li>beneficiaries</li>
+      <li>settlors</li>
+      <li>grantors</li>
+      <li>interested persons</li>
+    </ul>
+
+    <p class="govuk-body">
+      It also includes each person who has ever been a beneficial owner in relation to the overseas entity, by being a trustee of the trust.
+    </p>
+
+    <p class="govuk-body">
+      You can add information about multiple trusts if needed.
+    </p>
+
+    <form class="form" method="post">
+      {{ govukButton({
+        text: "Continue",
+        attributes: {
+          "id": "submit",
+          "data-event-id": "trust-interrupt-continue-button"
+        }
+      }) }}
+    </form>
+  </div>
+</div>

--- a/views/trust-interrupt.html
+++ b/views/trust-interrupt.html
@@ -10,38 +10,7 @@
   {% include "includes/back-link.html" %}
 {% endblock %}
 
+{% set pageHeading = pageParams.title %}
 {% block content %}
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-xl">{{ pageParams.title }}</h1>
-
-        <p class="govuk-body">At least one individual or entity you’ve told us
-           about is a beneficial owner of the overseas entity, due to being a trustee of a trust.</p>
-
-        <p class="govuk-body">
-          In the next section, you’ll need to tell us about the trust. 
-          This includes details about people or entities that are:</p>
-
-        <ul class="govuk-body">
-          <li>beneficiaries</li>
-          <li>settlors</li>
-          <li>grantors</li>
-          <li>interested persons</li>
-        </ul>
-        <p class="govuk-body">It also includes each person who has ever been a beneficial owner in relation to the
-           overseas entity, by being a trustee of the trust.</p>
-
-        <p class="govuk-body">You can add information about multiple trusts if needed.</p>
-
-      <form class="form" method="post">
-        {{ govukButton({
-          text: "Continue",
-          attributes: {
-            "id": "submit",
-            "data-event-id": "trust-interrupt-continue-button"
-          }
-        }) }}
-      </form>
-    </div>
-  </div>
+  {% include "includes/page-templates/trust-submission-interrupt.html" %}
 {% endblock %}

--- a/views/update/update-trusts-submission-interrupt.html
+++ b/views/update/update-trusts-submission-interrupt.html
@@ -1,7 +1,9 @@
 {% extends "update-layout.html" %}
 
+{% set pageHeading = "You now need to submit trust information" %}
+
 {% block pageTitle %}
-  You now need to submit trust information - {{ UPDATE_SERVICE_NAME }} - GOV.UK
+  {{ pageHeading }} - {{ UPDATE_SERVICE_NAME }} - GOV.UK
 {% endblock %}
 
 {% block backLink %}
@@ -9,10 +11,5 @@
 {% endblock %}
 
 {% block content %}
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds-from-desktop">
-      <h1 class="govuk-heading-xl">You now need to submit trust information</h1>
-      <form method="post">{% include "includes/continue-button.html" %}</form>
-    </div>
-  </div>
+  {% include "includes/page-templates/trust-submission-interrupt.html" %}
 {% endblock %}


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/UAR-275

### Change description

- Added content to Trusts Submission Interrupt for Update journey
- Added middleware function to return if any BOs (non gov) have Trustee NOCs
  - Added to `GET` controller endpoint for the page
  - Redirects to Update CYA if no BOs exist

### Work checklist

- [x] Tests added where applicable
- [x] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
