### PR TITLE
fix/UAR-1003-missing-rows-managing-officers-check-your-answers

### DIFF
--- a/views/includes/check-your-answers/managing-officer-corporate.html
+++ b/views/includes/check-your-answers/managing-officer-corporate.html
@@ -1,5 +1,3 @@
-{% set inChangeJourney = not pageParams.noChangeFlag %}
-
 {% set mocFormattedPrincipalAddressHtml %}
   {% set address = moc.principal_address %}
   {% include "includes/display_address.html" %}
@@ -28,13 +26,9 @@
   {% endif %}
 {% endset %}
 
-<h3 class="govuk-heading-m">Corporate managing officer</h3>
+{% set changeLinkUrl = OE_CONFIGS.MANAGING_OFFICER_CORPORATE_URL + "/" + moc.id %}
 
-{% if pageParams.isRegistration %}
-  {% set changeLinkUrl = OE_CONFIGS.MANAGING_OFFICER_CORPORATE_URL %}
-{% else %}
-  {% set changeLinkUrl = OE_CONFIGS.UPDATE_MANAGING_OFFICER_CORPORATE_URL %}
-{% endif %}
+<h3 class="govuk-heading-m">Corporate managing officer</h3>
 
 {{ govukSummaryList({
     rows: [
@@ -47,11 +41,11 @@
         },
         actions: {
           items: [CREATE_CHANGE_LINK(
-            changeLinkUrl + "/" + moc.id + OE_CONFIGS.NAME,
+            changeLinkUrl + OE_CONFIGS.NAME,
             "Corporate managing officer " + moc.name + " - name",
             "change-corporate-managing-officer-name-button"
           )]
-        } if inChangeJourney
+        }
       },
       {
         key: {
@@ -62,11 +56,11 @@
         },
         actions: {
           items: [CREATE_CHANGE_LINK(
-            changeLinkUrl + "/" + moc.id + OE_CONFIGS.CHANGE_PRINCIPAL_ADDRESS,
+            changeLinkUrl + OE_CONFIGS.CHANGE_PRINCIPAL_ADDRESS,
             "Corporate managing officer " + moc.name + " - principal or registered office address",
             "change-corporate-managing-officer-principal-address-button"
           )]
-        } if inChangeJourney
+        }
       },
       {
         key: {
@@ -77,11 +71,11 @@
         },
         actions: {
           items: [CREATE_CHANGE_LINK(
-            changeLinkUrl + "/" + moc.id + mocChangeServiceAddressHtml,
+            changeLinkUrl + mocChangeServiceAddressHtml,
             "Corporate managing officer " + moc.name + " - correspondence address",
             "change-corporate-managing-officer-correspondence-address-button"
           )]
-        } if inChangeJourney
+        }
       },
       {
         key: {
@@ -92,11 +86,11 @@
         },
         actions: {
           items: [CREATE_CHANGE_LINK(
-            changeLinkUrl + "/" + moc.id + OE_CONFIGS.LEGAL_FORM,
+            changeLinkUrl + OE_CONFIGS.LEGAL_FORM,
             "Corporate managing officer " + moc.name + " - legal form",
             "change-corporate-managing-officer-legal-form-button"
           )]
-        } if inChangeJourney
+        }
       },
       {
         key: {
@@ -107,11 +101,11 @@
         },
         actions: {
           items: [CREATE_CHANGE_LINK(
-            changeLinkUrl + "/" + moc.id + OE_CONFIGS.LAW_GOVERNED,
+            changeLinkUrl + OE_CONFIGS.LAW_GOVERNED,
             "Corporate managing officer " + moc.name + " - governing law",
             "change-corporate-managing-officer-law-governed-button"
           )]
-        } if inChangeJourney
+        }
       },
       {
         key: {
@@ -122,11 +116,11 @@
         },
         actions: {
           items: [CREATE_CHANGE_LINK(
-            changeLinkUrl + "/" + moc.id + mocChangePublicregisterNameHtml,
+            changeLinkUrl + mocChangePublicregisterNameHtml,
             "Corporate managing officer " + moc.name + " - on a public register in the country it was formed in",
             "change-corporate-managing-officer-public-register-button"
           )]
-        } if inChangeJourney
+        }
       },
       {
         key: {
@@ -137,11 +131,11 @@
         },
         actions: {
           items: [CREATE_CHANGE_LINK(
-            changeLinkUrl + "/" + moc.id + OE_CONFIGS.ROLE_AND_RESPONSIBILITIES,
+            changeLinkUrl + OE_CONFIGS.ROLE_AND_RESPONSIBILITIES,
             "Corporate managing officer " + moc.name + " - role and responsibilities",
             "change-corporate-managing-officer-role-and-responsibilities-button"
           )]
-        } if inChangeJourney
+        }
       },
       {
         key: {
@@ -152,11 +146,11 @@
         },
         actions: {
           items: [CREATE_CHANGE_LINK(
-            changeLinkUrl + "/" + moc.id + OE_CONFIGS.CONTACT_FULL_NAME,
+            changeLinkUrl + OE_CONFIGS.CONTACT_FULL_NAME,
             "Corporate managing officer " + moc.name + " - contact full name",
             "change-corporate-managing-officer-contact-name-button"
           )]
-        } if inChangeJourney
+        }
       },
       {
         key: {
@@ -167,11 +161,11 @@
         },
         actions: {
           items: [CREATE_CHANGE_LINK(
-            changeLinkUrl + "/" + moc.id + OE_CONFIGS.CONTACT_EMAIL,
+            changeLinkUrl + OE_CONFIGS.CONTACT_EMAIL,
             "Corporate managing officer " + moc.name + " - contact email",
             "change-corporate-managing-officer-contact-email-button"
           )]
-        } if inChangeJourney
+        }
       }
     ]
 }) }}

--- a/views/includes/check-your-answers/managing-officer-individual.html
+++ b/views/includes/check-your-answers/managing-officer-individual.html
@@ -1,7 +1,5 @@
 {% import "includes/date-macros.html" as dateMacros %}
 
-{% set inChangeJourney = not pageParams.noChangeFlag %}
-
 {% set moiDateOfBirth = dateMacros.formatDate(moi.date_of_birth["day"], moi.date_of_birth["month"], moi.date_of_birth["year"]) %}
 
 {% set moiFormattedResidentialAddressHtml %}
@@ -28,11 +26,7 @@
   {% endif %}
 {% endset %}
 
-{% if pageParams.isRegistration %}
-  {% set changeLinkUrl = OE_CONFIGS.MANAGING_OFFICER_URL %}
-{% else %}
-  {% set changeLinkUrl = OE_CONFIGS.UPDATE_MANAGING_OFFICER_URL %}
-{% endif %}
+{% set changeLinkUrl = OE_CONFIGS.MANAGING_OFFICER_URL + "/" + moi.id %}
 
 {# Build and add each govukSummaryList row separately so that some rows can be optional #}
 {% set rows=[] %}
@@ -46,11 +40,11 @@
   },
   actions: {
     items: [CREATE_CHANGE_LINK(
-      changeLinkUrl + "/" + moi.id + OE_CONFIGS.FIRST_NAME,
+      changeLinkUrl + OE_CONFIGS.FIRST_NAME,
       "Individual managing officer " + moi.first_name + " " + moi.last_name + " - first name",
       "change-individual-managing-officer-first-name-button"
     )]
-  } if inChangeJourney
+  }
 }), rows) %}
 
 {% set rows = (rows.push({
@@ -62,11 +56,11 @@
   },
   actions: {
     items: [CREATE_CHANGE_LINK(
-      changeLinkUrl + "/" + moi.id + OE_CONFIGS.LAST_NAME,
+      changeLinkUrl + OE_CONFIGS.LAST_NAME,
       "Individual managing officer " + moi.first_name + " " + moi.last_name + " - last name",
       "change-individual-managing-officer-last-name-button"
     )]
-  } if inChangeJourney
+  }
 }), rows) %}
 
 {% set rows = (rows.push({
@@ -78,11 +72,11 @@
   },
   actions: {
     items: [CREATE_CHANGE_LINK(
-      changeLinkUrl + "/" + moi.id + moiChangeFormerNamesHtml,
+      changeLinkUrl + moiChangeFormerNamesHtml,
       "Individual managing officer " + moi.first_name + " " + moi.last_name + " - former names",
       "change-individual-managing-officer-former-names-button"
     )]
-  } if inChangeJourney
+  }
 }), rows) %}
 
 {% set rows = (rows.push({
@@ -94,11 +88,11 @@
   },
   actions: {
     items: [CREATE_CHANGE_LINK(
-      changeLinkUrl + "/" + moi.id + OE_CONFIGS.DATE_OF_BIRTH,
+      changeLinkUrl + OE_CONFIGS.DATE_OF_BIRTH,
       "Individual managing officer " + moi.first_name + " " + moi.last_name + " - date of birth",
       "change-individual-managing-officer-date-of-birth-button"
     )]
-  } if inChangeJourney
+  }
 }), rows) %}
 
 {% set rows = (rows.push({
@@ -110,11 +104,11 @@
   },
   actions: {
     items: [CREATE_CHANGE_LINK(
-      changeLinkUrl + "/" + moi.id + OE_CONFIGS.NATIONALITY,
+      changeLinkUrl + OE_CONFIGS.NATIONALITY,
       "Individual managing officer " + moi.first_name + " " + moi.last_name + " - nationality",
       "change-individual-managing-officer-nationality-button"
     )]
-  } if inChangeJourney
+  }
 }), rows) %}
 
 {% if moi.second_nationality %}
@@ -127,11 +121,11 @@
     },
     actions: {
       items: [CREATE_CHANGE_LINK(
-        changeLinkUrl + "/" + moi.id + OE_CONFIGS.SECOND_NATIONALITY,
+        changeLinkUrl  + OE_CONFIGS.SECOND_NATIONALITY,
         "Individual managing officer " + moi.first_name + " " + moi.last_name + " - second_nationality",
         "change-individual-managing-officer-second-nationality-button"
       )]
-    } if inChangeJourney
+    }
   }), rows) %}
 {% endif %}
 
@@ -144,11 +138,11 @@
   },
   actions: {
     items: [CREATE_CHANGE_LINK(
-      changeLinkUrl + "/" + moi.id + OE_CONFIGS.CHANGE_RESIDENTIAL_ADDRESS,
+      changeLinkUrl + OE_CONFIGS.CHANGE_RESIDENTIAL_ADDRESS,
       "Individual managing officer " + moi.first_name + " " + moi.last_name + " - home address",
       "change-individual-managing-officer-residential-address-button"
     )]
-  } if inChangeJourney
+  }
 }), rows) %}
 
 {% set rows = (rows.push({
@@ -160,11 +154,11 @@
   },
   actions: {
     items: [CREATE_CHANGE_LINK(
-      changeLinkUrl + "/" + moi.id + moiChangeServiceAddressHtml,
+      changeLinkUrl + moiChangeServiceAddressHtml,
       "Individual managing officer " + moi.first_name + " " + moi.last_name + " - correspondence address",
       "change-individual-managing-officer-correspondence-address-button"
     )]
-  } if inChangeJourney
+  }
 }), rows) %}
 
 {% set rows = (rows.push({
@@ -176,11 +170,11 @@
   },
   actions: {
     items: [CREATE_CHANGE_LINK(
-      changeLinkUrl + "/" + moi.id + OE_CONFIGS.OCCUPATION,
+      changeLinkUrl + OE_CONFIGS.OCCUPATION,
       "Individual managing officer " + moi.first_name + " " + moi.last_name + " - occupation",
       "change-individual-managing-officer-occupation-button"
     )]
-  } if inChangeJourney
+  }
 }), rows) %}
 
 {% set rows = (rows.push({
@@ -192,11 +186,11 @@
   },
   actions: {
     items: [CREATE_CHANGE_LINK(
-      changeLinkUrl + "/" + moi.id + OE_CONFIGS.ROLE_AND_RESPONSIBILITIES,
+      changeLinkUrl + OE_CONFIGS.ROLE_AND_RESPONSIBILITIES,
       "Individual managing officer " + moi.first_name + " " + moi.last_name + " - role and responsibilities",
       "change-individual-managing-officer-role-and-responsibilities-button"
     )]
-  } if inChangeJourney
+  }
 }), rows) %}
 
 <h3 class="govuk-heading-m">Individual managing officer</h3>

--- a/views/includes/check-your-answers/update/managing-officers-addresses.html
+++ b/views/includes/check-your-answers/update/managing-officers-addresses.html
@@ -1,7 +1,4 @@
-{% set inNoChangeJourney = pageParams.noChangeFlag %}
-{% set inChangeJourney = not inNoChangeJourney %}
-
-{% if managing_officer_individual %}
+{% if isIndividualManagingOfficer %}
   {% set residentialOrPrincipalAddressText = "Home address" %}
   {% set sameAddressText = "The correspondence address is the same as the home address" %}
   {% set changeResidentialOrPrincipalAddress = OE_CONFIGS.CHANGE_RESIDENTIAL_ADDRESS %}
@@ -34,33 +31,25 @@
 {% endset %}
 
 {% set rows = (rows.push({
-    key: {
-      text: residentialOrPrincipalAddressText
-    },
-    value: {
-      html: moFormattedResidentialOrPrincipalAddressHtml
-    },
-    actions: {
-      items: [CREATE_CHANGE_LINK(
-        changeLinkUrl + OE_CONFIGS.REVIEW_OWNER_INDEX_PARAM + moIndex + changeResidentialOrPrincipalAddress, 
-        moChangeLinkText + " - residential or principal address", 
-        "change-managing-officer-residential-or-principal-address-button"
-      )]
-    } if inChangeJourney
-  }), rows) %}
+  key: { text: residentialOrPrincipalAddressText },
+  value: { html: moFormattedResidentialOrPrincipalAddressHtml },
+  actions: {
+    items: [CREATE_CHANGE_LINK(
+      changeLinkUrl + changeResidentialOrPrincipalAddress, 
+      hiddenTextPrefix + " - residential or principal address", 
+      "change-managing-officer-residential-or-principal-address-button"
+    )]
+  } if inChangeJourney
+}), rows) %}
 
 {% set rows = (rows.push({
-    key: {
-      text: "Correspondence address"
-    },
-    value: {
-      html: moFormattedServiceAddressHtml
-    },
-    actions: {
-      items: [CREATE_CHANGE_LINK(
-        changeLinkUrl + OE_CONFIGS.REVIEW_OWNER_INDEX_PARAM + moIndex + changeCorrespondenceAddress, 
-        moChangeLinkText + " - correspondence address", 
-        "change-managing-officer-correspondence-address-button"
-      )]
-    } if inChangeJourney
+  key: { text: "Correspondence address" },
+  value: { html: moFormattedServiceAddressHtml },
+  actions: {
+    items: [CREATE_CHANGE_LINK(
+      changeLinkUrl + changeCorrespondenceAddress, 
+      hiddenTextPrefix + " - correspondence address", 
+      "change-managing-officer-correspondence-address-button"
+    )]
+  } if inChangeJourney
 }), rows) %}

--- a/views/includes/check-your-answers/update/managing-officers-resigned-on.html
+++ b/views/includes/check-your-answers/update/managing-officers-resigned-on.html
@@ -1,50 +1,42 @@
-{% set inChangeJourney = not pageParams.noChangeFlag %}
+{% set startDateKey = "Date they became a managing officer" if isIndividualManagingOfficer else "Date it became a managing officer" %}
+{% set isResignedKey = "Are they still a managing officer?" if isIndividualManagingOfficer else "Is it still a managing officer?" %}
+{% set isResignedValue = "No" if moIsResigned else "Yes" %}
 
-{% if resigned_on | length %}
+{% if isNewMo %}
   {% set rows = (rows.push({
-    key: {
-      text: "Are they still a managing officer?"
-    },
-    value: {
-      html: "No"
-    },
+    key: { text: startDateKey },
+    value: { html: moStartDate },
     actions: {
       items: [CREATE_CHANGE_LINK(
-        changeLinkUrl + OE_CONFIGS.REVIEW_OWNER_INDEX_PARAM + moIndex + OE_CONFIGS.IS_RESIGNED, 
-        moChangeLinkText + " - is resigned", 
-        "change-managing-officer-is-resigned-button"
+        changeLinkUrl + OE_CONFIGS.START_DATE,
+        hiddenTextPrefix + " - start date",
+        "change-managing-officer-start-date-button"
       )]
     } if inChangeJourney
   }), rows) %}
-  {% set resignedOn = dateMacros.formatDate(resigned_on["day"], resigned_on["month"], resigned_on["year"]) %}
+{% endif %}
+
+{% set rows = (rows.push({
+  key: { text: isResignedKey },
+  value: { text: isResignedValue },
+  actions: {
+    items: [CREATE_CHANGE_LINK(
+      changeLinkUrl + OE_CONFIGS.IS_RESIGNED,
+      hiddenTextPrefix + " - is resigned",
+      "change-managing-officer-is-resigned-button"
+    )]
+  } if inChangeJourney
+}), rows) %}
+
+{% if moIsResigned %}
   {% set rows = (rows.push({
-    key: {
-      text: "Resigned on"
-    },
-    value: {
-      html: resignedOn
-    },
+    key: { text: "Resigned on" },
+    value: { html: moResignedOn },
     actions: {
       items: [CREATE_CHANGE_LINK(
-        changeLinkUrl + OE_CONFIGS.REVIEW_OWNER_INDEX_PARAM + moIndex + OE_CONFIGS.RESIGNED_DATE, 
-        moChangeLinkText + " - resigned on", 
+        changeLinkUrl + OE_CONFIGS.RESIGNED_DATE,
+        hiddenTextPrefix + " - resigned on",
         "change-managing-officer-resigned-on-button"
-      )]
-    } if inChangeJourney
-  }), rows) %}
-{% else %}
-  {% set rows = (rows.push({
-    key: {
-      text: "Are they still a managing officer?"
-    },
-    value: {
-      html: "Yes"
-    },
-    actions: {
-      items: [CREATE_CHANGE_LINK(
-        changeLinkUrl + OE_CONFIGS.REVIEW_OWNER_INDEX_PARAM + moIndex + OE_CONFIGS.IS_RESIGNED, 
-        moChangeLinkText + " - is resigned", 
-        "change-managing-officer-is-resigned-button"
       )]
     } if inChangeJourney
   }), rows) %}

--- a/views/includes/check-your-answers/update/update-managing-officer-corporate.html
+++ b/views/includes/check-your-answers/update/update-managing-officer-corporate.html
@@ -2,19 +2,31 @@
 
 {% set inNoChangeJourney = pageParams.noChangeFlag %}
 {% set inChangeJourney = not inNoChangeJourney %}
+{% set isNewMo = not (moc.ch_reference | length) %}
+{% set moIsOnRegisterInCountryFormedIn = moc.is_on_register_in_country_formed_in == 1 %}
 
+{% set moId = moc.id %}
+{% set moName = moc.name %}
 {% set moAddress = moc.principal_address %}
-{% set moSameAddresses = moc.is_service_address_same_as_principal_address %}
 {% set moServiceAddress = moc.service_address %}
-{% set resigned_on = moc.resigned_on %}
+{% set moSameAddresses = moc.is_service_address_same_as_principal_address %}
+{% set moLegalForm = moc.legal_form %}
+{% set moLawGoverned = moc.law_governed %}
+{% set moPublicRegisterName = moc.public_register_name %}
+{% set moRegistrationNumber = moc.registration_number %}
+{% set moRoleAndResponsibilities = moc.role_and_responsibilities %}
+{% set moContactFullName = moc.contact_full_name %}
+{% set moContactEmail = moc.contact_email %}
+{% set moStartDate = dateMacros.formatDate(moc.start_date["day"], moc.start_date["month"], moc.start_date["year"]) %}
+{% set moIsResigned = moc.resigned_on | length %}
+{% set moResignedOn = dateMacros.formatDate(moc.resigned_on["day"], moc.resigned_on["month"], moc.resigned_on["year"]) %}
 
-{% set mocChangePublicregisterNameHtml = "" %}
-{% set mocFormattedPublicRegister %}
-  {% if moc.is_on_register_in_country_formed_in == 1 %}
-    {% set mocChangePublicregisterNameHtml = "#public_register_name" %}
-    {{ moc.public_register_name }} / {{ moc.registration_number }}
+{% set moFormattedPublicRegister %}
+  {% if moIsOnRegisterInCountryFormedIn %}
+    {% set mocChangePublicRegisterNameHtml = OE_CONFIGS.PUBLIC_REGISTER_NAME %}
+    {{ moPublicRegisterName }} / {{ moRegistrationNumber }}
   {% else %}
-    {% set mocChangePublicregisterNameHtml = "#is_on_register_in_country_formed_in" %}
+    {% set mocChangePublicRegisterNameHtml = OE_CONFIGS.IS_ON_REGISTER_IN_COUNTRY_FORMED_IN %}
     No
   {% endif %}
 {% endset %}
@@ -23,29 +35,29 @@
   {% if inNoChangeJourney %}
     <strong class="govuk-tag govuk-tag--blue">CANNOT BE DISPLAYED</strong>
   {% else %}
-    {{ moc.contact_email }}
+    {{ moContactEmail }}
   {% endif %}
 {% endset %}
 
-{% set changeLinkUrl = OE_CONFIGS.UPDATE_REVIEW_MANAGING_OFFICER_CORPORATE_URL %}
+{% set hiddenTextPrefix = "Corporate managing officer " + moName %}
 {% if inChangeJourney %}
-  {% set moIndex = appData.managing_officers_corporate.indexOf(moc) %}
+  {% if isNewMo %}
+    {% set changeLinkUrl = OE_CONFIGS.UPDATE_MANAGING_OFFICER_CORPORATE_URL + '/' + moId %}
+  {% else %}
+    {% set moIndex = appData.managing_officers_corporate.indexOf(moc) %}
+    {% set changeLinkUrl = OE_CONFIGS.UPDATE_REVIEW_MANAGING_OFFICER_CORPORATE_URL + OE_CONFIGS.REVIEW_OWNER_INDEX_PARAM + moIndex %}
+  {% endif %}
 {% endif %}
-{% set moChangeLinkText =  "Corporate managing officer " + moc.name %}
 
 {% set rows = [] %}
 
 {% set rows = (rows.push({
-  key: {
-    text: "Name"
-  },
-  value: {
-    text: moc.name
-  },
+  key: { text: "Name" },
+  value: { text: moName },
   actions: {
     items: [CREATE_CHANGE_LINK(
-      changeLinkUrl + OE_CONFIGS.REVIEW_OWNER_INDEX_PARAM + moIndex + OE_CONFIGS.NAME, 
-      moChangeLinkText + " - Name", 
+      changeLinkUrl + OE_CONFIGS.NAME,
+      hiddenTextPrefix + " - Name",
       "change-corporate-managing-officer-name-button"
     )]
   } if inChangeJourney
@@ -54,95 +66,72 @@
 {% include "includes/check-your-answers/update/managing-officers-addresses.html" %}
 
 {% set rows = (rows.push({
-  key: {
-    text: "Legal form"
-  },
-  value: {
-    text: moc.legal_form
-  },
+  key: { text: "Legal form" },
+  value: { text: moLegalForm },
   actions: {
     items: [CREATE_CHANGE_LINK(
-      changeLinkUrl + OE_CONFIGS.REVIEW_OWNER_INDEX_PARAM + moIndex + OE_CONFIGS.LEGAL_FORM, 
-      moChangeLinkText + " - Legal form", 
+      changeLinkUrl + OE_CONFIGS.LEGAL_FORM,
+      hiddenTextPrefix + " - Legal form",
       "change-corporate-managing-officer-legal-form-button"
     )]
   } if inChangeJourney
 }), rows) %}
 
 {% set rows = (rows.push({
-  key: {
-    text: "Governing law"
-  },
-  value: {
-    html: moc.law_governed
-  },
+  key: { text: "Governing law" },
+  value: { html: moLawGoverned },
   actions: {
     items: [CREATE_CHANGE_LINK(
-      changeLinkUrl + OE_CONFIGS.REVIEW_OWNER_INDEX_PARAM + moIndex + OE_CONFIGS.LAW_GOVERNED, 
-      moChangeLinkText + " - Law governed", 
+      changeLinkUrl + OE_CONFIGS.LAW_GOVERNED,
+      hiddenTextPrefix + " - Law governed",
       "change-corporate-managing-officer-governing-law-button"
     )]
   } if inChangeJourney
 }), rows) %}
 
 {% set rows = (rows.push({
-  key: {
-    text: "On a public register in the country it was formed in"
-  },
-  value: {
-    html: mocFormattedPublicRegister
-  },
+  key: { text: "On a public register in the country it was formed in" },
+  value: { html: moFormattedPublicRegister },
   actions: {
     items: [CREATE_CHANGE_LINK(
-      changeLinkUrl + OE_CONFIGS.REVIEW_OWNER_INDEX_PARAM + moIndex + mocChangePublicregisterNameHtml, 
-      moChangeLinkText + " - Public register", 
+      changeLinkUrl + mocChangePublicRegisterNameHtml,
+      hiddenTextPrefix + " - Public register",
       "change-corporate-managing-officer-public-register-button"
     )]
   } if inChangeJourney
 }), rows) %}
+
 {% set rows = (rows.push({
-  key: {
-    text: "Role and responsibilities"
-  },
-  value: {
-    text: moc.role_and_responsibilities
-  },
+  key: { text: "Role and responsibilities" },
+  value: { text: moRoleAndResponsibilities },
   actions: {
     items: [CREATE_CHANGE_LINK(
-      changeLinkUrl + OE_CONFIGS.REVIEW_OWNER_INDEX_PARAM + moIndex + OE_CONFIGS.ROLE_AND_RESPONSIBILITIES, 
-      moChangeLinkText + " - Role and responsibilities", 
+      changeLinkUrl + OE_CONFIGS.ROLE_AND_RESPONSIBILITIES,
+      moChangeLinkText + " - Role and responsibilities",
       "change-corporate-managing-officer-role-and-responsibilities-button"
     )]
   } if inChangeJourney
 }), rows) %}
 
 {% set rows = (rows.push({
-  key: {
-    text: "Contact full name"
-  },
-  value: {
-    html: moc.contact_full_name
-  },
+  key: { text: "Contact full name" },
+  value: { html: moContactFullName },
   actions: {
     items: [CREATE_CHANGE_LINK(
-      changeLinkUrl + OE_CONFIGS.REVIEW_OWNER_INDEX_PARAM + moIndex + OE_CONFIGS.CONTACT_FULL_NAME, 
-      moChangeLinkText + " - Contact full name", 
+      changeLinkUrl + OE_CONFIGS.CONTACT_FULL_NAME,
+      moChangeLinkText + " - Contact full name",
       "change-corporate-managing-officer-contact-full-name-button"
     )]
   } if inChangeJourney
 }), rows) %}
 
 {% set rows = (rows.push({
-  key: {
-    text: "Contact email address"
-  },
-  value: {
-    html: moFormattedContactEmailHtml
-  },
+  key: { text: "Contact email address" },
+  value: { html: moFormattedContactEmailHtml },
   actions: {
     items: [CREATE_CHANGE_LINK(
-      changeLinkUrl + OE_CONFIGS.REVIEW_OWNER_INDEX_PARAM + moIndex + OE_CONFIGS.CONTACT_EMAIL, 
-      moChangeLinkText + " - Contact email", 
+      changeLinkUrl + OE_CONFIGS.CONTACT_EMAIL,
+      moChangeLinkText + " - Contact email",
       "change-corporate-managing-officer-contact-email-address-button"
     )]
   } if inChangeJourney
@@ -152,6 +141,4 @@
 
 <h3 class="govuk-heading-m">Corporate managing officer</h3>
 
-{{ govukSummaryList({
-   rows: rows
-}) }}
+{{ govukSummaryList({ rows: rows }) }}

--- a/views/includes/check-your-answers/update/update-managing-officer-individual.html
+++ b/views/includes/check-your-answers/update/update-managing-officer-individual.html
@@ -1,110 +1,107 @@
 {% import "includes/date-macros.html" as dateMacros %}
 
-{% set inChangeJourney = not pageParams.noChangeFlag %}
+{% set inNoChangeJourney = pageParams.noChangeFlag %}
+{% set inChangeJourney = not inNoChangeJourney %}
+{% set isNewMo = not (moi.ch_reference | length) %}
+{% set isIndividualManagingOfficer = true %}
 
-{% set moiDateOfBirth = dateMacros.formatDate("", moi.date_of_birth["month"], moi.date_of_birth["year"]) %}
-{% set managing_officer_individual = true %}
+{% set moId = moi.id %}
+{% set moFirstName = moi.first_name %}
+{% set moLastName = moi.last_name %}
+{% set moHasFormerNames = moi.has_former_names == 1 %}
+{% set moFormerNames = moi.former_names %}
+{% set moDateOfBirth = dateMacros.formatDate("", moi.date_of_birth["month"], moi.date_of_birth["year"]) %}
+{% set moNationality = moi.nationality %}
+{% set moSecondNationality = moi.second_nationality %}
 {% set moAddress = moi.usual_residential_address %}
-{% set moSameAddresses = moi.is_service_address_same_as_usual_residential_address %}
 {% set moServiceAddress = moi.service_address %}
-{% set resigned_on = moi.resigned_on %}
+{% set moSameAddresses = moi.is_service_address_same_as_usual_residential_address %}
+{% set moOccupation = moi.occupation %}
+{% set moRoleAndResponsibilities = moi.role_and_responsibilities %}
+{% set moStartDate = dateMacros.formatDate(moi.start_date["day"], moi.start_date["month"], moi.start_date["year"]) %}
+{% set moIsResigned = moi.resigned_on | length %}
+{% set moResignedOn = dateMacros.formatDate(moi.resigned_on["day"], moi.resigned_on["month"], moi.resigned_on["year"]) %}
 
-{% set changeLinkUrl = OE_CONFIGS.UPDATE_REVIEW_INDIVIDUAL_MANAGING_OFFICER_URL %}
-
+{% set hiddenTextPrefix = "Individual managing officer " + moFirstName + " " + moLastName %}
 {% if inChangeJourney %}
-  {% set moIndex = appData.managing_officers_individual.indexOf(moi)  %}
+  {% if isNewMo %}
+    {% set changeLinkUrl = OE_CONFIGS.UPDATE_MANAGING_OFFICER_URL + '/' + moId %}
+  {% else %}
+    {% set moIndex = appData.managing_officers_individual.indexOf(moi) %}
+    {% set changeLinkUrl = OE_CONFIGS.UPDATE_REVIEW_INDIVIDUAL_MANAGING_OFFICER_URL + OE_CONFIGS.REVIEW_OWNER_INDEX_PARAM + moIndex %}
+  {% endif %}
 {% endif %}
-
-{% set moChangeLinkText =  "Individual managing officer " + moi.first_name + " " + moi.last_name %}
 
 {% set rows = [] %}
 
 {% set rows = (rows.push({
-  key: {
-    text: "First name"
-  },
-  value: {
-    text: moi.first_name
-  },
+  key: { text: "First name" },
+  value: { text: moFirstName },
   actions: {
     items: [CREATE_CHANGE_LINK(
-      changeLinkUrl + OE_CONFIGS.REVIEW_OWNER_INDEX_PARAM + moIndex + OE_CONFIGS.FIRST_NAME, 
-      moChangeLinkText + " - first name", 
+      changeLinkUrl + OE_CONFIGS.FIRST_NAME,
+      hiddenTextPrefix + " - first name",
       "change-individual-managing-officer-first-name-button"
     )]
   } if inChangeJourney
 }), rows) %}
 
 {% set rows = (rows.push({
-  key: {
-    text: "Last name"
-  },
-  value: {
-    text: moi.last_name
-  },
+  key: { text: "Last name" },
+  value: { text: moLastName },
   actions: {
     items: [CREATE_CHANGE_LINK(
-      changeLinkUrl + OE_CONFIGS.REVIEW_OWNER_INDEX_PARAM + moIndex + OE_CONFIGS.LAST_NAME,
-      moChangeLinkText + " - last name", 
+      changeLinkUrl + OE_CONFIGS.LAST_NAME,
+      hiddenTextPrefix + " - last name",
       "change-individual-managing-officer-last-name-button"
     )]
   } if inChangeJourney
 }), rows) %}
-{% if moi.former_names | length %}
-  {% set rows = (rows.push({
-  key: {
-    text: "Former names"
-  },
-  value: {
-    text: moi.former_names
-  },
+
+{% set rows = (rows.push({
+  key: { text: "Former names" },
+  value: { text: moFormerNames },
   actions: {
     items: [CREATE_CHANGE_LINK(
-      changeLinkUrl + OE_CONFIGS.REVIEW_OWNER_INDEX_PARAM + moIndex + OE_CONFIGS.FORMER_NAMES,
-      moChangeLinkText + " - former names", 
+      changeLinkUrl + (OE_CONFIGS.FORMER_NAMES if moHasFormerNames else OE_CONFIGS.HAS_FORMER_NAMES),
+      hiddenTextPrefix + " - former names",
       "change-individual-managing-officer-former-names-button"
     )]
   } if inChangeJourney
 }), rows) %}
-{% endif %}
 
 {% set rows = (rows.push({
-  key: {
-    text: "Date of birth" if inChangeJourney else "Born" 
-  },
-  value: {
-    text: moiDateOfBirth
-  }
+  key: { text: "Date of birth" if inChangeJourney else "Born" },
+  value: { text: moDateOfBirth },
+  actions: {
+    items: [CREATE_CHANGE_LINK(
+      changeLinkUrl + OE_CONFIGS.DATE_OF_BIRTH,
+      hiddenTextPrefix + " - date of birth",
+      "change-individual-managing-officer-date-of-birth-button"
+    )]
+  } if inChangeJourney and isNewMo
 }), rows) %}
 
 {% set rows = (rows.push({
-  key: {
-    text: "Nationality"
-  },
-  value: {
-    text: moi.nationality
-  },
+  key: { text: "Nationality" },
+  value: { text: moNationality },
   actions: {
     items: [CREATE_CHANGE_LINK(
-      changeLinkUrl + OE_CONFIGS.REVIEW_OWNER_INDEX_PARAM + moIndex + OE_CONFIGS.NATIONALITY,
-      moChangeLinkText + " - nationality", 
+      changeLinkUrl + OE_CONFIGS.NATIONALITY,
+      hiddenTextPrefix + " - nationality",
       "change-individual-managing-officer-nationality-button"
     )]
   } if inChangeJourney
 }), rows) %}
 
-{% if moi.second_nationality %}
+{% if moSecondNationality | length %}
   {% set rows = (rows.push({
-    key: {
-      text: "Second nationality"
-    },
-    value: {
-      text: moi.second_nationality
-    },
+    key: { text: "Second nationality" },
+    value: { text: moSecondNationality },
     actions: {
       items: [CREATE_CHANGE_LINK(
-        changeLinkUrl + OE_CONFIGS.REVIEW_OWNER_INDEX_PARAM + moIndex + OE_CONFIGS.SECOND_NATIONALITY,
-        moChangeLinkText + " - second nationality", 
+        changeLinkUrl + OE_CONFIGS.SECOND_NATIONALITY,
+        hiddenTextPrefix + " - second nationality",
         "change-individual-managing-officer-second-nationality-button"
       )]
     } if inChangeJourney
@@ -114,32 +111,24 @@
 {% include "includes/check-your-answers/update/managing-officers-addresses.html" %}
 
 {% set rows = (rows.push({
-  key: {
-    text: "Occupation"
-  },
-  value: {
-    html: moi.occupation
-  },
+  key: { text: "Occupation" },
+  value: { html: moOccupation },
   actions: {
     items: [CREATE_CHANGE_LINK(
-      changeLinkUrl + OE_CONFIGS.REVIEW_OWNER_INDEX_PARAM + moIndex + OE_CONFIGS.OCCUPATION,
-      moChangeLinkText + " - occupation", 
+      changeLinkUrl + OE_CONFIGS.OCCUPATION,
+      hiddenTextPrefix + " - occupation",
       "change-individual-managing-officer-occupation-button"
     )]
   } if inChangeJourney
 }), rows) %}
 
 {% set rows = (rows.push({
-  key: {
-    text: "Role and responsibilities"
-  },
-  value: {
-    html: moi.role_and_responsibilities
-  },
+  key: { text: "Role and responsibilities" },
+  value: { html: moRoleAndResponsibilities },
   actions: {
     items: [CREATE_CHANGE_LINK(
-      changeLinkUrl + OE_CONFIGS.REVIEW_OWNER_INDEX_PARAM + moIndex + OE_CONFIGS.ROLE_AND_RESPONSIBILITIES,
-      moChangeLinkText + " - roles and responsibilities", 
+      changeLinkUrl + OE_CONFIGS.ROLE_AND_RESPONSIBILITIES,
+      hiddenTextPrefix + " - roles and responsibilities",
       "change-individual-managing-officer-role-and-responsibilities-button"
     )]
   } if inChangeJourney
@@ -149,6 +138,4 @@
 
 <h3 class="govuk-heading-m">Individual managing officer</h3>
 
-{{ govukSummaryList({
-   rows: rows
-}) }}
+{{ govukSummaryList({ rows: rows }) }}

--- a/views/update/review-update-statement.html
+++ b/views/update/review-update-statement.html
@@ -189,55 +189,42 @@
       ]
   }) }}
 
-      <br>
-      {% include "includes/entity.html" %}
-      {% set boTextDisplayed = false %}
-      {% if (appData.update.review_beneficial_owners_individual and appData.update.review_beneficial_owners_individual.length > 0) %}
-        {% set hideChangeLinksForNonEditableFields = true %}
-        {% set existingIndividualBO = appData.update.review_beneficial_owners_individual %}
-        {% if (existingIndividualBO.length > 0)%}
-          {% set boTextDisplayed = true %}
-          <br>
-          <h2 class="govuk-heading-l">Beneficial owners</h2>
-        {% endif %}
-        {% for boi in existingIndividualBO %}
-          {% include "includes/check-your-answers/beneficial-owner-individual.html" %}
-        {% endfor %}
-      {% endif %}
-      {% if (appData.update.review_beneficial_owners_corporate and appData.update.review_beneficial_owners_corporate.length > 0) %}
-        {% set existingCorporateBO = appData.update.review_beneficial_owners_corporate %}
-        {% for boc in existingCorporateBO %}
-          {% include "includes/check-your-answers/beneficial-owner-other.html" %}
-        {% endfor %}
-      {% endif %}
-      {% if (appData.update.review_beneficial_owners_government_or_public_authority and appData.update.review_beneficial_owners_government_or_public_authority.length > 0) %}
-        {% set existingGovernmentBO = appData.update.review_beneficial_owners_government_or_public_authority %}
-        {% for bog in existingGovernmentBO %}
-          {% include "includes/check-your-answers/beneficial-owner-gov.html" %}
-        {% endfor %}
-      {% endif %}
+  <br>
+  {% include "includes/entity.html" %}
 
-      {% set existingMoTextDisplayed = false %}
-      {% if (appData.update.review_managing_officers_individual and appData.update.review_managing_officers_individual.length > 0) %}
-      {% set hideChangeLinksForNonEditableFields = true %}
-        {% set existingIndividualMO =  appData.update.review_managing_officers_individual %}
-        {% if (existingIndividualMO.length > 0)%}
-          {% set existingMoTextDisplayed = true %}
-          <br>
-          <h2 class="govuk-heading-l">Managing officers</h2>
-        {% endif %}
-        {% for moi in existingIndividualMO %}
-          {% include "includes/check-your-answers/update/update-managing-officer-individual.html" %}
-        {% endfor %}
-      {% endif %}
-      {% if (appData.update.review_managing_officers_corporate and appData.update.review_managing_officers_corporate.length > 0) %}
-      {% set existingCorporateMO = appData.update.review_managing_officers_corporate  %}
-      {% for moc in existingCorporateMO %}
-        {% include "includes/check-your-answers/update/update-managing-officer-corporate.html" %}
-      {% endfor %}
-    {% endif %}
+  {% set hideChangeLinksForNonEditableFields = true %}
 
+  {% set bois = appData.update.review_beneficial_owners_individual or [] %}
+  {% set bocs = appData.update.review_beneficial_owners_corporate or [] %}
+  {% set bogs = appData.update.review_beneficial_owners_government_or_public_authority or [] %}
 
+  {% if bois | length or bocs | length or bogs | length %}
+    <br>
+    <h2 class="govuk-heading-l">Beneficial owners</h2>
+    {% for boi in bois %}
+      {% include "includes/check-your-answers/beneficial-owner-individual.html" %}
+    {% endfor %}
+    {% for boc in bocs %}
+      {% include "includes/check-your-answers/beneficial-owner-other.html" %}
+    {% endfor %}
+    {% for bog in bogs %}
+      {% include "includes/check-your-answers/beneficial-owner-gov.html" %}
+    {% endfor %}
+  {% endif %}
+
+  {% set mois = appData.update.review_managing_officers_individual or [] %}
+  {% set mocs = appData.update.review_managing_officers_corporate or [] %}
+
+  {% if mois | length or mocs | length %}
+    <br>
+    <h2 class="govuk-heading-l">Managing officers</h2>
+    {% for moi in mois %}
+      {% include "includes/check-your-answers/update/update-managing-officer-individual.html" %}
+    {% endfor %}
+    {% for moc in mocs %}
+      {% include "includes/check-your-answers/update/update-managing-officer-corporate.html" %}
+    {% endfor %}
+  {% endif %}
 
       <br>
       <form method="post">

--- a/views/update/update-check-your-answers.html
+++ b/views/update/update-check-your-answers.html
@@ -23,126 +23,77 @@
       <br>
       {% include "includes/check-your-answers/beneficial-owner-statements.html" %}
 
-      {% set boTextDisplayed = false %}
-      {% if (appData.beneficial_owners_individual and appData.beneficial_owners_individual.length > 0) %}
+      {% set bois = appData.beneficial_owners_individual or [] %}
+      {% set existingBOIs = bois | selectattr('ch_reference') %}
+      {% set newBOIs = bois | rejectattr('ch_reference') %}
+
+      {% set bocs = appData.beneficial_owners_corporate or [] %}
+      {% set existingBOCs = bocs | selectattr('ch_reference') %}
+      {% set newBOCs = bocs | rejectattr('ch_reference') %}
+
+      {% set bogs = appData.beneficial_owners_government_or_public_authority or [] %}
+      {% set existingBOGs = bogs | selectattr('ch_reference') %}
+      {% set newBOGs = bogs | rejectattr('ch_reference') %}
+
+      {% if existingBOIs | length or existingBOCs | length or existingBOGs | length %}
         {% set hideChangeLinksForNonEditableFields = true %}
-        {% set existingIndividualBO = appData.beneficial_owners_individual | selectattr("ch_reference", "undefined") %}
-        {% if (existingIndividualBO.length > 0)%}
-          {% set boTextDisplayed = true %}
-          <br>
-          <h2 class="govuk-heading-l">Beneficial owners you have reviewed</h2>
-        {% endif %}
-        {% for boi in existingIndividualBO %}
+        <br>
+        <h2 class="govuk-heading-l">Beneficial owners you have reviewed</h2>
+        {% for boi in existingBOIs %}
           {% include "includes/check-your-answers/beneficial-owner-individual.html" %}
         {% endfor %}
-      {% endif %}
-      {% if (appData.beneficial_owners_corporate and appData.beneficial_owners_corporate.length > 0) %}
-        {% set existingCorporateBO = appData.beneficial_owners_corporate | selectattr("ch_reference", "undefined") %}
-        {% if (existingCorporateBO.length > 0 and boTextDisplayed == false) %}
-          {% set boTextDisplayed = true %}
-          <br>
-          <h2 class="govuk-heading-l">Beneficial owners you have reviewed</h2>
-        {% endif %}
-        {% for boc in existingCorporateBO %}
+        {% for boc in existingBOCs %}
           {% include "includes/check-your-answers/beneficial-owner-other.html" %}
         {% endfor %}
-      {% endif %}
-      {% if (appData.beneficial_owners_government_or_public_authority and appData.beneficial_owners_government_or_public_authority.length > 0) %}
-        {% set existingGovernmentBO = appData.beneficial_owners_government_or_public_authority | selectattr("ch_reference", "undefined") %}
-        {% if (existingGovernmentBO.length > 0 and boTextDisplayed == false) %}
-          {% set boTextDisplayed = true %}
-          <br>
-          <h2 class="govuk-heading-l">Beneficial owners you have reviewed</h2>
-        {% endif %}
-        {% for bog in existingGovernmentBO %}
+        {% for bog in existingBOGs %}
           {% include "includes/check-your-answers/beneficial-owner-gov.html" %}
         {% endfor %}
       {% endif %}
 
-      {% set newBoTextDisplayed = false %}
-      {% if (appData.beneficial_owners_individual and appData.beneficial_owners_individual.length > 0) %}
+      {% if newBOIs | length or newBOCs | length or newBOGs | length %}
         {% set hideChangeLinksForNonEditableFields = false %}
-        {% set savedIndividualBO = appData.beneficial_owners_individual | rejectattr("ch_reference", "undefined") %}
-        {% if (savedIndividualBO.length > 0)%}
-          {% set newBoTextDisplayed = true %}
-          <br>
-          <h2 class="govuk-heading-l">Beneficial owners you have added</h2>
-        {% endif %}
-        {% for boi in savedIndividualBO %}
+        <br>
+        <h2 class="govuk-heading-l">Beneficial owners you have added</h2>
+        {% for boi in newBOIs %}
           {% include "includes/check-your-answers/beneficial-owner-individual.html" %}
         {% endfor %}
-      {% endif %}
-
-      {% if (appData.beneficial_owners_corporate and appData.beneficial_owners_corporate.length > 0) %}
-        {% set savedCorporateBO = appData.beneficial_owners_corporate | rejectattr("ch_reference", "undefined") %}
-        {% if (savedCorporateBO.length > 0 and newBoTextDisplayed == false) %}
-          {% set newBoTextDisplayed = true %}
-          <br>
-          <h2 class="govuk-heading-l">Beneficial owners you have added</h2>
-        {% endif %}
-        {% for boc in savedCorporateBO %}
+        {% for boc in newBOCs %}
           {% include "includes/check-your-answers/beneficial-owner-other.html" %}
         {% endfor %}
-      {% endif %}
-      {% if (appData.beneficial_owners_government_or_public_authority and appData.beneficial_owners_government_or_public_authority.length > 0) %}
-        {% set savedGovernmentBO = appData.beneficial_owners_government_or_public_authority | rejectattr("ch_reference", "undefined") %}
-        {% if (savedGovernmentBO.length > 0 and newBoTextDisplayed == false) %}
-          {% set newBoTextDisplayed = true %}
-          <br>
-          <h2 class="govuk-heading-l">Beneficial owners you have added</h2>
-        {% endif %}
-        {% for bog in savedGovernmentBO %}
+        {% for bog in newBOGs %}
           {% include "includes/check-your-answers/beneficial-owner-gov.html" %}
         {% endfor %}
       {% endif %}
 
-      {% set existingMoTextDisplayed = false %}
-      {% if (appData.managing_officers_individual and appData.managing_officers_individual.length > 0) %}
+      {% set mois = appData.managing_officers_individual or [] %}
+      {% set existingMOIs = mois | selectattr('ch_reference') %}
+      {% set newMOIs = mois | rejectattr('ch_reference') %}
+
+      {% set mocs = appData.managing_officers_corporate or [] %}
+      {% set existingMOCs = mocs | selectattr('ch_reference') %}
+      {% set newMOCs = mocs | rejectattr('ch_reference') %}
+
+      {% if existingMOIs | length or existingMOCs | length %}
         {% set hideChangeLinksForNonEditableFields = true %}
-        {% set existingIndividualMO = appData.managing_officers_individual | selectattr("ch_reference", "undefined") %}
-        {% if (existingIndividualMO.length > 0)%}
-          {% set existingMoTextDisplayed = true %}
-          <br>
-          <h2 class="govuk-heading-l">Managing officers you have reviewed</h2>
-        {% endif %}
-        {% for moi in existingIndividualMO %}
+        <br>
+        <h2 class="govuk-heading-l">Managing officers you have reviewed</h2>
+        {% for moi in existingMOIs %}
           {% include "includes/check-your-answers/update/update-managing-officer-individual.html" %}
         {% endfor %}
-      {% endif %}
-      {% if (appData.managing_officers_corporate and appData.managing_officers_corporate.length > 0) %}
-        {% set existingCorporateMO = appData.managing_officers_corporate | selectattr("ch_reference", "undefined") %}
-        {% if (existingCorporateMO.length > 0 and existingMoTextDisplayed == false) %}
-          {% set existingMoTextDisplayed = true %}
-          <br>
-          <h2 class="govuk-heading-l">Managing officers you have reviewed</h2>
-        {% endif %}
-        {% for moc in existingCorporateMO %}
+        {% for moc in existingMOCs %}
           {% include "includes/check-your-answers/update/update-managing-officer-corporate.html" %}
         {% endfor %}
       {% endif %}
 
-      {% set newMoTextDisplayed = false %}
-      {% if (appData.managing_officers_individual and appData.managing_officers_individual.length > 0) %}
+      {% if newMOIs | length or newMOCs | length %}
         {% set hideChangeLinksForNonEditableFields = false %}
-        {% set savedIndividualMO = appData.managing_officers_individual | rejectattr("ch_reference", "undefined") %}
-        {% if (savedIndividualMO.length > 0)%}
-          {% set newMoTextDisplayed = true %}
-          <br>
-          <h2 class="govuk-heading-l">Managing officers you have added</h2>
-        {% endif %}
-        {% for moi in savedIndividualMO %}
-          {% include "includes/check-your-answers/managing-officer-individual.html" %}
+        <br>
+        <h2 class="govuk-heading-l">Managing officers you have added</h2>
+        {% for moi in newMOIs %}
+          {% include "includes/check-your-answers/update/update-managing-officer-individual.html" %}
         {% endfor %}
-      {% endif %}
-      {% if (appData.managing_officers_corporate and appData.managing_officers_corporate.length > 0) %}
-        {% set savedCorporateMO = appData.managing_officers_corporate | rejectattr("ch_reference", "undefined") %}
-        {% if (savedCorporateMO.length > 0 and newMoTextDisplayed == false) %}
-          {% set newoTextDisplayed = true %}
-          <br>
-          <h2 class="govuk-heading-l">Managing officers you have added</h2>
-        {% endif %}
-        {% for moc in savedCorporateMO %}
-          {% include "includes/check-your-answers/managing-officer-corporate.html" %}
+        {% for moc in newMOCs %}
+          {% include "includes/check-your-answers/update/update-managing-officer-corporate.html" %}
         {% endfor %}
       {% endif %}
 


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/UAR-1003

### Change description

At a high level, start date/resigned date info for MOs is now displaying where appropriate on the Update - Check Your Answers page.

- Refactored BO/MO rendering in templates for Update CYA page and Review info update statement page
  - This fixed an issue where the Beneficial owners/Managing officers section headings on the Review info update statement page were not rendered when there was no individual BO/MO respectively
- Refactored summary list row definitions in BO/MO templates
- Removed references to change journey and non registration logic from MO templates used in Registration CYA

### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
