### PR TITLE
Fix sonar code coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,9 @@ sonar:
 test-unit: clean
 	npm run coverage
 
+.PHONY: test
+test: test-unit
+
 .PHONY: security-check
 security-check:
 	npm audit --audit-level=high

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -8,4 +8,4 @@ sonar.projectName=overseas-entities-web
 sonar.exclusions=**/bin/**, **/dist/**, **/coverage/**, **/node_modules/**, **/src/model/**
 sonar.tests=test
 sonar.test.inclusions=**/test/**.spec.*
-sonar.typescript.lcov.reportPaths=coverage/lcov.info
+sonar.javascript.lcov.reportPaths=coverage/lcov.info


### PR DESCRIPTION
### Change description
Sonar code coverage was not being produced. 
This was because the build-test-unit pipeline task calls make test-unit and the pull-request-analysis task calls make test.
We had renamed make test to make test-unit for build-test-unit.
This fix is to add a make target of 'test' back in that simply calls test-unit.

Also changed the config naming to remove a deprecation warning in the logs.


### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
