### PR TITLE
[UAR-1061] remove appending of jurisdiction and registration number in noChange …

### DIFF
--- a/views/includes/entity.html
+++ b/views/includes/entity.html
@@ -17,7 +17,11 @@
 
 {% set formattedPublicRegister %}
   {% if appData.entity.is_on_register_in_country_formed_in == 1 %}
-     {{ appData.entity.public_register_name | safe}} / {{ appData.entity.public_register_jurisdiction | safe }} / {{ appData.entity.registration_number | safe }}
+    {% if inNoChangeJourney %}
+      {{ appData.entity.public_register_name | safe }}
+    {% else %}
+      {{ appData.entity.public_register_name | safe }} / {{ appData.entity.public_register_jurisdiction | safe }} / {{ appData.entity.registration_number | safe }}
+    {% endif %}
   {% else %}
     No
   {% endif %}
@@ -46,7 +50,7 @@
 {% endset %}
 
 {% if inNoChangeJourney %}
-  {% set jurisdiction = 
+  {% set jurisdiction =
     {
       key: {
         text: "Jurisdiction"

--- a/views/includes/entity.html
+++ b/views/includes/entity.html
@@ -15,7 +15,7 @@
   {% endif %}
 {% endset %}
 
-{% set formattedPublicRegister %}
+{% set formattedPublicRegister   %}
   {% if appData.entity.is_on_register_in_country_formed_in == 1 %}
     {% if inNoChangeJourney %}
       {{ appData.entity.public_register_name | safe }}

--- a/views/includes/entity.html
+++ b/views/includes/entity.html
@@ -15,7 +15,7 @@
   {% endif %}
 {% endset %}
 
-{% set formattedPublicRegister   %}
+{% set formattedPublicRegister %}
   {% if appData.entity.is_on_register_in_country_formed_in == 1 %}
     {% if inNoChangeJourney %}
       {{ appData.entity.public_register_name | safe }}


### PR DESCRIPTION
…scenario

### JIRA link
https://companieshouse.atlassian.net/browse/UAR-1061


### Change description
In the includes/entity.html, their are rows for displaying the `Overseas public register` information for the OE. 
In the Registration check your answers page we want the information to show concatenated into the one table row, same for the Update check your answers page

For the No Change journey Review Update page we want 3 separate fields for each bit of information, but it was also showing the 1 field with concatenated values.

Before fix:

<img width="450" alt="Screenshot 2023-08-03 at 14 22 59" src="https://github.com/companieshouse/overseas-entities-web/assets/117734784/4e7fbb1f-291d-4064-995d-8680dc93d7af">


After fix:

<img width="450" alt="Screenshot 2023-08-03 at 11 59 33" src="https://github.com/companieshouse/overseas-entities-web/assets/117734784/d28eed60-497e-47e0-b862-2f6f9f4f41a0">




### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
