### PR TITLE
UAR-894: fix reloading of BO/MO data during no change journey

### DIFF
--- a/src/controllers/update/overseas.entity.change.controller.ts
+++ b/src/controllers/update/overseas.entity.change.controller.ts
@@ -6,7 +6,7 @@ import { ApplicationData } from "../../model";
 import { saveAndContinue } from "../../utils/save.and.continue";
 import { Session } from "@companieshouse/node-session-handler";
 import { NoChangeKey } from "../../model/update.type.model";
-import { retrieveBeneficialOwners, retrieveManagingOfficers } from "../../utils/update/beneficial_owners_managing_officers_data_fetch";
+import { retrieveBoAndMoData } from "../../utils/update/beneficial_owners_managing_officers_data_fetch";
 import { getCompanyProfile } from "../../service/company.profile.service";
 import { reloadOE } from "./overseas.entity.query.controller";
 import { CompanyProfile } from "@companieshouse/api-sdk-node/dist/services/company-profile/types";
@@ -35,16 +35,16 @@ export const post = async (req: Request, resp: Response, next: NextFunction) => 
     const appData: ApplicationData = getApplicationData(req.session);
     const noChangeStatement = req.body[NoChangeKey];
 
-    if (appData.update){
-      appData.update.no_change = noChangeStatement === "1" ? true : false;
+    if (appData.update) {
+      appData.update.no_change = noChangeStatement === "1";
       setExtraData(session, appData);
     }
 
-    if (noChangeStatement === "1"){
-      await resetChangeData(req, appData);
+    if (noChangeStatement === "1") {
+      await resetDataForNoChange(req, appData);
       redirectUrl = config.UPDATE_NO_CHANGE_BENEFICIAL_OWNER_STATEMENTS_URL;
     } else {
-      resetNoChangeData(appData);
+      resetDataForChange(appData);
       redirectUrl = config.WHO_IS_MAKING_UPDATE_URL;
     }
     await saveAndContinue(req, session, false);
@@ -56,8 +56,8 @@ export const post = async (req: Request, resp: Response, next: NextFunction) => 
   }
 };
 
-export const resetChangeData = async (req: Request, appData: ApplicationData) => {
-  if (appData){
+export const resetDataForNoChange = async (req: Request, appData: ApplicationData) => {
+  if (appData) {
     appData.who_is_registering = undefined;
     appData.due_diligence = undefined;
     appData.overseas_entity_due_diligence = undefined;
@@ -73,27 +73,19 @@ export const resetChangeData = async (req: Request, appData: ApplicationData) =>
     const companyProfile = await getCompanyProfile(req, appData.entity_number as string) as CompanyProfile;
     reloadOE(appData, appData.entity_number as string, companyProfile);
   }
-  if (appData.update){
+  if (appData.update) {
     appData.update.registrable_beneficial_owner = undefined;
     appData.update.bo_mo_data_fetched = false;
-    await existingBoMoForNoChange(req, appData);
+    await retrieveBoAndMoData(req, appData);
   }
   return appData;
 };
 
-export const resetNoChangeData = (appData: ApplicationData) => {
+export const resetDataForChange = (appData: ApplicationData) => {
   if (appData.update){
     appData.update.registrable_beneficial_owner = undefined;
   }
   appData.beneficial_owners_statement = undefined;
   appData.payment = undefined;
   return appData;
-};
-
-const existingBoMoForNoChange = async (req: Request, appData: ApplicationData) => {
-  if (appData.update){
-    await retrieveBeneficialOwners(req, appData);
-    await retrieveManagingOfficers(req, appData);
-    appData.update.bo_mo_data_fetched = true;
-  }
 };

--- a/test/__mocks__/session.mock.ts
+++ b/test/__mocks__/session.mock.ts
@@ -54,6 +54,8 @@ import { DUE_DILIGENCE_OBJECT_MOCK } from "./due.diligence.mock";
 import { ADDRESS } from "./fields/address.mock";
 import { DATE_OF_BIRTH, EMPTY_DATE, RESIGNED_ON_DATE, START_DATE } from "./fields/date.mock";
 import { ANY_MESSAGE_ERROR } from "./text.mock";
+import { EntityKey } from "../../src/model/entity.model";
+import { OverseasEntityDueDiligenceKey } from "../../src/model/overseas.entity.due.diligence.model";
 
 export const BO_GOV_ID = "10722c3c-9301-4f46-ad8b-b30f5dcd76a0";
 export const BO_GOV_ID_URL = "/" + BO_GOV_ID;
@@ -1751,7 +1753,7 @@ export const UPDATE_REVIEW_INDIVIDUAL_MANAGING_OFFICER_WITH_PARAM_URL_TEST = `${
 export const serviceNameGetCompanyPsc = "companyPsc";
 export const fnNameGetCompanyPsc = "getCompanyPsc";
 
-export const RESET_NO_CHANGE_RESPONSE = {
+export const RESET_DATA_FOR_CHANGE_RESPONSE = {
   [PaymentKey]: undefined,
   [beneficialOwnerStatementType.BeneficialOwnerStatementKey]: undefined,
   [updateType.UpdateKey]: {
@@ -1759,25 +1761,172 @@ export const RESET_NO_CHANGE_RESPONSE = {
   }
 };
 
-export const RESET_CHANGE_RESPONSE = {
+export const RESET_DATA_FOR_NO_CHANGE_RESPONSE = {
   [EntityNameKey]: "Test1",
   [presenterType.PresenterKey]: PRESENTER_OBJECT_MOCK,
-  [dueDiligenceType.DueDiligenceKey]: undefined,
-  [beneficialOwnerStatementType.BeneficialOwnerStatementKey]: undefined,
-  [beneficialOwnerIndividualType.BeneficialOwnerIndividualKey]: undefined,
-  [beneficialOwnerOtherType.BeneficialOwnerOtherKey]: undefined,
-  [beneficialOwnerGovType.BeneficialOwnerGovKey]: undefined,
-  [managingOfficerType.ManagingOfficerKey]: undefined,
-  [managingOfficerCorporateType.ManagingOfficerCorporateKey]: undefined,
-  [WhoIsRegisteringKey]: undefined,
-  [PaymentKey]: undefined,
   [OverseasEntityKey]: OVERSEAS_ENTITY_ID,
   [Transactionkey]: TRANSACTION_ID,
   [HasSoldLandKey]: hasSoldLandKey,
   [IsSecureRegisterKey]: isSecureRegisterKey,
-  [TrustKey]: undefined,
   [EntityNumberKey]: COMPANY_NUMBER,
+  [WhoIsRegisteringKey]: undefined,
+  [dueDiligenceType.DueDiligenceKey]: undefined,
+  [OverseasEntityDueDiligenceKey]: undefined,
+  [beneficialOwnerIndividualType.BeneficialOwnerIndividualKey]: undefined,
+  [beneficialOwnerOtherType.BeneficialOwnerOtherKey]: undefined,
+  [beneficialOwnerGovType.BeneficialOwnerGovKey]: undefined,
+  [managingOfficerCorporateType.ManagingOfficerCorporateKey]: undefined,
+  [managingOfficerType.ManagingOfficerKey]: undefined,
+  [beneficialOwnerStatementType.BeneficialOwnerStatementKey]: undefined,
+  [PaymentKey]: undefined,
+  [TrustKey]: undefined,
+  [EntityKey]: {
+    email: "",
+    incorporation_country: "",
+    is_on_register_in_country_formed_in: 0,
+    is_service_address_same_as_principal_address: 0,
+    law_governed: undefined,
+    legal_form: undefined,
+    principal_address: {},
+    public_register_name: undefined,
+    registration_number: undefined
+  },
   [updateType.UpdateKey]: {
-    registrable_beneficial_owner: undefined
+    registrable_beneficial_owner: undefined,
+    bo_mo_data_fetched: true,
+    review_beneficial_owners_individual: [
+      {
+        beneficial_owner_nature_of_control_types: [],
+        ch_reference: "RandomeaP1EB70SSD9SLmiK5Y",
+        date_of_birth: {
+          day: "01",
+          month: "undefined",
+          year: undefined,
+        },
+        first_name: undefined,
+        id: "/company/OE111129/persons-with-significant-control/individual/RandomeaP1EB70SSD9SLmiK5Y",
+        is_on_sanctions_list: 0,
+        is_service_address_same_as_usual_residential_address: 0,
+        last_name: undefined,
+        nationality: "British",
+        non_legal_firm_members_nature_of_control_types: [],
+        second_nationality: undefined,
+        service_address: {
+          country: "Wales",
+          county: undefined,
+          line_1: undefined,
+          line_2: undefined,
+          postcode: undefined,
+          property_name_number: "Companies House",
+          town: "Limavady",
+        },
+        start_date: undefined,
+        trustees_nature_of_control_types: [],
+        usual_residential_address: undefined,
+      }
+    ],
+    review_beneficial_owners_corporate: [
+      {
+        beneficial_owner_nature_of_control_types: [],
+        ch_reference: "OtherBOP1EB70SSD9SLmiK5Y",
+        id: "/company/OE111129/persons-with-significant-control/corporate-entity/OtherBOP1EB70SSD9SLmiK5Y",
+        is_on_register_in_country_formed_in: 0,
+        is_on_sanctions_list: 0,
+        is_service_address_same_as_principal_address: undefined,
+        law_governed: undefined,
+        legal_form: undefined,
+        name: "Mr Other Beneficial Owner",
+        non_legal_firm_members_nature_of_control_types: [],
+        principal_address: {},
+        public_register_name: undefined,
+        registration_number: undefined,
+        service_address: {
+          country: "Wales",
+          county: undefined,
+          line_1: undefined,
+          line_2: undefined,
+          postcode: undefined,
+          property_name_number: "Companies House",
+          town: "Limavady",
+        },
+        start_date: undefined,
+        trustees_nature_of_control_types: [],
+      }
+    ],
+    review_beneficial_owners_government_or_public_authority: [
+      {
+        beneficial_owner_nature_of_control_types: [],
+        ch_reference: "RandomeaP1EB70SSD9SLmiK5Y",
+        id: "/company/OE111129/persons-with-significant-control/legal-person/RandomeaP1EB70SSD9SLmiK5Y",
+        is_on_sanctions_list: 0,
+        is_service_address_same_as_principal_address: undefined,
+        law_governed: undefined,
+        legal_form: undefined,
+        name: "Mr Random Notreal Person",
+        non_legal_firm_members_nature_of_control_types: [],
+        principal_address: {},
+        service_address: {
+          country: "Wales",
+          county: undefined,
+          line_1: undefined,
+          line_2: undefined,
+          postcode: undefined,
+          property_name_number: "Companies House",
+          town: "Limavady",
+        },
+        start_date: undefined,
+      }
+    ],
+    review_managing_officers_corporate: [
+      {
+        ch_reference: "officers",
+        contact_full_name: undefined,
+        id: "/company/OE111129/officers",
+        is_on_register_in_country_formed_in: 0,
+        is_service_address_same_as_principal_address: undefined,
+        law_governed: undefined,
+        legal_form: undefined,
+        name: "Rev MO Corporate",
+        principal_address: undefined,
+        public_register_name: undefined,
+        registration_number: undefined,
+        role_and_responsibilities: undefined,
+        service_address: {
+          country: "England",
+          county: "Gloucestershire",
+          line_1: "Cerney House",
+          line_2: "North Cerney",
+          postcode: "GL7 7BX",
+          property_name_number: "Samron House",
+          town: "Cirencester",
+        },
+        start_date: {
+          day: "1",
+          month: "1",
+          year: "2023"
+        },
+      }
+    ],
+    review_managing_officers_individual: [
+      {
+        ch_reference: "officers",
+        id: "/company/OE111129/officers",
+        role_and_responsibilities: undefined,
+        service_address: {
+          country: "England",
+          county: "Gloucestershire",
+          line_1: "Cerney House",
+          line_2: "North Cerney",
+          postcode: "GL7 7BX",
+          property_name_number: "Samron House",
+          town: "Cirencester",
+        },
+        start_date: {
+          day: "1",
+          month: "1",
+          year: "2023"
+        },
+      }
+    ],
   }
 };


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/UAR-894

### Change description

* Updated the resetting of the appData for BO/MOs when 'no change' is selected on the ‘Do you need to make any changes to this overseas entity?’ page

### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
