### PR TITLE
UAR-161: Add former bo page to update trusts journey

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -124,6 +124,7 @@ export const UPDATE_TRUSTS_SUBMISSION_INTERRUPT_PAGE = "update-trusts-submission
 export const UPDATE_TRUSTS_TELL_US_ABOUT_IT_PAGE = "update-tell-us-about-the-trust";
 export const UPDATE_TRUSTS_INDIVIDUALS_OR_ENTITIES_INVOLVED_PAGE = "update-trusts-individuals-or-entities-involved";
 export const UPDATE_TRUSTS_ASSOCIATED_WITH_THE_OVERSEAS_ENTITY_PAGE = "update-trusts-associated-with-overseas-entity";
+export const UPDATE_TRUSTS_TELL_US_ABOUT_FORMER_BO_PAGE = "update-trusts-tell-us-about-former-bo";
 
 // URL PARAMS
 export const ROUTE_PARAM_TRUST_ID = "trustId";

--- a/src/controllers/index.ts
+++ b/src/controllers/index.ts
@@ -82,3 +82,4 @@ export * as updateTrustsSubmissionInterrupt from "./update/update.trusts.submiss
 export * as updateTrustsTellUsAboutIt from "./update/update.trusts.tell.us.about.it.controller";
 export * as updateTrustsIndividualsOrEntitiesInvolved from "./update/update.trusts.individuals.or.entities.involved.controller";
 export * as updateTrustsAssociatedWithEntity from "./update/update.trusts.associated.with.entity.controller";
+export * as updateTrustHistoricalBeneficialOwner from './update/update.trusts.historical.beneficial.owner.controller';

--- a/src/controllers/update/update.trusts.historical.beneficial.owner.controller.ts
+++ b/src/controllers/update/update.trusts.historical.beneficial.owner.controller.ts
@@ -1,10 +1,10 @@
 import { NextFunction, Request, Response } from 'express';
-import { getTrustFormerBo, postTrustFormerBo } from '../utils/trust.former.bo';
+import { getTrustFormerBo, postTrustFormerBo } from '../../utils/trust.former.bo';
 
 export const get = (req: Request, res: Response, next: NextFunction) => {
-  getTrustFormerBo(req, res, next, false);
+  getTrustFormerBo(req, res, next, true);
 };
 
 export const post = async (req: Request, res: Response, next: NextFunction) => {
-  await postTrustFormerBo(req, res, next, false);
+  await postTrustFormerBo(req, res, next, true);
 };

--- a/src/middleware/navigation/has.trust.middleware.ts
+++ b/src/middleware/navigation/has.trust.middleware.ts
@@ -1,13 +1,13 @@
 import { NextFunction, Request, Response } from 'express';
 import { logger } from '../../utils/logger';
-import { SOLD_LAND_FILTER_URL, ROUTE_PARAM_TRUST_ID } from '../../config';
+import { SOLD_LAND_FILTER_URL, SECURE_UPDATE_FILTER_URL, ROUTE_PARAM_TRUST_ID } from '../../config';
 import { getApplicationData } from "../../utils/application.data";
 import { ApplicationData } from '../../model/application.model';
 import { TrustKey } from '../../model/trust.model';
 import { NavigationErrorMessage } from './check.condition';
 import { containsTrustData, getTrustArray } from '../../utils/trusts';
 
-export const hasTrustWithId = (req: Request, res: Response, next: NextFunction): void => {
+const hasTrustWithId = (req: Request, res: Response, next: NextFunction, url: string): void => {
   try {
     const trustId = req.params[ROUTE_PARAM_TRUST_ID];
     const appData: ApplicationData = getApplicationData(req.session);
@@ -19,7 +19,7 @@ export const hasTrustWithId = (req: Request, res: Response, next: NextFunction):
     if (!isTrustPresent) {
       logger.infoRequest(req, NavigationErrorMessage);
 
-      return res.redirect(SOLD_LAND_FILTER_URL);
+      return res.redirect(url);
     }
 
     return next();
@@ -28,17 +28,21 @@ export const hasTrustWithId = (req: Request, res: Response, next: NextFunction):
   }
 };
 
-export const hasTrustData = (req: Request, res: Response, next: NextFunction): void => {
+const hasTrustData = (req: Request, res: Response, next: NextFunction, url: string): void => {
   try {
-
     const appData: ApplicationData = getApplicationData(req.session);
     if (containsTrustData(getTrustArray(appData))) {
       return next();
     }
 
     logger.infoRequest(req, NavigationErrorMessage);
-    return res.redirect(SOLD_LAND_FILTER_URL);
+    return res.redirect(url);
   } catch (err) {
     next(err);
   }
 };
+
+export const hasTrustWithIdRegister = (req: Request, res: Response, next: NextFunction) => hasTrustWithId(req, res, next, SOLD_LAND_FILTER_URL);
+export const hasTrustDataRegister = (req: Request, res: Response, next: NextFunction) => hasTrustData(req, res, next, SOLD_LAND_FILTER_URL);
+export const hasTrustWithIdUpdate = (req: Request, res: Response, next: NextFunction) => hasTrustWithId(req, res, next, SECURE_UPDATE_FILTER_URL);
+export const hasTrustDataUpdate = (req: Request, res: Response, next: NextFunction) => hasTrustData(req, res, next, SECURE_UPDATE_FILTER_URL);

--- a/src/middleware/navigation/index.ts
+++ b/src/middleware/navigation/index.ts
@@ -6,7 +6,7 @@ import { hasPresenter } from "./has.presenter.middleware";
 import { hasSoldLand } from "./has.sold.land.middleware";
 import { isSecureRegister } from "./is.secure.register.middleware";
 import { hasOverseasName } from "./has.overseas.name.middleware";
-import { hasTrustWithId, hasTrustData } from "./has.trust.middleware";
+import { hasTrustWithIdRegister, hasTrustDataRegister, hasTrustWithIdUpdate, hasTrustDataUpdate } from "./has.trust.middleware";
 
 // UPDATE journey
 import { hasOverseasEntityNumber, hasOverseasEntity } from "./update/has.overseas.entity.middleware";
@@ -27,8 +27,10 @@ export const navigation = {
   hasBeneficialOwnersStatement,
   hasBOsOrMOs,
   hasOverseasName,
-  hasTrustWithId,
-  hasTrustData,
+  hasTrustWithIdRegister,
+  hasTrustDataRegister,
+  hasTrustWithIdUpdate,
+  hasTrustDataUpdate,
   hasOverseasEntityNumber,
   hasOverseasEntity,
   hasUpdatePresenter,

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -61,6 +61,7 @@ import {
   updateTrustsTellUsAboutIt,
   updateTrustsIndividualsOrEntitiesInvolved,
   updateTrustsAssociatedWithEntity,
+  updateTrustHistoricalBeneficialOwner,
   updateCheckYourAnswers,
   updateSignOut,
   updateBeneficialOwnerOther,
@@ -235,7 +236,7 @@ router
   .all(
     isFeatureEnabled(config.FEATURE_FLAG_ENABLE_TRUSTS_WEB),
     authentication,
-    navigation.hasTrustData,
+    navigation.hasTrustDataRegister,
   )
   .get(addTrust.get)
   .post(...validator.addTrust, addTrust.post);
@@ -255,7 +256,7 @@ router
   .all(
     isFeatureEnabled(config.FEATURE_FLAG_ENABLE_TRUSTS_WEB),
     authentication,
-    navigation.hasTrustWithId,
+    navigation.hasTrustWithIdRegister,
   )
   .get(trustInvolved.get)
   .post(
@@ -268,7 +269,7 @@ router
   .all(
     isFeatureEnabled(config.FEATURE_FLAG_ENABLE_TRUSTS_WEB),
     authentication,
-    navigation.hasTrustWithId,
+    navigation.hasTrustWithIdRegister,
   )
   .get(trustHistoricalbeneficialOwner.get)
   .post(...validator.trustHistoricalBeneficialOwner, trustHistoricalbeneficialOwner.post);
@@ -278,7 +279,7 @@ router
   .all(
     isFeatureEnabled(config.FEATURE_FLAG_ENABLE_TRUSTS_WEB),
     authentication,
-    navigation.hasTrustWithId,
+    navigation.hasTrustWithIdRegister,
   )
   .get(trustIndividualbeneficialOwner.get)
   .post(...validator.trustIndividualBeneficialOwner, trustIndividualbeneficialOwner.post);
@@ -288,7 +289,7 @@ router
   .all(
     isFeatureEnabled(config.FEATURE_FLAG_ENABLE_TRUSTS_WEB),
     authentication,
-    navigation.hasTrustWithId,
+    navigation.hasTrustWithIdRegister,
   )
   .get(trustLegalEntitybeneficialOwner.get)
   .post(...validator.trustLegalEntityBeneficialOwnerValidator, trustLegalEntitybeneficialOwner.post);
@@ -494,13 +495,25 @@ router.route(config.UPDATE_TRUSTS_INDIVIDUALS_OR_ENTITIES_INVOLVED_URL + config.
   .get(updateTrustsIndividualsOrEntitiesInvolved.get)
   .post(...validator.trustInvolved, updateTrustsIndividualsOrEntitiesInvolved.post);
 
+router
+  .route(config.UPDATE_TRUSTS_INDIVIDUALS_OR_ENTITIES_INVOLVED_URL + config.TRUST_ID + config.TRUST_HISTORICAL_BENEFICIAL_OWNER_URL + config.TRUSTEE_ID + '?')
+  .all(
+    isFeatureEnabled(config.FEATURE_FLAG_ENABLE_UPDATE_TRUSTS),
+    authentication,
+    companyAuthentication,
+    navigation.hasUpdatePresenter,
+    navigation.hasTrustWithIdUpdate,
+  )
+  .get(updateTrustHistoricalBeneficialOwner.get)
+  .post(...validator.trustHistoricalBeneficialOwner, updateTrustHistoricalBeneficialOwner.post);
+
 router.route(config.UPDATE_TRUSTS_ASSOCIATED_WITH_THE_OVERSEAS_ENTITY_URL)
   .all(
     isFeatureEnabled(config.FEATURE_FLAG_ENABLE_UPDATE_TRUSTS),
     authentication,
     companyAuthentication,
     navigation.hasUpdatePresenter,
-    navigation.hasTrustData
+    navigation.hasTrustDataUpdate,
   )
   .get(updateTrustsAssociatedWithEntity.get)
   .post(...validator.addTrust, updateTrustsAssociatedWithEntity.post);

--- a/src/utils/trust.former.bo.ts
+++ b/src/utils/trust.former.bo.ts
@@ -1,0 +1,154 @@
+import { NextFunction, Request, Response } from 'express';
+import * as config from '../config';
+import { logger } from '../utils/logger';
+import { TrusteeType } from '../model/trustee.type.model';
+import { getApplicationData, setExtraData } from '../utils/application.data';
+import { getTrustByIdFromApp, saveHistoricalBoInTrust, saveTrustInApp } from '../utils/trusts';
+import { mapBeneficialOwnerToSession, mapFormerTrusteeFromSessionToPage } from '../utils/trust/historical.beneficial.owner.mapper';
+import * as CommonTrustDataMapper from '../utils/trust/common.trust.data.mapper';
+import { ApplicationData } from '../model';
+import * as PageModel from '../model/trust.page.model';
+import { saveAndContinue } from '../utils/save.and.continue';
+import { Session } from '@companieshouse/node-session-handler';
+import { FormattedValidationErrors, formatValidationError } from '../middleware/validation.middleware';
+import { validationResult } from 'express-validator';
+import { safeRedirect } from '../utils/http.ext';
+
+export const HISTORICAL_BO_TEXTS = {
+  title: 'Tell us about the former beneficial owner',
+};
+
+type TrustHistoricalBeneficialOwnerProperties = {
+  backLinkUrl: string,
+  templateName: string;
+  pageParams: {
+    title: string;
+  },
+  pageData: {
+    trustData: PageModel.CommonTrustData,
+    trusteeType: typeof TrusteeType;
+  },
+  formData?: PageModel.TrustHistoricalBeneficialOwnerForm,
+  errors?: FormattedValidationErrors,
+  url: string,
+};
+
+const getPageProperties = (
+  req: Request,
+  trustId: string,
+  isUpdate: boolean,
+  formData?: PageModel.TrustHistoricalBeneficialOwnerForm,
+  errors?: FormattedValidationErrors,
+): TrustHistoricalBeneficialOwnerProperties => ({
+  backLinkUrl: getBackLinkUrl(isUpdate, trustId),
+  templateName: getPageTemplate(isUpdate),
+  pageParams: {
+    title: HISTORICAL_BO_TEXTS.title,
+  },
+  pageData: {
+    trustData: CommonTrustDataMapper.mapCommonTrustDataToPage(getApplicationData(req.session), trustId),
+    trusteeType: TrusteeType,
+  },
+  formData,
+  errors,
+  url: getUrl(isUpdate),
+});
+
+export const getTrustFormerBo = (req: Request, res: Response, next: NextFunction, isUpdate: boolean): void => {
+  try {
+    logger.debugRequest(req, `${req.method} ${req.route.path}`);
+
+    const trustId = req.params[config.ROUTE_PARAM_TRUST_ID];
+    const trusteeId = req.params[config.ROUTE_PARAM_TRUSTEE_ID];
+    const appData: ApplicationData = getApplicationData(req.session);
+
+    const formData: PageModel.TrustHistoricalBeneficialOwnerForm = mapFormerTrusteeFromSessionToPage(
+      appData,
+      trustId,
+      trusteeId
+    );
+    const pageProps = getPageProperties(req, trustId, isUpdate, formData);
+
+    return res.render(pageProps.templateName, pageProps);
+  } catch (error) {
+    logger.errorRequest(req, error);
+
+    return next(error);
+  }
+};
+
+export const postTrustFormerBo = async (req: Request, res: Response, next: NextFunction, isUpdate: boolean) => {
+  try {
+    logger.debugRequest(req, `${req.method} ${req.route.path}`);
+
+    const trustId = req.params[config.ROUTE_PARAM_TRUST_ID];
+
+    // convert form data to application (session) object
+    const boData = mapBeneficialOwnerToSession(req.body);
+
+    // get trust data from session
+    let appData: ApplicationData = getApplicationData(req.session);
+
+    // check for errors
+    const errorList = validationResult(req);
+    const formData: PageModel.TrustHistoricalBeneficialOwnerForm = req.body as PageModel.TrustHistoricalBeneficialOwnerForm;
+
+    // if no errors present rerender the page
+    if (!errorList.isEmpty()) {
+      const pageProps = getPageProperties(
+        req,
+        trustId,
+        isUpdate,
+        formData,
+        formatValidationError(errorList.array()),
+      );
+
+      return res.render(pageProps.templateName, pageProps);
+    }
+
+    // save (add/update) bo to trust
+    const updatedTrust = saveHistoricalBoInTrust(
+      getTrustByIdFromApp(appData, trustId),
+      boData,
+    );
+
+    // update trust in application data
+    appData = saveTrustInApp(appData, updatedTrust);
+
+    // save to session
+    const session = req.session as Session;
+    setExtraData(session, appData);
+
+    await saveAndContinue(req, session, true);
+
+    return safeRedirect(res, getNextPage(isUpdate, trustId));
+  } catch (error) {
+    logger.errorRequest(req, error);
+
+    return next(error);
+  }
+};
+
+const getBackLinkUrl = (isUpdate: boolean, trustId: String) => (
+  isUpdate
+    ? `${config.UPDATE_TRUSTS_INDIVIDUALS_OR_ENTITIES_INVOLVED_URL}/${trustId}${config.TRUST_INVOLVED_URL}`
+    : `${config.TRUST_ENTRY_URL}/${trustId}${config.TRUST_INVOLVED_URL}`
+);
+
+const getPageTemplate = (isUpdate: boolean) => (
+  isUpdate
+    ? config.UPDATE_TRUSTS_TELL_US_ABOUT_FORMER_BO_PAGE
+    : config.TRUST_HISTORICAL_BENEFICIAL_OWNER_PAGE
+);
+
+const getUrl = (isUpdate: boolean) => (
+  isUpdate
+    ? config.UPDATE_AN_OVERSEAS_ENTITY_URL
+    : config.REGISTER_AN_OVERSEAS_ENTITY_URL
+);
+
+const getNextPage = (isUpdate: boolean, trustId: string) => (
+  isUpdate
+    ? `${config.UPDATE_TRUSTS_INDIVIDUALS_OR_ENTITIES_INVOLVED_URL}/${trustId}${config.TRUST_INVOLVED_URL}`
+    : `${config.TRUST_ENTRY_URL}/${trustId}${config.TRUST_INVOLVED_URL}`
+);

--- a/src/utils/trust/trust.involved.ts
+++ b/src/utils/trust/trust.involved.ts
@@ -127,7 +127,9 @@ const postTrustInvolvedPage = (
     const typeOfTrustee = req.body.typeOfTrustee;
 
     // the req.params['id'] is already validated in the has.trust.middleware but sonar can not recognise this.
-    let url = `${config.TRUST_ENTRY_URL}/${req.params[config.ROUTE_PARAM_TRUST_ID]}`;
+    let url = isUpdate
+      ? `${config.UPDATE_TRUSTS_INDIVIDUALS_OR_ENTITIES_INVOLVED_URL}/${req.params[config.ROUTE_PARAM_TRUST_ID]}`
+      : `${config.TRUST_ENTRY_URL}/${req.params[config.ROUTE_PARAM_TRUST_ID]}`;
 
     switch (typeOfTrustee) {
         case TrusteeType.HISTORICAL:

--- a/test/controllers/add.trust.controller.spec.ts
+++ b/test/controllers/add.trust.controller.spec.ts
@@ -16,7 +16,7 @@ import { Session } from '@companieshouse/node-session-handler';
 import { ANY_MESSAGE_ERROR, PAGE_TITLE_ERROR } from "../__mocks__/text.mock";
 import { getApplicationData } from "../../src/utils/application.data";
 import { authentication } from "../../src/middleware/authentication.middleware";
-import { hasTrustData } from "../../src/middleware/navigation/has.trust.middleware";
+import { hasTrustDataRegister } from "../../src/middleware/navigation/has.trust.middleware";
 import { Trust, TrustKey } from "../../src/model/trust.model";
 import { generateTrustId } from "../../src/utils/trust/details.mapper";
 import { get, post } from "../../src/controllers/add.trust.controller";
@@ -129,7 +129,7 @@ describe("Add Trust Controller Tests", () => {
   describe('Endpoint Access tests with supertest', () => {
     beforeEach(() => {
       (authentication as jest.Mock).mockImplementation((_, __, next: NextFunction) => next());
-      (hasTrustData as jest.Mock).mockImplementation((_, __, next: NextFunction) => next());
+      (hasTrustDataRegister as jest.Mock).mockImplementation((_, __, next: NextFunction) => next());
     });
 
     test(`successfully access GET method`, async () => {
@@ -141,7 +141,7 @@ describe("Add Trust Controller Tests", () => {
       expect(resp.text).not.toContain(PAGE_TITLE_ERROR);
 
       expect(authentication).toBeCalledTimes(1);
-      expect(hasTrustData).toBeCalledTimes(1);
+      expect(hasTrustDataRegister).toBeCalledTimes(1);
     });
 
     test(`successfully access POST method`, async () => {

--- a/test/controllers/trust.historical.beneficial.owner.controller.spec.ts
+++ b/test/controllers/trust.historical.beneficial.owner.controller.spec.ts
@@ -17,10 +17,11 @@ import { Params } from 'express-serve-static-core';
 import { Session } from '@companieshouse/node-session-handler';
 import request from "supertest";
 import app from "../../src/app";
-import { get, HISTORICAL_BO_TEXTS, post } from "../../src/controllers/trust.historical.beneficial.owner.controller";
+import { get, post } from "../../src/controllers/trust.historical.beneficial.owner.controller";
+import { HISTORICAL_BO_TEXTS } from '../../src/utils/trust.former.bo';
 import { ANY_MESSAGE_ERROR, PAGE_TITLE_ERROR } from '../__mocks__/text.mock';
 import { authentication } from '../../src/middleware/authentication.middleware';
-import { hasTrustWithId } from '../../src/middleware/navigation/has.trust.middleware';
+import { hasTrustWithIdRegister } from '../../src/middleware/navigation/has.trust.middleware';
 import { TRUST_ENTRY_URL, TRUST_HISTORICAL_BENEFICIAL_OWNER_URL } from '../../src/config';
 import { Trust, TrustHistoricalBeneficialOwner, TrustKey } from '../../src/model/trust.model';
 import { getApplicationData, setExtraData } from '../../src/utils/application.data';
@@ -148,7 +149,7 @@ describe('Trust Historical Beneficial Owner Controller', () => {
   describe('Endpoint Access tests', () => {
     beforeEach(() => {
       (authentication as jest.Mock).mockImplementation((_, __, next: NextFunction) => next());
-      (hasTrustWithId as jest.Mock).mockImplementation((_, __, next: NextFunction) => next());
+      (hasTrustWithIdRegister as jest.Mock).mockImplementation((_, __, next: NextFunction) => next());
     });
 
     test('successfully access GET method and render', async () => {
@@ -166,7 +167,7 @@ describe('Trust Historical Beneficial Owner Controller', () => {
       expect(resp.text).not.toContain(PAGE_TITLE_ERROR);
 
       expect(authentication).toBeCalledTimes(1);
-      expect(hasTrustWithId).toBeCalledTimes(1);
+      expect(hasTrustWithIdRegister).toBeCalledTimes(1);
     });
 
     test('successfully access POST method', async () => {
@@ -177,7 +178,7 @@ describe('Trust Historical Beneficial Owner Controller', () => {
       expect(resp.text).toContain(PAGE_TITLE_ERROR);
 
       expect(authentication).toBeCalledTimes(1);
-      expect(hasTrustWithId).toBeCalledTimes(1);
+      expect(hasTrustWithIdRegister).toBeCalledTimes(1);
     });
   });
 });

--- a/test/controllers/trust.individual.beneficial.owner.controller.int.spec.ts
+++ b/test/controllers/trust.individual.beneficial.owner.controller.int.spec.ts
@@ -14,7 +14,7 @@ import request from "supertest";
 import { constants } from 'http2';
 import app from "../../src/app";
 import { authentication } from "../../src/middleware/authentication.middleware";
-import { hasTrustWithId } from '../../src/middleware/navigation/has.trust.middleware';
+import { hasTrustWithIdRegister } from '../../src/middleware/navigation/has.trust.middleware';
 import { TRUST_ENTRY_URL, TRUST_INDIVIDUAL_BENEFICIAL_OWNER_PAGE, TRUST_INDIVIDUAL_BENEFICIAL_OWNER_URL } from '../../src/config';
 import { getTrustByIdFromApp } from '../../src/utils/trusts';
 import { TRUST_WITH_ID } from '../__mocks__/session.mock';
@@ -37,7 +37,7 @@ describe('Trust Individual Beneficial Owner Controller Integration Tests', () =>
   beforeEach(() => {
     jest.clearAllMocks();
     (authentication as jest.Mock).mockImplementation((_, __, next: NextFunction) => next());
-    (hasTrustWithId as jest.Mock).mockImplementation((_, __, next: NextFunction) => next());
+    (hasTrustWithIdRegister as jest.Mock).mockImplementation((_, __, next: NextFunction) => next());
   });
 
   describe("POST tests", () => {

--- a/test/controllers/trust.individual.beneficial.owner.controller.spec.ts
+++ b/test/controllers/trust.individual.beneficial.owner.controller.spec.ts
@@ -22,7 +22,7 @@ import app from "../../src/app";
 import { get, INDIVIDUAL_BO_TEXTS, post } from "../../src/controllers/trust.individual.beneficial.owner.controller";
 import { ANY_MESSAGE_ERROR, PAGE_TITLE_ERROR } from '../__mocks__/text.mock';
 import { authentication } from '../../src/middleware/authentication.middleware';
-import { hasTrustWithId } from '../../src/middleware/navigation/has.trust.middleware';
+import { hasTrustWithIdRegister } from '../../src/middleware/navigation/has.trust.middleware';
 import { TRUST_ENTRY_URL, TRUST_INDIVIDUAL_BENEFICIAL_OWNER_PAGE, TRUST_INDIVIDUAL_BENEFICIAL_OWNER_URL, TRUST_INVOLVED_URL } from '../../src/config';
 import { getApplicationData, setExtraData } from '../../src/utils/application.data';
 import { TRUST_WITH_ID } from '../__mocks__/session.mock';
@@ -180,7 +180,7 @@ describe('Trust Individual Beneficial Owner Controller', () => {
   describe('Endpoint Access tests with supertest', () => {
     beforeEach(() => {
       (authentication as jest.Mock).mockImplementation((_, __, next: NextFunction) => next());
-      (hasTrustWithId as jest.Mock).mockImplementation((_, __, next: NextFunction) => next());
+      (hasTrustWithIdRegister as jest.Mock).mockImplementation((_, __, next: NextFunction) => next());
     });
 
     test(`successfully access GET method`, async () => {
@@ -197,7 +197,7 @@ describe('Trust Individual Beneficial Owner Controller', () => {
       expect(resp.text).not.toContain(PAGE_TITLE_ERROR);
 
       expect(authentication).toBeCalledTimes(1);
-      expect(hasTrustWithId).toBeCalledTimes(1);
+      expect(hasTrustWithIdRegister).toBeCalledTimes(1);
     });
 
     test('successfully access POST method', async () => {
@@ -212,7 +212,7 @@ describe('Trust Individual Beneficial Owner Controller', () => {
       expect(resp.header.location).toEqual(`${TRUST_ENTRY_URL}/${trustId}${TRUST_INVOLVED_URL}`);
 
       expect(authentication).toBeCalledTimes(1);
-      expect(hasTrustWithId).toBeCalledTimes(1);
+      expect(hasTrustWithIdRegister).toBeCalledTimes(1);
       expect(mockSaveAndContinue).toHaveBeenCalledTimes(1);
     });
   });

--- a/test/controllers/trust.legal.entity.beneficial.owner.controller.int.spec.ts
+++ b/test/controllers/trust.legal.entity.beneficial.owner.controller.int.spec.ts
@@ -12,7 +12,7 @@ import { NextFunction } from "express";
 import app from "../../src/app";
 import { TRUST_ENTRY_URL, TRUST_LEGAL_ENTITY_BENEFICIAL_OWNER_PAGE, TRUST_LEGAL_ENTITY_BENEFICIAL_OWNER_URL } from "../../src/config";
 import { authentication } from "../../src/middleware/authentication.middleware";
-import { hasTrustWithId } from "../../src/middleware/navigation/has.trust.middleware";
+import { hasTrustWithIdRegister } from "../../src/middleware/navigation/has.trust.middleware";
 import { Trust } from "../../src/model/trust.model";
 import { saveAndContinue } from "../../src/utils/save.and.continue";
 import { getTrustByIdFromApp } from "../../src/utils/trusts";
@@ -35,7 +35,7 @@ describe("Legal entity beneficial owner integration tests", () => {
     legalEntityWithMissingFields = {};
     jest.clearAllMocks();
     (authentication as jest.Mock).mockImplementation((_, __, next: NextFunction) => next());
-    (hasTrustWithId as jest.Mock).mockImplementation((_, __, next: NextFunction) => next());
+    (hasTrustWithIdRegister as jest.Mock).mockImplementation((_, __, next: NextFunction) => next());
   });
 
   test(`renders the ${TRUST_LEGAL_ENTITY_BENEFICIAL_OWNER_PAGE} page with missing mandatory field messages`, async () => {

--- a/test/controllers/trust.legal.entity.beneficial.owner.controller.spec.ts
+++ b/test/controllers/trust.legal.entity.beneficial.owner.controller.spec.ts
@@ -28,7 +28,7 @@ import {
 } from "../../src/controllers/trust.legal.entity.beneficial.owner.controller";
 import { ANY_MESSAGE_ERROR, PAGE_TITLE_ERROR } from "../__mocks__/text.mock";
 import { authentication } from "../../src/middleware/authentication.middleware";
-import { hasTrustWithId } from "../../src/middleware/navigation/has.trust.middleware";
+import { hasTrustWithIdRegister } from "../../src/middleware/navigation/has.trust.middleware";
 import {
   TRUST_ENTRY_URL,
   TRUST_LEGAL_ENTITY_BENEFICIAL_OWNER_URL,
@@ -207,7 +207,7 @@ describe("Trust Legal Entity Beneficial Owner Controller", () => {
       (authentication as jest.Mock).mockImplementation(
         (_, __, next: NextFunction) => next()
       );
-      (hasTrustWithId as jest.Mock).mockImplementation((_, __, next: NextFunction) =>
+      (hasTrustWithIdRegister as jest.Mock).mockImplementation((_, __, next: NextFunction) =>
         next()
       );
     });
@@ -230,7 +230,7 @@ describe("Trust Legal Entity Beneficial Owner Controller", () => {
       expect(resp.text).not.toContain(PAGE_TITLE_ERROR);
 
       expect(authentication).toBeCalledTimes(1);
-      expect(hasTrustWithId).toBeCalledTimes(1);
+      expect(hasTrustWithIdRegister).toBeCalledTimes(1);
     });
 
     test("successfully access POST method", async () => {
@@ -242,7 +242,7 @@ describe("Trust Legal Entity Beneficial Owner Controller", () => {
       );
 
       expect(authentication).toBeCalledTimes(1);
-      expect(hasTrustWithId).toBeCalledTimes(1);
+      expect(hasTrustWithIdRegister).toBeCalledTimes(1);
       expect(mockSaveAndContinue).toHaveBeenCalledTimes(1);
     });
 
@@ -257,7 +257,7 @@ describe("Trust Legal Entity Beneficial Owner Controller", () => {
 
       expect(resp.status).toEqual(constants.HTTP_STATUS_OK);
       expect(authentication).toBeCalledTimes(1);
-      expect(hasTrustWithId).toBeCalledTimes(1);
+      expect(hasTrustWithIdRegister).toBeCalledTimes(1);
     });
   });
 });

--- a/test/controllers/trusts.involved.controller.spec.ts
+++ b/test/controllers/trusts.involved.controller.spec.ts
@@ -32,7 +32,7 @@ import {
 } from '../../src/config';
 import { get, post } from "../../src/controllers/trust.involved.controller";
 import { authentication } from '../../src/middleware/authentication.middleware';
-import { hasTrustWithId } from '../../src/middleware/navigation/has.trust.middleware';
+import { hasTrustWithIdRegister } from '../../src/middleware/navigation/has.trust.middleware';
 import { ErrorMessages } from '../../src/validation/error.messages';
 import { TrusteeType } from '../../src/model/trustee.type.model';
 import { getApplicationData } from '../../src/utils/application.data';
@@ -290,7 +290,7 @@ describe('Trust Involved controller', () => {
   describe('Endpoint Access tests with supertest', () => {
     beforeEach(() => {
       (authentication as jest.Mock).mockImplementation((_, __, next: NextFunction) => next());
-      (hasTrustWithId as jest.Mock).mockImplementation((_, __, next: NextFunction) => next());
+      (hasTrustWithIdRegister as jest.Mock).mockImplementation((_, __, next: NextFunction) => next());
     });
 
     test(`successfully access GET method`, async () => {
@@ -305,7 +305,7 @@ describe('Trust Involved controller', () => {
       expect(resp.text).toContain(TRUST_INVOLVED_TITLE);
       expect(resp.text).toContain(mockTrustData.trustName);
       expect(resp.text).not.toContain(PAGE_TITLE_ERROR);
-      expect(hasTrustWithId).toBeCalledTimes(1);
+      expect(hasTrustWithIdRegister).toBeCalledTimes(1);
     });
 
     test(`successfully access POST method`, async () => {

--- a/test/controllers/update/update.trusts.historical.beneficial.owner.controller.spec.ts
+++ b/test/controllers/update/update.trusts.historical.beneficial.owner.controller.spec.ts
@@ -1,0 +1,212 @@
+jest.mock("ioredis");
+jest.mock("../../../src/utils/application.data");
+jest.mock('../../../src/utils/trust/historical.beneficial.owner.mapper');
+jest.mock('../../../src/middleware/authentication.middleware');
+jest.mock('../../../src/middleware/company.authentication.middleware');
+jest.mock('../../../src/utils/save.and.continue');
+jest.mock('../../../src/middleware/navigation/has.trust.middleware');
+jest.mock('../../../src/utils/feature.flag');
+jest.mock('../../../src/utils/trusts');
+jest.mock('../../../src/utils/trust/common.trust.data.mapper');
+jest.mock('../../../src/middleware/navigation/update/has.presenter.middleware');
+jest.mock('../../../src/middleware/service.availability.middleware');
+
+import { constants } from 'http2';
+import { beforeEach, describe, expect, jest, test } from '@jest/globals';
+import { NextFunction, Request, Response } from "express";
+import { Params } from 'express-serve-static-core';
+import { Session } from '@companieshouse/node-session-handler';
+import request from "supertest";
+import app from "../../../src/app";
+import { get, post } from "../../../src/controllers/trust.historical.beneficial.owner.controller";
+import { HISTORICAL_BO_TEXTS } from '../../../src/utils/trust.former.bo';
+import { ANY_MESSAGE_ERROR, PAGE_NOT_FOUND_TEXT, PAGE_TITLE_ERROR } from '../../__mocks__/text.mock';
+import { authentication } from '../../../src/middleware/authentication.middleware';
+import { hasTrustWithIdUpdate } from '../../../src/middleware/navigation/has.trust.middleware';
+import { UPDATE_TRUSTS_INDIVIDUALS_OR_ENTITIES_INVOLVED_URL, TRUST_HISTORICAL_BENEFICIAL_OWNER_URL } from '../../../src/config';
+import { Trust, TrustHistoricalBeneficialOwner, TrustKey } from '../../../src/model/trust.model';
+import { getApplicationData, setExtraData } from '../../../src/utils/application.data';
+import { getTrustByIdFromApp, saveHistoricalBoInTrust, saveTrustInApp } from '../../../src/utils/trusts';
+import { mapBeneficialOwnerToSession } from '../../../src/utils/trust/historical.beneficial.owner.mapper';
+import { mapCommonTrustDataToPage } from '../../../src/utils/trust/common.trust.data.mapper';
+import { companyAuthentication } from '../../../src/middleware/company.authentication.middleware';
+import { hasUpdatePresenter } from '../../../src/middleware/navigation/update/has.presenter.middleware';
+import { serviceAvailabilityMiddleware } from '../../../src/middleware/service.availability.middleware';
+import { isActiveFeature } from '../../../src/utils/feature.flag';
+
+const mockIsActiveFeature = isActiveFeature as jest.Mock;
+const mockGetApplicationData = getApplicationData as jest.Mock;
+
+const mockAuthentication = (authentication as jest.Mock);
+mockAuthentication.mockImplementation((_, __, next: NextFunction) => next());
+
+const mockCompanyAuthentication = (companyAuthentication as jest.Mock);
+mockCompanyAuthentication.mockImplementation((_, __, next: NextFunction) => next());
+
+const mockHasUpdatePresenter = (hasUpdatePresenter as jest.Mock);
+mockHasUpdatePresenter.mockImplementation((_, __, next: NextFunction) => next());
+
+const mockHasTrustWithIdUpdate = (hasTrustWithIdUpdate as jest.Mock);
+mockHasTrustWithIdUpdate.mockImplementation((_, __, next: NextFunction) => next());
+
+const mockServiceAvailabilityMiddleware = (serviceAvailabilityMiddleware as jest.Mock);
+mockServiceAvailabilityMiddleware.mockImplementation((_, __, next: NextFunction) => next());
+
+describe('Trust Historical Beneficial Owner Controller', () => {
+  const trustId = '99999';
+  const pageUrl = UPDATE_TRUSTS_INDIVIDUALS_OR_ENTITIES_INVOLVED_URL + "/" + trustId + TRUST_HISTORICAL_BENEFICIAL_OWNER_URL;
+
+  const mockTrust1Data = {
+    trust_id: '999',
+    trust_name: 'dummyTrustName1',
+  } as Trust;
+
+  const mockTrust2Data = {
+    trust_id: '802',
+    trust_name: 'dummyTrustName2',
+  } as Trust;
+
+  const mockTrust3Data = {
+    trust_id: '803',
+    trust_name: 'dummyTrustName3',
+  } as Trust;
+
+  let mockAppData = {};
+
+  let mockReq = {} as Request;
+  const mockRes = {
+    render: jest.fn() as any,
+    redirect: jest.fn() as any,
+  } as Response;
+  const mockNext = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockIsActiveFeature.mockReturnValue(true);
+
+    mockAppData = {
+      [TrustKey]: [
+        mockTrust1Data,
+        mockTrust2Data,
+        mockTrust3Data,
+      ],
+    };
+
+    mockReq = {
+      params: {
+        trustId: trustId,
+      } as Params,
+      headers: {},
+      session: {} as Session,
+      route: '',
+      method: '',
+      body: { 'body': 'dummy' },
+    } as Request;
+  });
+
+  describe('GET unit tests', () => {
+    test('catch error when renders the page', () => {
+      const error = new Error(ANY_MESSAGE_ERROR);
+      mockGetApplicationData.mockImplementationOnce(() => { throw error; });
+
+      get(mockReq, mockRes, mockNext);
+
+      expect(mockNext).toBeCalledTimes(1);
+      expect(mockNext).toBeCalledWith(error);
+    });
+  });
+
+  describe('POST unit tests', () => {
+    test('Save', () => {
+      const mockBoData = {} as TrustHistoricalBeneficialOwner;
+      (mapBeneficialOwnerToSession as jest.Mock).mockReturnValue(mockBoData);
+
+      mockGetApplicationData.mockReturnValue(mockAppData);
+
+      const mockUpdatedTrust = {} as Trust;
+      (saveHistoricalBoInTrust as jest.Mock).mockReturnValue(mockBoData);
+
+      const mockTrust = {} as Trust;
+      (getTrustByIdFromApp as jest.Mock).mockReturnValue(mockTrust);
+
+      const mockUpdatedAppData = {} as Trust;
+      (saveTrustInApp as jest.Mock).mockReturnValue(mockUpdatedAppData);
+
+      post(mockReq, mockRes, mockNext);
+
+      expect(mapBeneficialOwnerToSession).toBeCalledTimes(1);
+      expect(mapBeneficialOwnerToSession).toBeCalledWith(mockReq.body);
+
+      expect(getTrustByIdFromApp).toBeCalledTimes(1);
+      expect(getTrustByIdFromApp).toBeCalledWith(mockAppData, trustId);
+
+      expect(saveHistoricalBoInTrust).toBeCalledTimes(1);
+      expect(saveHistoricalBoInTrust).toBeCalledWith(mockTrust, mockBoData);
+
+      expect(saveTrustInApp).toBeCalledTimes(1);
+      expect(saveTrustInApp).toBeCalledWith(mockAppData, mockUpdatedTrust);
+
+      expect(setExtraData as jest.Mock).toBeCalledWith(
+        mockReq.session,
+        mockUpdatedAppData,
+      );
+    });
+
+    test('catch error when renders the page', () => {
+      const error = new Error(ANY_MESSAGE_ERROR);
+      (mapBeneficialOwnerToSession as jest.Mock).mockImplementationOnce(() => { throw error; });
+
+      post(mockReq, mockRes, mockNext);
+
+      expect(mockNext).toBeCalledTimes(1);
+      expect(mockNext).toBeCalledWith(error);
+    });
+  });
+
+  describe('Endpoint Access tests', () => {
+    test('successfully access GET method and render', async () => {
+      (mapCommonTrustDataToPage as jest.Mock).mockReturnValue({ trustName: 'dummyName' });
+
+      const resp = await request(app).get(pageUrl);
+
+      expect(resp.text).toContain('dummyName');
+
+      expect(resp.status).toEqual(constants.HTTP_STATUS_OK);
+      expect(resp.text).toContain(HISTORICAL_BO_TEXTS.title);
+      expect(resp.text).not.toContain(PAGE_TITLE_ERROR);
+
+      expect(authentication).toBeCalledTimes(1);
+      expect(hasTrustWithIdUpdate).toBeCalledTimes(1);
+    });
+
+    test('successfully access POST method', async () => {
+      const resp = await request(app).post(pageUrl).send({});
+
+      expect(resp.status).toEqual(constants.HTTP_STATUS_OK);
+      expect(resp.text).toContain(HISTORICAL_BO_TEXTS.title);
+      expect(resp.text).toContain(PAGE_TITLE_ERROR);
+
+      expect(authentication).toBeCalledTimes(1);
+      expect(hasTrustWithIdUpdate).toBeCalledTimes(1);
+    });
+
+    test('when feature flag for update trusts is off GET returns 404', async () => {
+      mockIsActiveFeature.mockReturnValue(false);
+
+      const resp = await request(app).get(pageUrl);
+
+      expect(resp.status).toEqual(404);
+      expect(resp.text).toContain(PAGE_NOT_FOUND_TEXT);
+    });
+
+    test('when feature flag for update trusts is off POST returns 404', async () => {
+      mockIsActiveFeature.mockReturnValue(false);
+
+      const resp = await request(app).post(pageUrl).send({});
+
+      expect(resp.status).toEqual(404);
+      expect(resp.text).toContain(PAGE_NOT_FOUND_TEXT);
+    });
+  });
+});

--- a/test/middleware/navigation/has.trust.middleware.spec.ts
+++ b/test/middleware/navigation/has.trust.middleware.spec.ts
@@ -4,22 +4,25 @@ jest.mock("ioredis");
 import { Request, Response } from "express";
 import { beforeEach, describe, expect, jest, test } from "@jest/globals";
 import { logger } from "../../../src/utils/logger";
-import { hasTrustWithId, hasTrustData } from "../../../src/middleware/navigation/has.trust.middleware";
+import { hasTrustWithIdRegister, hasTrustDataRegister, hasTrustWithIdUpdate, hasTrustDataUpdate } from "../../../src/middleware/navigation/has.trust.middleware";
 import { Session } from "@companieshouse/node-session-handler";
 import { Params } from "express-serve-static-core";
 import { ANY_MESSAGE_ERROR } from "../../__mocks__/text.mock";
 import { APPLICATION_DATA_NO_TRUSTS_MOCK, APPLICATION_DATA_WITH_TRUST_ID_MOCK, TRUST_WITH_ID } from "../../__mocks__/session.mock";
 import { getApplicationData } from "../../../src/utils/application.data";
-import { SOLD_LAND_FILTER_URL } from "../../../src/config";
+import { SECURE_UPDATE_FILTER_URL, SOLD_LAND_FILTER_URL } from "../../../src/config";
 
-describe("hasTrustWithId Middleware tests", () => {
-  let req = {} as Request;
+describe("Trusts Middleware tests", () => {
+  const mockGetApplicationData = getApplicationData as jest.Mock;
+  const next = jest.fn();
+
   const res = {
     status: jest.fn().mockReturnThis() as any,
     render: jest.fn() as any,
     redirect: jest.fn() as any,
   } as Response;
-  const next = jest.fn();
+
+  let req = {} as Request;
 
   beforeEach(() => {
     logger.infoRequest = jest.fn();
@@ -27,88 +30,157 @@ describe("hasTrustWithId Middleware tests", () => {
     jest.clearAllMocks();
   });
 
-  test("Trust present, return next", () => {
-    req = {
-      params: {
-        trustId: TRUST_WITH_ID.trust_id,
-      } as Params,
-      session: {} as Session,
-      route: "",
-      method: "",
-    } as Request;
+  describe('register tests', () => {
+    test("Trust present, return next", () => {
+      req = {
+        params: {
+          trustId: TRUST_WITH_ID.trust_id,
+        } as Params,
+        session: {} as Session,
+        route: "",
+        method: "",
+      } as Request;
 
-    (getApplicationData as jest.Mock).mockReturnValue(
-      APPLICATION_DATA_WITH_TRUST_ID_MOCK
-    );
+      mockGetApplicationData.mockReturnValueOnce(APPLICATION_DATA_WITH_TRUST_ID_MOCK);
 
-    hasTrustWithId(req, res, next);
+      hasTrustWithIdRegister(req, res, next);
 
-    expect(next).toBeCalled();
-    expect(res.redirect).not.toBeCalled();
-  });
-
-  test("Trust not present, redirect to landing page", () => {
-    req = {
-      params: {
-        trustId: "otherID",
-      } as Params,
-      session: {} as Session,
-      route: "",
-      method: "",
-    } as Request;
-
-    (getApplicationData as jest.Mock).mockReturnValue(
-      APPLICATION_DATA_WITH_TRUST_ID_MOCK
-    );
-
-    hasTrustWithId(req, res, next);
-
-    expect(res.redirect).toBeCalled();
-    expect(res.redirect).toBeCalledWith(SOLD_LAND_FILTER_URL);
-    expect(next).not.toBeCalled();
-  });
-
-  test("Submission contains trust data", () => {
-    (getApplicationData as jest.Mock).mockReturnValue(
-      APPLICATION_DATA_WITH_TRUST_ID_MOCK
-    );
-
-    hasTrustData(req, res, next);
-
-    expect(next).toBeCalled();
-    expect(res.redirect).not.toBeCalled();
-  });
-
-  test("Submission does not contain trust data", () => {
-    (getApplicationData as jest.Mock).mockReturnValue(
-      APPLICATION_DATA_NO_TRUSTS_MOCK
-    );
-
-    hasTrustData(req, res, next);
-
-    expect(res.redirect).toBeCalled();
-    expect(res.redirect).toBeCalledWith(SOLD_LAND_FILTER_URL);
-    expect(next).not.toBeCalled();
-  });
-
-  test("catch error when renders the page", () => {
-    req = {
-      params: {
-        trustId: "otherID",
-      } as Params,
-      session: {} as Session,
-      route: "",
-      method: "",
-    } as Request;
-
-    const error = new Error(ANY_MESSAGE_ERROR);
-    (getApplicationData as jest.Mock).mockImplementationOnce(() => {
-      throw error;
+      expect(next).toBeCalled();
+      expect(res.redirect).not.toBeCalled();
     });
 
-    hasTrustWithId(req, res, next);
+    test("Trust not present, redirect to landing page", () => {
+      req = {
+        params: {
+          trustId: "otherID",
+        } as Params,
+        session: {} as Session,
+        route: "",
+        method: "",
+      } as Request;
 
-    expect(next).toBeCalledTimes(1);
-    expect(next).toBeCalledWith(error);
+      mockGetApplicationData.mockReturnValueOnce(APPLICATION_DATA_WITH_TRUST_ID_MOCK);
+
+      hasTrustWithIdRegister(req, res, next);
+
+      expect(res.redirect).toBeCalled();
+      expect(res.redirect).toBeCalledWith(SOLD_LAND_FILTER_URL);
+      expect(next).not.toBeCalled();
+    });
+
+    test("Submission contains trust data", () => {
+      mockGetApplicationData.mockReturnValueOnce(APPLICATION_DATA_WITH_TRUST_ID_MOCK);
+
+      hasTrustDataRegister(req, res, next);
+
+      expect(next).toBeCalled();
+      expect(res.redirect).not.toBeCalled();
+    });
+
+    test("Submission does not contain trust data", () => {
+      mockGetApplicationData.mockReturnValueOnce(APPLICATION_DATA_NO_TRUSTS_MOCK);
+
+      hasTrustDataRegister(req, res, next);
+
+      expect(res.redirect).toBeCalled();
+      expect(res.redirect).toBeCalledWith(SOLD_LAND_FILTER_URL);
+      expect(next).not.toBeCalled();
+    });
+
+    test("catch error when renders the page", () => {
+      req = {
+        params: {
+          trustId: "otherID",
+        } as Params,
+        session: {} as Session,
+        route: "",
+        method: "",
+      } as Request;
+
+      const error = new Error(ANY_MESSAGE_ERROR);
+      mockGetApplicationData.mockImplementationOnce(() => { throw error; });
+
+      hasTrustWithIdRegister(req, res, next);
+
+      expect(next).toBeCalledTimes(1);
+      expect(next).toBeCalledWith(error);
+    });
+  });
+
+  describe('update tests', () => {
+    test("Trust present, return next", () => {
+      req = {
+        params: {
+          trustId: TRUST_WITH_ID.trust_id,
+        } as Params,
+        session: {} as Session,
+        route: "",
+        method: "",
+      } as Request;
+
+      mockGetApplicationData.mockReturnValueOnce(APPLICATION_DATA_WITH_TRUST_ID_MOCK);
+
+      hasTrustWithIdUpdate(req, res, next);
+
+      expect(next).toBeCalled();
+      expect(res.redirect).not.toBeCalled();
+    });
+
+    test("Trust not present, redirect to landing page", () => {
+      req = {
+        params: {
+          trustId: "otherID",
+        } as Params,
+        session: {} as Session,
+        route: "",
+        method: "",
+      } as Request;
+
+      mockGetApplicationData.mockReturnValueOnce(APPLICATION_DATA_WITH_TRUST_ID_MOCK);
+
+      hasTrustWithIdUpdate(req, res, next);
+
+      expect(res.redirect).toBeCalled();
+      expect(res.redirect).toBeCalledWith(SECURE_UPDATE_FILTER_URL);
+      expect(next).not.toBeCalled();
+    });
+
+    test("Submission contains trust data", () => {
+      mockGetApplicationData.mockReturnValueOnce(APPLICATION_DATA_WITH_TRUST_ID_MOCK);
+
+      hasTrustDataUpdate(req, res, next);
+
+      expect(next).toBeCalled();
+      expect(res.redirect).not.toBeCalled();
+    });
+
+    test("Submission does not contain trust data", () => {
+      mockGetApplicationData.mockReturnValueOnce(APPLICATION_DATA_NO_TRUSTS_MOCK);
+
+      hasTrustDataUpdate(req, res, next);
+
+      expect(res.redirect).toBeCalled();
+      expect(res.redirect).toBeCalledWith(SECURE_UPDATE_FILTER_URL);
+      expect(next).not.toBeCalled();
+    });
+
+    test("catch error when renders the page", () => {
+      req = {
+        params: {
+          trustId: "otherID",
+        } as Params,
+        session: {} as Session,
+        route: "",
+        method: "",
+      } as Request;
+
+      const error = new Error(ANY_MESSAGE_ERROR);
+      mockGetApplicationData.mockImplementationOnce(() => { throw error; });
+
+      hasTrustWithIdUpdate(req, res, next);
+
+      expect(next).toBeCalledTimes(1);
+      expect(next).toBeCalledWith(error);
+    });
   });
 });

--- a/views/includes/page-templates/trust-historical-bo.html
+++ b/views/includes/page-templates/trust-historical-bo.html
@@ -1,0 +1,113 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    {% include "includes/list/errors.html" %}
+
+    <span class="govuk-caption-l">{{ pageData.trustData.trustName }}</span>
+    <h1 class="govuk-heading-xl govuk-!-margin-0">{{ pageParams.title }}</h1>
+    <br> <p class="govuk-body">You can add more later.</p> <br>
+
+    <form class="form" method="post">
+      {% set legalEntityHtml %}
+      <br>
+      {% set fieldParam = {
+        name: 'corporate_name',
+        label: 'Name',
+        value: formData.corporate_name,
+        classes: 'govuk-!-width-two-thirds',
+        error: errors.corporate_name if errors
+      } %}
+      {% include "includes/inputs/text-input.html" %}
+      {% endset -%}
+
+      {% set individualBoHtml %}
+      <br>
+      {% set fieldParam = {
+        name: 'firstName',
+        label: 'First Name',
+        value: formData.firstName,
+        classes: 'govuk-!-width-two-thirds',
+        error: errors.firstName if errors
+      } %}
+      {% include "includes/inputs/text-input.html" %}
+
+      {% set fieldParam = {
+        name: 'lastName',
+        label: 'Last Name',
+        classes: 'govuk-!-width-two-thirds',
+        value: formData.lastName,
+        error: errors.lastName if errors
+      } %}
+      {% include "includes/inputs/text-input.html" %}
+      {% endset -%}
+
+      {% set fieldParam = {
+        name: 'type',
+        label: 'Is the former beneficial owner an individual or a legal entity?',
+        error: errors.type if errors,
+        value: formData.type,
+        items: [
+          {
+            value: pageData.trusteeType.LEGAL_ENTITY,
+            text: "Legal Entity",
+            checked: formData.type == pageData.trusteeType.LEGAL_ENTITY,
+            conditional: {
+              html: legalEntityHtml
+            }
+          },
+          {
+            value: pageData.trusteeType.INDIVIDUAL,
+            text: "Individual",
+            checked: formData.type == pageData.trusteeType.INDIVIDUAL,
+            conditional: {
+              html: individualBoHtml
+            }
+          }
+        ]
+      } %}
+      {% include "includes/inputs/radio-input.html" %}
+
+      {% set date_classes_year = "govuk-input--width-4 govuk-input" %}
+      {% set date_classes_month = "govuk-input--width-2 govuk-input" %}
+      {% set date_classes_day = "govuk-input--width-2 govuk-input" %}
+
+      {% set fieldParam = {
+        name: 'startDate',
+        label: 'When did they become a beneficial owner?',
+        value: {
+          'Day': formData.startDateDay,
+          'Month': formData.startDateMonth,
+          'Year': formData.startDateYear
+        },
+        hint: 'For example, 27 3 2007',
+        error: errors.startDate if errors
+      } %}
+
+      {% include "includes/inputs/date-input.html" %}
+
+      {% set fieldParam = {
+        name: 'endDate',
+        label: 'When did they stop being a beneficial owner?',
+        value: {
+          'Day': formData.endDateDay,
+          'Month': formData.endDateMonth,
+          'Year': formData.endDateYear
+        },
+        hint: 'For example, 28 5 2011',
+        error: errors.endDate if errors
+      } %}
+
+      {% include "includes/inputs/date-input.html" %}
+
+      {{ govukInsetText({
+        html: '
+          <h2 class="govuk-heading-m">What information we’ll show on the public register</h2>
+          <p>We will not show any of the information you provide on this screen on the public Register of Overseas Entities. However, we may share it with HMRC.</p>
+        '
+      }) }}
+
+      <input type="hidden" name="boId" value="{{ formData.boId }}"/>
+
+      {% include "includes/save-and-continue-button.html" %}
+    </form>
+  </div>
+</div>

--- a/views/update/update-trusts-tell-us-about-former-bo.html
+++ b/views/update/update-trusts-tell-us-about-former-bo.html
@@ -1,9 +1,9 @@
-{% extends "layout.html" %}
+{% extends "update-layout.html" %}
 
-{% set title = "Historical beneficial owner" %}
+{% set title = pageParams.title %}
 
 {% block pageTitle %}
-  {% include "includes/page-title.html" %}
+  {% include "includes/update-page-title.html" %}
 {% endblock %}
 
 {% block backLink %}


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/UAR-161

### Change description

Added Add Former BO to Trust page in update journey
- refactored existing controller and page from registration into shared util/template files, adding conditional logic for the update journey where appropriate

TODO: Unit tests for the new page 

### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
