### PR TITLE
UAR-956: Fix accessibility issue with review update statement radios

### DIFF
--- a/views/update/review-update-statement.html
+++ b/views/update/review-update-statement.html
@@ -248,8 +248,7 @@
           fieldset: {
           legend: {
             text: "Is all the information in this update statement correct?",
-            isPageHeading: true,
-            classes: "govuk-fieldset__legend--xl"
+            classes: "govuk-fieldset__legend--l"
           }
           },
           items: [


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/UAR-956

### Change description

Updated the review update statement radio legend to be accessible
- no longer defined as a 'page heading'
- change the css class applied from a `heading-xl` to `heading-l`, inline with the prototype.

### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
