### PR TITLE
[UAR-763] statement validation middleware run on answer of 2nd statement

### DIFF
--- a/src/controllers/update/update.statement.validation.errors.controller.ts
+++ b/src/controllers/update/update.statement.validation.errors.controller.ts
@@ -43,7 +43,7 @@ export const post = (req: Request, res: Response, next: NextFunction) => {
 
     return req.body[StatementResolutionKey] === StatementResolutionType.CHANGE_INFORMATION
       ? res.redirect(getChangeInformationRedirectUrl(inNoChangeJourney))
-      : res.redirect(getFirstBOStatementsUrl(inNoChangeJourney));
+      : res.redirect(identifiedBOStatement(inNoChangeJourney));
   } catch (error) {
     next(error);
   }
@@ -51,7 +51,7 @@ export const post = (req: Request, res: Response, next: NextFunction) => {
 
 const renderPage = (res: Response, appData: ApplicationData, inNoChangeJourney: boolean, statementErrorList: string[], errors?: FormattedValidationErrors) => (
   res.render(UPDATE_STATEMENT_VALIDATION_ERRORS_PAGE, {
-    backLinkUrl: getSecondBOStatementsUrl(inNoChangeJourney),
+    backLinkUrl: ceasedBOStatement(inNoChangeJourney),
     templateName: UPDATE_STATEMENT_VALIDATION_ERRORS_PAGE,
     appData,
     statementErrorList,
@@ -65,13 +65,13 @@ const getChangeInformationRedirectUrl = (inNoChangeJourney: boolean) => (
     : UPDATE_BENEFICIAL_OWNER_TYPE_URL
 );
 
-const getFirstBOStatementsUrl = (inNoChangeJourney: boolean) => (
+const identifiedBOStatement = (inNoChangeJourney: boolean) => (
   inNoChangeJourney
     ? UPDATE_NO_CHANGE_BENEFICIAL_OWNER_STATEMENTS_URL
     : UPDATE_BENEFICIAL_OWNER_STATEMENTS_URL
 );
 
-const getSecondBOStatementsUrl = (inNoChangeJourney: boolean) => (
+const ceasedBOStatement = (inNoChangeJourney: boolean) => (
   inNoChangeJourney
     ? UPDATE_NO_CHANGE_REGISTRABLE_BENEFICIAL_OWNER_URL
     : UPDATE_REGISTRABLE_BENEFICIAL_OWNER_URL

--- a/src/controllers/update/update.statement.validation.errors.controller.ts
+++ b/src/controllers/update/update.statement.validation.errors.controller.ts
@@ -3,8 +3,10 @@ import { validationResult } from "express-validator";
 
 import { logger } from "../../utils/logger";
 import {
+  UPDATE_BENEFICIAL_OWNER_STATEMENTS_URL,
   UPDATE_BENEFICIAL_OWNER_TYPE_URL,
   UPDATE_DO_YOU_WANT_TO_MAKE_OE_CHANGE_URL,
+  UPDATE_NO_CHANGE_BENEFICIAL_OWNER_STATEMENTS_URL,
   UPDATE_NO_CHANGE_REGISTRABLE_BENEFICIAL_OWNER_URL,
   UPDATE_REGISTRABLE_BENEFICIAL_OWNER_URL,
   UPDATE_STATEMENT_VALIDATION_ERRORS_PAGE,
@@ -21,7 +23,7 @@ export const get = (req: Request, res: Response, next: NextFunction) => {
     const appData = getApplicationData(req.session);
     const inNoChangeJourney = !!appData.update?.no_change;
 
-    return renderPage(res, appData, inNoChangeJourney);
+    return renderPage(res, appData, inNoChangeJourney, req['statementErrorList']);
   } catch (error) {
     next(error);
   }
@@ -36,22 +38,23 @@ export const post = (req: Request, res: Response, next: NextFunction) => {
     const inNoChangeJourney = !!appData.update?.no_change;
 
     if (!errors.isEmpty()) {
-      return renderPage(res, appData, inNoChangeJourney, formatValidationError(errors.array()));
+      return renderPage(res, appData, inNoChangeJourney, req.body['statementErrorList[]'], formatValidationError(errors.array()));
     }
 
     return req.body[StatementResolutionKey] === StatementResolutionType.CHANGE_INFORMATION
       ? res.redirect(getChangeInformationRedirectUrl(inNoChangeJourney))
-      : res.redirect(getBOStatementsUrl(inNoChangeJourney));
+      : res.redirect(getFirstBOStatementsUrl(inNoChangeJourney));
   } catch (error) {
     next(error);
   }
 };
 
-const renderPage = (res: Response, appData: ApplicationData, inNoChangeJourney: boolean, errors?: FormattedValidationErrors) => (
+const renderPage = (res: Response, appData: ApplicationData, inNoChangeJourney: boolean, statementErrorList: string[], errors?: FormattedValidationErrors) => (
   res.render(UPDATE_STATEMENT_VALIDATION_ERRORS_PAGE, {
-    backLinkUrl: getBOStatementsUrl(inNoChangeJourney),
+    backLinkUrl: getSecondBOStatementsUrl(inNoChangeJourney),
     templateName: UPDATE_STATEMENT_VALIDATION_ERRORS_PAGE,
     appData,
+    statementErrorList,
     errors,
   })
 );
@@ -62,7 +65,13 @@ const getChangeInformationRedirectUrl = (inNoChangeJourney: boolean) => (
     : UPDATE_BENEFICIAL_OWNER_TYPE_URL
 );
 
-const getBOStatementsUrl = (inNoChangeJourney: boolean) => (
+const getFirstBOStatementsUrl = (inNoChangeJourney: boolean) => (
+  inNoChangeJourney
+    ? UPDATE_NO_CHANGE_BENEFICIAL_OWNER_STATEMENTS_URL
+    : UPDATE_BENEFICIAL_OWNER_STATEMENTS_URL
+);
+
+const getSecondBOStatementsUrl = (inNoChangeJourney: boolean) => (
   inNoChangeJourney
     ? UPDATE_NO_CHANGE_REGISTRABLE_BENEFICIAL_OWNER_URL
     : UPDATE_REGISTRABLE_BENEFICIAL_OWNER_URL

--- a/src/middleware/statement.validation.middleware.ts
+++ b/src/middleware/statement.validation.middleware.ts
@@ -1,0 +1,43 @@
+import { NextFunction, Request, Response } from "express";
+import { isActiveFeature } from "../utils/feature.flag";
+import { checkActiveBOExists, getApplicationData } from "../utils/application.data";
+import {
+  FEATURE_FLAG_ENABLE_UPDATE_STATEMENT_VALIDATION,
+  UPDATE_CHECK_YOUR_ANSWERS_URL,
+  UPDATE_REVIEW_STATEMENT_URL
+} from '../config';
+import { BeneficialOwnerStatementKey, BeneficialOwnersStatementType } from "../model/beneficial.owner.statement.model";
+import { ApplicationData } from "../model";
+import { ErrorMessages } from "../validation/error.messages";
+import { Session } from "@companieshouse/node-session-handler";
+
+export const hasValidStatements = (req: Request, res: Response, next: NextFunction) => {
+  const errorList: string[] = [];
+  const appData: ApplicationData = getApplicationData(req.session as Session);
+
+  if (
+    isActiveFeature(FEATURE_FLAG_ENABLE_UPDATE_STATEMENT_VALIDATION) &&
+      !checkStatementsValid(appData, errorList)
+  ) {
+    req['statementErrorList'] = errorList;
+    return next();
+  }
+
+  const redirectUrl = appData.update?.no_change ? UPDATE_REVIEW_STATEMENT_URL : UPDATE_CHECK_YOUR_ANSWERS_URL;
+  return res.redirect(redirectUrl);
+};
+
+const validateIdentifiedBOsStatement = (appData: ApplicationData, errorList: string[]): boolean => {
+  const allOrSomeBOsIdentified: boolean = (appData[BeneficialOwnerStatementKey] === BeneficialOwnersStatementType.ALL_IDENTIFIED_ALL_DETAILS || appData[BeneficialOwnerStatementKey] === BeneficialOwnersStatementType.SOME_IDENTIFIED_ALL_DETAILS);
+
+  if (allOrSomeBOsIdentified && !checkActiveBOExists(appData)) {
+    errorList.push(ErrorMessages.NO_ACTIVE_REGISTRABLE_BO);
+    return false;
+  }
+
+  return true;
+};
+
+const checkStatementsValid = (appData: ApplicationData, errorList: string[]): boolean => {
+  return validateIdentifiedBOsStatement(appData, errorList);
+};

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -97,6 +97,7 @@ import { isFeatureEnabled } from '../middleware/is.feature.enabled.middleware';
 import { isFeatureDisabled } from '../middleware/is.feature.disabled.middleware';
 import { validator } from "../validation";
 import { companyAuthentication } from "../middleware/company.authentication.middleware";
+import { hasValidStatements } from "../middleware/statement.validation.middleware";
 
 const router = Router();
 
@@ -782,7 +783,7 @@ router.route(config.UPDATE_STATEMENT_VALIDATION_ERRORS_URL)
     companyAuthentication,
     navigation.hasUpdatePresenter,
   )
-  .get(updateStatementValidationErrors.get)
+  .get(hasValidStatements, updateStatementValidationErrors.get)
   .post(...validator.statementResolution, updateStatementValidationErrors.post);
 
 export default router;

--- a/src/utils/application.data.ts
+++ b/src/utils/application.data.ts
@@ -53,6 +53,21 @@ export const mapDataObjectToFields = (data: any, htmlFields: string[], dataModel
   return (data) ? htmlFields.reduce((o, key, i) => Object.assign(o, { [key]: data[dataModelKeys[i]] }), {}) : {};
 };
 
+export const allBeneficialOwners = (appData: ApplicationData) => {
+  return [
+    ...(appData[BeneficialOwnerIndividualKey] ?? []),
+    ...(appData[BeneficialOwnerOtherKey] ?? []),
+    ...(appData[BeneficialOwnerGovKey] ?? []),
+    ...(appData.update?.review_beneficial_owners_individual ?? []),
+    ...(appData.update?.review_beneficial_owners_corporate ?? []),
+    ...(appData.update?.review_beneficial_owners_government_or_public_authority ?? [])
+  ];
+};
+
+export const checkActiveBOExists = (appData: ApplicationData): boolean => {
+  return allBeneficialOwners(appData).some((bo) => !bo.ceased_date || Object.keys(bo.ceased_date).length === 0);
+};
+
 export const checkBOsDetailsEntered = (appData: ApplicationData): boolean => {
   return Boolean( appData[BeneficialOwnerIndividualKey]?.length || appData[BeneficialOwnerOtherKey]?.length || appData[BeneficialOwnerGovKey]?.length );
 };

--- a/src/utils/registrable.beneficial.owner.ts
+++ b/src/utils/registrable.beneficial.owner.ts
@@ -57,7 +57,11 @@ export const postRegistrableBeneficialOwner = (req: Request, res: Response, next
 
 const noChangeHandler = (req: Request, res: Response, next: NextFunction, registrableOwnerChoice) => {
   if (registrableOwnerChoice === "0"){
-    return res.redirect(config.UPDATE_STATEMENT_VALIDATION_ERRORS_URL);
+    const redirectUrl = isActiveFeature(config.FEATURE_FLAG_ENABLE_UPDATE_STATEMENT_VALIDATION)
+      ? config.UPDATE_STATEMENT_VALIDATION_ERRORS_URL
+      : config.UPDATE_REVIEW_STATEMENT_URL;
+
+    return res.redirect(redirectUrl);
   } else {
     return res.redirect(config.UPDATE_DO_YOU_WANT_TO_MAKE_OE_CHANGE_URL);
   }

--- a/src/utils/registrable.beneficial.owner.ts
+++ b/src/utils/registrable.beneficial.owner.ts
@@ -46,7 +46,7 @@ export const postRegistrableBeneficialOwner = (req: Request, res: Response, next
       noChangeHandler(req, res, next, isRegistrableBeneficialOwner);
     } else {
       const redirectUrl = isActiveFeature(config.FEATURE_FLAG_ENABLE_UPDATE_STATEMENT_VALIDATION)
-        ? config.UPDATE_CHECK_YOUR_ANSWERS_URL
+        ? config.UPDATE_STATEMENT_VALIDATION_ERRORS_URL
         : config.UPDATE_BENEFICIAL_OWNER_BO_MO_REVIEW_URL;
       return res.redirect(redirectUrl);
     }
@@ -57,7 +57,7 @@ export const postRegistrableBeneficialOwner = (req: Request, res: Response, next
 
 const noChangeHandler = (req: Request, res: Response, next: NextFunction, registrableOwnerChoice) => {
   if (registrableOwnerChoice === "0"){
-    return res.redirect(config.UPDATE_REVIEW_STATEMENT_URL);
+    return res.redirect(config.UPDATE_STATEMENT_VALIDATION_ERRORS_URL);
   } else {
     return res.redirect(config.UPDATE_DO_YOU_WANT_TO_MAKE_OE_CHANGE_URL);
   }

--- a/src/utils/update/psc.to.beneficial.owner.type.mapper.ts
+++ b/src/utils/update/psc.to.beneficial.owner.type.mapper.ts
@@ -21,7 +21,6 @@ export const mapPscToBeneficialOwnerTypeIndividual = (psc: CompanyPersonWithSign
     usual_residential_address: undefined,
     service_address: service_address,
     start_date: mapInputDate(psc.notifiedOn),
-    ceased_date: psc.ceasedOn ? mapInputDate(psc.ceasedOn) : undefined,
     is_on_sanctions_list: psc.isSanctioned === true ? yesNoResponse.Yes : yesNoResponse.No,
   };
   mapNatureOfControl(psc, result, false);
@@ -45,7 +44,6 @@ export const mapPscToBeneficialOwnerOther = (psc: CompanyPersonWithSignificantCo
     registration_number: psc.identification?.registrationNumber,
     is_on_register_in_country_formed_in: psc.identification !== undefined && psc.identification?.registrationNumber ? yesNoResponse.Yes : yesNoResponse.No,
     start_date: mapInputDate(psc.notifiedOn),
-    ceased_date: psc.ceasedOn ? mapInputDate(psc.ceasedOn) : undefined,
     is_on_sanctions_list: psc.isSanctioned === true ? yesNoResponse.Yes : yesNoResponse.No,
   };
   mapNatureOfControl(psc, result, false);
@@ -66,7 +64,6 @@ export const mapPscToBeneficialOwnerGov = (psc: CompanyPersonWithSignificantCont
     legal_form: psc.identification?.legalForm,
     law_governed: psc.identification?.legalAuthority,
     start_date: mapInputDate(psc.notifiedOn),
-    ceased_date: psc.ceasedOn ? mapInputDate(psc.ceasedOn) : undefined,
     is_on_sanctions_list: psc.isSanctioned === true ? yesNoResponse.Yes : yesNoResponse.No,
   };
   mapNatureOfControl(psc, result, true);

--- a/src/utils/update/psc.to.beneficial.owner.type.mapper.ts
+++ b/src/utils/update/psc.to.beneficial.owner.type.mapper.ts
@@ -21,6 +21,7 @@ export const mapPscToBeneficialOwnerTypeIndividual = (psc: CompanyPersonWithSign
     usual_residential_address: undefined,
     service_address: service_address,
     start_date: mapInputDate(psc.notifiedOn),
+    ceased_date: psc.ceasedOn ? mapInputDate(psc.ceasedOn) : undefined,
     is_on_sanctions_list: psc.isSanctioned === true ? yesNoResponse.Yes : yesNoResponse.No,
   };
   mapNatureOfControl(psc, result, false);
@@ -44,6 +45,7 @@ export const mapPscToBeneficialOwnerOther = (psc: CompanyPersonWithSignificantCo
     registration_number: psc.identification?.registrationNumber,
     is_on_register_in_country_formed_in: psc.identification !== undefined && psc.identification?.registrationNumber ? yesNoResponse.Yes : yesNoResponse.No,
     start_date: mapInputDate(psc.notifiedOn),
+    ceased_date: psc.ceasedOn ? mapInputDate(psc.ceasedOn) : undefined,
     is_on_sanctions_list: psc.isSanctioned === true ? yesNoResponse.Yes : yesNoResponse.No,
   };
   mapNatureOfControl(psc, result, false);
@@ -64,6 +66,7 @@ export const mapPscToBeneficialOwnerGov = (psc: CompanyPersonWithSignificantCont
     legal_form: psc.identification?.legalForm,
     law_governed: psc.identification?.legalAuthority,
     start_date: mapInputDate(psc.notifiedOn),
+    ceased_date: psc.ceasedOn ? mapInputDate(psc.ceasedOn) : undefined,
     is_on_sanctions_list: psc.isSanctioned === true ? yesNoResponse.Yes : yesNoResponse.No,
   };
   mapNatureOfControl(psc, result, true);

--- a/src/validation/error.messages.ts
+++ b/src/validation/error.messages.ts
@@ -60,6 +60,9 @@ export enum ErrorMessages {
   UK_COUNTRY = "Select a country",
   POSTCODE = "Enter a postcode",
 
+  // Statements
+  NO_ACTIVE_REGISTRABLE_BO = "There are no active registrable beneficial owners.",
+
   // Trusts
   TRUST_DATA_EMPTY = "Paste the trust information from the Excel document into the box",
   TRUST_NAME = "Enter the trust name",

--- a/test/controllers/update/no.change.registrable.beneficial.owner.controller.spec.ts
+++ b/test/controllers/update/no.change.registrable.beneficial.owner.controller.spec.ts
@@ -15,7 +15,7 @@ import { UPDATE_DO_YOU_WANT_TO_MAKE_OE_CHANGE_PAGE,
   UPDATE_DO_YOU_WANT_TO_MAKE_OE_CHANGE_URL,
   UPDATE_NO_CHANGE_REGISTRABLE_BENEFICIAL_OWNER_PAGE,
   UPDATE_NO_CHANGE_REGISTRABLE_BENEFICIAL_OWNER_URL,
-  UPDATE_REVIEW_STATEMENT_PAGE, UPDATE_REVIEW_STATEMENT_URL
+  UPDATE_STATEMENT_VALIDATION_ERRORS_URL
 } from "../../../src/config";
 import { getApplicationData, setExtraData } from "../../../src/utils/application.data";
 import { APPLICATION_DATA_MOCK, APPLICATION_DATA_MOCK_WITHOUT_UPDATE } from "../../__mocks__/session.mock";
@@ -120,14 +120,14 @@ describe("No change registrable beneficial owner", () => {
       expect(mockSetExtraData).toHaveBeenCalledTimes(1);
     });
 
-    test(`redirects to the ${UPDATE_REVIEW_STATEMENT_PAGE} page when 'has reasonable cause' is selected`, async () => {
+    test(`redirects to the update-statement-validation-errors page when 'has reasonable cause' is selected`, async () => {
       mockGetApplicationData.mockReturnValueOnce({ ...APPLICATION_DATA_MOCK });
       const resp = await request(app)
         .post(UPDATE_NO_CHANGE_REGISTRABLE_BENEFICIAL_OWNER_URL)
         .send({ [RegistrableBeneficialOwnerKey]: "0" });
 
       expect(resp.status).toEqual(302);
-      expect(resp.header.location).toEqual(UPDATE_REVIEW_STATEMENT_URL);
+      expect(resp.header.location).toEqual(UPDATE_STATEMENT_VALIDATION_ERRORS_URL);
       expect(mockSetExtraData).toHaveBeenCalledTimes(1);
     });
 

--- a/test/middleware/statement.validation.middleware.spec.ts
+++ b/test/middleware/statement.validation.middleware.spec.ts
@@ -1,0 +1,122 @@
+jest.mock("../../src/utils/feature.flag" );
+jest.mock('../../src/utils/application.data');
+
+import { Request, Response } from 'express';
+import { describe, expect, test, beforeEach, jest } from '@jest/globals';
+import { hasValidStatements } from '../../src/middleware/statement.validation.middleware';
+import { isActiveFeature } from "../../src/utils/feature.flag";
+import { getApplicationData, checkActiveBOExists } from "../../src/utils/application.data";
+import {
+  APPLICATION_DATA_MOCK,
+  APPLICATION_DATA_UPDATE_NO_BO_OR_MO_TO_REVIEW,
+  BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK_WITH_CH_REF,
+  UPDATE_BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK, UPDATE_OBJECT_MOCK
+} from '../__mocks__/session.mock';
+import { BeneficialOwnerStatementKey, BeneficialOwnersStatementType } from '../../src/model/beneficial.owner.statement.model';
+import { BeneficialOwnerIndividualKey } from '../../src/model/beneficial.owner.individual.model';
+import { yesNoResponse } from '../../src/model/data.types.model';
+import { RegistrableBeneficialOwnerKey, UpdateKey } from '../../src/model/update.type.model';
+import { UPDATE_CHECK_YOUR_ANSWERS_URL, UPDATE_REVIEW_STATEMENT_URL } from '../../src/config';
+
+const req = {} as Request;
+const res = { redirect: jest.fn() as any } as Response;
+const next = jest.fn();
+
+const mockIsActiveFeature = isActiveFeature as jest.Mock;
+const mockGetApplicationData = getApplicationData as jest.Mock;
+const mockCheckActiveBOExists = checkActiveBOExists as jest.Mock;
+
+describe("hasValidStatements", () => {
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  test("when feature flag is off and on change journey redirects to update-beneficial-owner-bo-mo-review", () => {
+    mockIsActiveFeature.mockReturnValueOnce(false);
+    mockGetApplicationData.mockReturnValueOnce({
+      ...APPLICATION_DATA_MOCK,
+      [UpdateKey]: {
+        ...UPDATE_OBJECT_MOCK,
+        no_change: false
+      }
+    });
+
+    hasValidStatements(req, res, next);
+    expect(res.redirect).toHaveBeenCalledWith(UPDATE_CHECK_YOUR_ANSWERS_URL);
+  });
+
+  test("when feature flag is off and on no change journey redirects to review-update-statement", () => {
+    mockIsActiveFeature.mockReturnValueOnce(false);
+    mockGetApplicationData.mockReturnValueOnce({
+      ...APPLICATION_DATA_MOCK,
+      [UpdateKey]: {
+        ...UPDATE_OBJECT_MOCK,
+        no_change: true
+      }
+    });
+
+    hasValidStatements(req, res, next);
+    expect(res.redirect).toHaveBeenCalledWith(UPDATE_REVIEW_STATEMENT_URL);
+  });
+
+  describe("validateIdentifiedBOsStatement", () => {
+    describe("passes and redirects to next page", () => {
+      test.each([
+        [
+          "when all BOs identified and 1 active BO exists",
+          BeneficialOwnersStatementType.ALL_IDENTIFIED_ALL_DETAILS,
+        ],
+        [
+          "when some BOs identified and 1 active BO exists",
+          BeneficialOwnersStatementType.SOME_IDENTIFIED_ALL_DETAILS,
+        ]
+      ])(`%s`, (_, statementValue) => {
+        const appData = {
+          ...APPLICATION_DATA_UPDATE_NO_BO_OR_MO_TO_REVIEW,
+          [BeneficialOwnerStatementKey]: statementValue,
+          [BeneficialOwnerIndividualKey]: [UPDATE_BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK],
+          [UpdateKey]: {
+            ...UPDATE_OBJECT_MOCK,
+            [RegistrableBeneficialOwnerKey]: yesNoResponse.Yes,
+          }
+        };
+        mockIsActiveFeature.mockReturnValueOnce(true);
+        mockGetApplicationData.mockReturnValueOnce(appData);
+        mockCheckActiveBOExists.mockReturnValueOnce(true);
+
+        hasValidStatements(req, res, next);
+        expect(res.redirect).toHaveBeenCalled();
+      });
+    });
+
+    describe("fails and calls next() to continue to error page", () => {
+      test.each([
+        [
+          "when all BOs identified and no active BO exists",
+          BeneficialOwnersStatementType.ALL_IDENTIFIED_ALL_DETAILS,
+        ],
+        [
+          "when some BOs identified and no active BO exists",
+          BeneficialOwnersStatementType.SOME_IDENTIFIED_ALL_DETAILS,
+        ]
+      ])(`%s`, (_, statementValue) => {
+        const appData = {
+          ...APPLICATION_DATA_UPDATE_NO_BO_OR_MO_TO_REVIEW,
+          [BeneficialOwnerStatementKey]: statementValue,
+          [BeneficialOwnerIndividualKey]: [BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK_WITH_CH_REF],
+          [UpdateKey]: {
+            ...UPDATE_OBJECT_MOCK,
+            [RegistrableBeneficialOwnerKey]: yesNoResponse.Yes,
+          }
+        };
+        mockIsActiveFeature.mockReturnValueOnce(true);
+        mockGetApplicationData.mockReturnValueOnce(appData);
+        mockCheckActiveBOExists.mockReturnValueOnce(false);
+
+        hasValidStatements(req, res, next);
+        expect(next).toHaveBeenCalled();
+      });
+    });
+  });
+});

--- a/test/utils/application.data.spec.ts
+++ b/test/utils/application.data.spec.ts
@@ -13,7 +13,9 @@ import {
   checkBOsDetailsEntered,
   checkMOsDetailsEntered,
   findBoOrMo,
-  checkGivenBoOrMoDetailsExist
+  checkGivenBoOrMoDetailsExist,
+  allBeneficialOwners,
+  checkActiveBOExists
 } from "../../src/utils/application.data";
 import {
   APPLICATION_DATA_UPDATE_BO_MOCK,
@@ -28,6 +30,18 @@ import {
   getSessionRequestWithPermission,
   MO_IND_ID,
   MO_CORP_ID,
+  BENEFICIAL_OWNER_OTHER_OBJECT_MOCK,
+  BENEFICIAL_OWNER_GOV_OBJECT_MOCK,
+  BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK_WITH_CH_REF,
+  BENEFICIAL_OWNER_OTHER_OBJECT_MOCK_WITH_CH_REF,
+  BENEFICIAL_OWNER_GOV_OBJECT_MOCK_WITH_CH_REF,
+  UPDATE_OWNERS_DATA_WITH_VALUE,
+  UPDATE_BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK,
+  REVIEW_BENEFICIAL_OWNER_GOV_REQ_BODY_OBJECT_MOCK_WITH_FULL_DATA,
+  UPDATE_REVIEW_BENEFICIAL_OWNER_OTHER_REQ_MOCK,
+  APPLICATION_DATA_UPDATE_NO_BO_OR_MO_TO_REVIEW,
+  APPLICATION_DATA_MOCK_NEWLY_ADDED_BO,
+  UPDATE_BENEFICIAL_OWNER_INDIVIDUAL_REQ_BODY_OBJECT_MOCK,
 } from "../__mocks__/session.mock";
 import {
   PARAM_BENEFICIAL_OWNER_GOV,
@@ -44,6 +58,7 @@ import { BeneficialOwnerIndividualKey } from "../../src/model/beneficial.owner.i
 import { BeneficialOwnerOtherKey } from "../../src/model/beneficial.owner.other.model";
 import { ManagingOfficerCorporateKey } from "../../src/model/managing.officer.corporate.model";
 import { ManagingOfficerKey } from "../../src/model/managing.officer.model";
+import { UpdateKey } from "../../src/model/update.type.model";
 
 let req: Request;
 
@@ -340,5 +355,87 @@ describe("Application data utils", () => {
     req.session = session;
     const bo: BeneficialOwnerGov = getFromApplicationData(req, BeneficialOwnerGovKey, undefined as unknown as string, false);
     expect(bo).toBeUndefined;
+  });
+
+  test.each([
+    [
+      "1 individual BO",
+      BeneficialOwnerIndividualKey,
+      BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK
+    ],
+    [
+      "1 other BO",
+      BeneficialOwnerOtherKey,
+      BENEFICIAL_OWNER_OTHER_OBJECT_MOCK,
+    ],
+    [
+      "1 gov BO",
+      BeneficialOwnerGovKey,
+      BENEFICIAL_OWNER_GOV_OBJECT_MOCK,
+    ]
+  ])(`allBeneficialOwners with %s returns expected`, (_, boKey, boMock) => {
+    const allBOs = allBeneficialOwners({ [boKey]: [boMock] });
+
+    expect(allBOs).toEqual([boMock]);
+  });
+
+  test.each([
+    [
+      "1 individual BO for review",
+      "review_beneficial_owners_individual",
+      BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK_WITH_CH_REF
+    ],
+    [
+      "1 other BO for review",
+      "review_beneficial_owners_corporate",
+      BENEFICIAL_OWNER_OTHER_OBJECT_MOCK_WITH_CH_REF
+    ],
+    [
+      "1 gov BO for review",
+      "review_beneficial_owners_government_or_public_authority",
+      BENEFICIAL_OWNER_GOV_OBJECT_MOCK_WITH_CH_REF
+    ],
+  ])(`allBeneficialOwners with %s returns expected array`, (_, boKey, boMock) => {
+    const allBOs = allBeneficialOwners({ [UpdateKey]: { [boKey]: [boMock] } });
+
+    expect(allBOs).toEqual([boMock]);
+  });
+
+  test("allBeneficialOwners with 1 of each BO type returns array of all", () => {
+    const allBOs = allBeneficialOwners({ ...APPLICATION_DATA_MOCK, [UpdateKey]: UPDATE_OWNERS_DATA_WITH_VALUE });
+
+    expect(allBOs).toEqual([
+      BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK,
+      BENEFICIAL_OWNER_OTHER_OBJECT_MOCK,
+      BENEFICIAL_OWNER_GOV_OBJECT_MOCK,
+      UPDATE_BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK,
+      UPDATE_REVIEW_BENEFICIAL_OWNER_OTHER_REQ_MOCK,
+      REVIEW_BENEFICIAL_OWNER_GOV_REQ_BODY_OBJECT_MOCK_WITH_FULL_DATA
+    ]);
+  });
+
+  test.each([
+    [
+      "no beneficial owners returns false",
+      APPLICATION_DATA_UPDATE_NO_BO_OR_MO_TO_REVIEW,
+      false
+    ],
+    [
+      "no active beneficial owners returns false",
+      { ...APPLICATION_DATA_UPDATE_NO_BO_OR_MO_TO_REVIEW, [BeneficialOwnerIndividualKey]: [BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK_WITH_CH_REF] },
+      false
+    ],
+    [
+      "1 active beneficial owner, with no ceased_date key, returns true",
+      APPLICATION_DATA_MOCK_NEWLY_ADDED_BO,
+      true
+    ],
+    [
+      "1 active beneficial owner, with empty ceased_date, returns true",
+      { ...APPLICATION_DATA_UPDATE_NO_BO_OR_MO_TO_REVIEW, [BeneficialOwnerIndividualKey]: [UPDATE_BENEFICIAL_OWNER_INDIVIDUAL_REQ_BODY_OBJECT_MOCK] },
+      true
+    ]
+  ])(`checkActiveBOExists with %s returns expected array`, (_, appData, expectedResult) => {
+    expect(checkActiveBOExists(appData)).toBe(expectedResult);
   });
 });

--- a/views/update/update-statement-validation-errors.html
+++ b/views/update/update-statement-validation-errors.html
@@ -35,15 +35,15 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     {% include "includes/list/errors.html" %}
-    
+
     <span class="govuk-caption-l">{{ entityName }} - {{ entityNumber }}</span>
     <h1 class="govuk-heading-xl">{{ title }}</h1>
 
     {% set notificationBannerHtml %}
       <p class="govuk-notification-banner__heading">
-        You have added or ceased a beneficial owner as part of this update statement.
-        <br><br>
-        There are currently no registered beneficial owners.
+        {% for statementError in statementErrorList %}
+          {{ statementError }} <br><br>
+        {% endfor %}
       </p>
     {% endset %}
 
@@ -93,6 +93,9 @@
       }) }}
 
       {% include "includes/continue-button.html" %}
+      {% for statementError in statementErrorList %}
+        <input type="hidden" name="statementErrorList[]" value="{{ statementError }}" />
+      {% endfor %}
     </form>
   </div>
 </div>

--- a/views/update/update-statement-validation-errors.html
+++ b/views/update/update-statement-validation-errors.html
@@ -93,6 +93,8 @@
       }) }}
 
       {% include "includes/continue-button.html" %}
+      <!-- If page validation fails and re-renders the page, we need to forward the
+      statementErrorList so it is not lost -->
       {% for statementError in statementErrorList %}
         <input type="hidden" name="statementErrorList[]" value="{{ statementError }}" />
       {% endfor %}


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/UAR-763

### Change description
Introduced middleware that will validate the statements the user has made in their journey, and the middleware will (eventually) contain a set of rules that checks their statements are correct in relation to what they have answered/added in the BO/MO journey.
This change is for the 1st rule check, checking that at least 1 active BO exists if they have chosen they can identify all or some BOs in the 1st statement page `Has the overseas entity identified any registrable beneficial owners?`.

I've set the default behaviour after the 2nd statement page to redirect to the `update-statement-validation-errors` page, then the middleware runs on this route, so if statement validation fails it allows the middleware to manipulate the req, by adding req['statementErrorList'] and calling next(), which will continue onto the `update-statement-validation-errors` page which can then access the `statementErrorList` and display the errors.
Or if the user's statements are correct, the middleware will redirect the user away from `update-statement-validation-errors` page and onto their next page.

![Screenshot 2023-08-17 at 09 17 05](https://github.com/companieshouse/overseas-entities-web/assets/117734784/3fe5b3b6-d9a2-4591-b0cd-107a1bd736a8)



### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
