### PR TITLE
[UAR-930] Split foreignCompanyDetails.originatingRegistry.name and map jurisdiction

### DIFF
--- a/src/utils/update/company.profile.mapper.to.overseas.entity.ts
+++ b/src/utils/update/company.profile.mapper.to.overseas.entity.ts
@@ -1,19 +1,20 @@
 import { CompanyProfile } from "@companieshouse/api-sdk-node/dist/services/company-profile/types";
 import { yesNoResponse } from "../../model/data.types.model";
 import { Entity } from "../../model/entity.model";
-import { isSameAddress, lowerCaseAllWordsExceptFirstLetters, mapAddress } from "../../utils/update/mapper.utils";
+import { isSameAddress, lowerCaseAllWordsExceptFirstLetters, mapAddress, splitOriginatingRegistryName } from "../../utils/update/mapper.utils";
 
 export const mapCompanyProfileToOverseasEntity = (cp: CompanyProfile): Entity => {
   const serviceAddress = mapAddress(cp.serviceAddress);
   const principalAddress = mapAddress(cp.registeredOfficeAddress);
+  const publicRegister = splitOriginatingRegistryName(cp.foreignCompanyDetails?.originatingRegistry?.name);
 
   return {
     registration_number: cp.foreignCompanyDetails?.registrationNumber,
     law_governed: cp.foreignCompanyDetails?.governedBy,
     legal_form: cp.foreignCompanyDetails?.legalForm,
     incorporation_country: lowerCaseAllWordsExceptFirstLetters(cp.foreignCompanyDetails?.originatingRegistry?.country),
-    public_register_name: cp.foreignCompanyDetails?.originatingRegistry?.name,
-    public_register_jurisdiction: "",
+    public_register_name: publicRegister.registryName,
+    public_register_jurisdiction: publicRegister.jurisdiction,
     email: "", // private data
     service_address: serviceAddress,
     principal_address: principalAddress,

--- a/src/utils/update/mapper.utils.ts
+++ b/src/utils/update/mapper.utils.ts
@@ -128,3 +128,20 @@ export const lowerCaseAllWordsExceptFirstLetters = (country: string | undefined)
   }
   );
 };
+
+export const splitOriginatingRegistryName = (registryName: string | undefined) => {
+  if (!registryName){
+    return { registryName: "", jurisdiction: "" };
+  }
+
+  const firstComma = registryName.indexOf(",");
+
+  if (firstComma >= 0) {
+    return {
+      registryName: registryName.substring(0, firstComma),
+      jurisdiction: registryName.substring(firstComma + 1, registryName.length).trim()
+    };
+  }
+
+  return { registryName: registryName, jurisdiction: "" };
+};

--- a/test/__mocks__/session.mock.ts
+++ b/test/__mocks__/session.mock.ts
@@ -1788,7 +1788,7 @@ export const RESET_DATA_FOR_NO_CHANGE_RESPONSE = {
     law_governed: undefined,
     legal_form: undefined,
     principal_address: {},
-    public_register_name: undefined,
+    public_register_name: "",
     registration_number: undefined
   },
   [updateType.UpdateKey]: {

--- a/test/utils/update/mapper.utils.spec.ts
+++ b/test/utils/update/mapper.utils.spec.ts
@@ -1,4 +1,4 @@
-import { lowerCaseAllWordsExceptFirstLetters, mapBOIndividualName, mapInputDate } from "../../../src/utils/update/mapper.utils";
+import { lowerCaseAllWordsExceptFirstLetters, mapBOIndividualName, mapInputDate, splitOriginatingRegistryName } from "../../../src/utils/update/mapper.utils";
 
 describe("Test mapping utils", () => {
   test("does map date of creation for month format containing single digit ", () => {
@@ -61,6 +61,44 @@ describe("Test mapping utils", () => {
       ["GUINEA-BISSAU", "Guinea-Bissau"]
     ])(`Correctly reformats %s`, (str, expectedResult) => {
       expect(lowerCaseAllWordsExceptFirstLetters(str)).toEqual(expectedResult);
+    });
+  });
+
+  describe("splitOriginatingRegistryName", () => {
+    test.each([
+      [
+        "Undefined returns empty strings",
+        undefined,
+        { registryName: "", jurisdiction: "" }
+      ],
+      [
+        "Empty string returns empty strings",
+        "",
+        { registryName: "", jurisdiction: "" }
+      ],
+      [
+        "No comma returns correctly",
+        "Public Register Name",
+        { registryName: "Public Register Name", jurisdiction: "" }
+      ],
+      [
+        "One comma occurence splits correctly",
+        "Public Register Name,Country",
+        { registryName: "Public Register Name", jurisdiction: "Country" }
+      ],
+      [
+        "Multiple comma occurences in country splits correctly",
+        "Public Register Name, Virgin Islands, U.S.",
+        { registryName: "Public Register Name", jurisdiction: "Virgin Islands, U.S." }
+      ],
+      [
+        "Leading whitespace on country is removed",
+        "Public Register Name, Country",
+        { registryName: "Public Register Name", jurisdiction: "Country" }
+      ]
+    ])(`%s`, (_, stringToSplit, expectedResult) => {
+
+      expect(splitOriginatingRegistryName(stringToSplit as string)).toEqual(expectedResult);
     });
   });
 });


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/UAR-930

### Change description
public_register_name and public_register_jurisdiction fields on OE details page, gets concatenated into 1 string after Registration, so we need to split on the delimiter (a comma) when mapping the Company Profile. 
<img width="300" alt="Screenshot 2023-08-02 at 11 52 16" src="https://github.com/companieshouse/overseas-entities-web/assets/117734784/54a6f6c9-62af-4415-a1c3-cfd852c0432f">

<img width="300" alt="Screenshot 2023-08-02 at 11 53 29" src="https://github.com/companieshouse/overseas-entities-web/assets/117734784/f303f133-60ca-43af-86d2-55dd3138104e">



### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
