### PR TITLE
uar-975 strict date validation

### DIFF
--- a/src/validation/custom.validation.ts
+++ b/src/validation/custom.validation.ts
@@ -70,7 +70,9 @@ export const checkDateIsWithinLast3Months = (errMsg: string, day: string = "", m
 
 export const checkDateValueIsValid = (invalidDateErrMsg: string, dayStr: string = "", monthStr: string = "", yearStr: string = "") => {
   const day = parseInt(dayStr), month = parseInt(monthStr), year = parseInt(yearStr);
-  if (isNaN(day) || isNaN(month) || isNaN(year) || !DateTime.utc(year, month, day).isValid) {
+  if (isNaN(day) || isNaN(month) || isNaN(year) ||
+    day.toString() !== dayStr || month.toString() !== monthStr || year.toString() !== yearStr ||
+    !DateTime.utc(year, month, day).isValid) {
     throw new Error(invalidDateErrMsg);
   }
   return true;

--- a/test/controllers/trust.legal.entity.beneficial.owner.controller.int.spec.ts
+++ b/test/controllers/trust.legal.entity.beneficial.owner.controller.int.spec.ts
@@ -164,14 +164,14 @@ describe("Legal entity beneficial owner integration tests", () => {
       expect(decodedHTML).not.toContain(ErrorMessages.NAME_REGISTRATION_JURISDICTION_LEGAL_ENTITY_BO);
     });
 
-  test(`renders the ${TRUST_LEGAL_ENTITY_BENEFICIAL_OWNER_PAGE} page without errors interested person date`, async () => {
+    test(`renders the ${TRUST_LEGAL_ENTITY_BENEFICIAL_OWNER_PAGE} page without errors interested person date`, async () => {
     // Arrange
-    const mockTrust = <Trust>{};
-    (getTrustByIdFromApp as jest.Mock).mockReturnValue(mockTrust);
-    legalEntityWithMissingFields.roleWithinTrust = RoleWithinTrustType.INTERESTED_PERSON;
-    legalEntityWithMissingFields.interestedPersonStartDateDay = "2";
-    legalEntityWithMissingFields.interestedPersonStartDateMonth = "8";
-    legalEntityWithMissingFields.interestedPersonStartDateYear = "2012";
+      const mockTrust = <Trust>{};
+      (getTrustByIdFromApp as jest.Mock).mockReturnValue(mockTrust);
+      legalEntityWithMissingFields.roleWithinTrust = RoleWithinTrustType.INTERESTED_PERSON;
+      legalEntityWithMissingFields.interestedPersonStartDateDay = "2";
+      legalEntityWithMissingFields.interestedPersonStartDateMonth = "8";
+      legalEntityWithMissingFields.interestedPersonStartDateYear = "2012";
 
       // Act
       const resp = await request(app).post(pageUrl).send(legalEntityWithMissingFields);
@@ -310,8 +310,8 @@ describe("Legal entity beneficial owner integration tests", () => {
       const mockTrust = <Trust>{};
       (getTrustByIdFromApp as jest.Mock).mockReturnValue(mockTrust);
       legalEntityWithMissingFields.roleWithinTrust = RoleWithinTrustType.INTERESTED_PERSON;
-      legalEntityWithMissingFields.interestedPersonStartDateDay = "02";
-      legalEntityWithMissingFields.interestedPersonStartDateMonth = "08";
+      legalEntityWithMissingFields.interestedPersonStartDateDay = "2";
+      legalEntityWithMissingFields.interestedPersonStartDateMonth = "8";
       legalEntityWithMissingFields.interestedPersonStartDateYear = "2012";
 
       // Act

--- a/test/controllers/trust.legal.entity.beneficial.owner.controller.int.spec.ts
+++ b/test/controllers/trust.legal.entity.beneficial.owner.controller.int.spec.ts
@@ -164,14 +164,14 @@ describe("Legal entity beneficial owner integration tests", () => {
       expect(decodedHTML).not.toContain(ErrorMessages.NAME_REGISTRATION_JURISDICTION_LEGAL_ENTITY_BO);
     });
 
-    test(`renders the ${TRUST_LEGAL_ENTITY_BENEFICIAL_OWNER_PAGE} page without errors interested person date`, async () => {
-      // Arrange
-      const mockTrust = <Trust>{};
-      (getTrustByIdFromApp as jest.Mock).mockReturnValue(mockTrust);
-      legalEntityWithMissingFields.roleWithinTrust = RoleWithinTrustType.INTERESTED_PERSON;
-      legalEntityWithMissingFields.interestedPersonStartDateDay = "02";
-      legalEntityWithMissingFields.interestedPersonStartDateMonth = "08";
-      legalEntityWithMissingFields.interestedPersonStartDateYear = "2012";
+  test(`renders the ${TRUST_LEGAL_ENTITY_BENEFICIAL_OWNER_PAGE} page without errors interested person date`, async () => {
+    // Arrange
+    const mockTrust = <Trust>{};
+    (getTrustByIdFromApp as jest.Mock).mockReturnValue(mockTrust);
+    legalEntityWithMissingFields.roleWithinTrust = RoleWithinTrustType.INTERESTED_PERSON;
+    legalEntityWithMissingFields.interestedPersonStartDateDay = "2";
+    legalEntityWithMissingFields.interestedPersonStartDateMonth = "8";
+    legalEntityWithMissingFields.interestedPersonStartDateYear = "2012";
 
       // Act
       const resp = await request(app).post(pageUrl).send(legalEntityWithMissingFields);

--- a/test/controllers/update/update.manage.trusts.tell.us.about.the.former.bo.controller.spec.ts
+++ b/test/controllers/update/update.manage.trusts.tell.us.about.the.former.bo.controller.spec.ts
@@ -168,10 +168,10 @@ describe('Update - Manage Trusts - Review former beneficial owners', () => {
         type: 'legalEntity',
         corporate_name: 'Corporate BO',
         startDateDay: '18',
-        startDateMonth: '09',
+        startDateMonth: '9',
         startDateYear: '2023',
         endDateDay: '20',
-        endDateMonth: '09',
+        endDateMonth: '9',
         endDateYear: '2023',
         boId: ''
       });
@@ -189,10 +189,10 @@ describe('Update - Manage Trusts - Review former beneficial owners', () => {
         firstName: 'Individual',
         lastName: 'BO',
         startDateDay: '18',
-        startDateMonth: '09',
+        startDateMonth: '9',
         startDateYear: '2023',
         endDateDay: '20',
-        endDateMonth: '09',
+        endDateMonth: '9',
         endDateYear: '2023',
         boId: ''
       });
@@ -210,10 +210,10 @@ describe('Update - Manage Trusts - Review former beneficial owners', () => {
         firstName: 'Updated Individual',
         lastName: 'BO',
         startDateDay: '18',
-        startDateMonth: '09',
+        startDateMonth: '9',
         startDateYear: '2023',
         endDateDay: '20',
-        endDateMonth: '09',
+        endDateMonth: '9',
         endDateYear: '2023',
         boId: ''
       });

--- a/test/controllers/update/update.manage.trusts.tell.us.about.the.individual.controller.spec.ts
+++ b/test/controllers/update/update.manage.trusts.tell.us.about.the.individual.controller.spec.ts
@@ -100,8 +100,8 @@ describe('Update - Manage Trusts - Review individuals', () => {
         forename: 'Jack',
         other_forenames: '',
         surname: 'Frost',
-        dob_day: '01',
-        dob_month: '02',
+        dob_day: '1',
+        dob_month: '2',
         dob_year: '1990',
         nationality: 'Chadian',
         second_nationality: 'Afghan',
@@ -124,8 +124,8 @@ describe('Update - Manage Trusts - Review individuals', () => {
         sa_address_care_of: 'SA Care of',
         sa_address_po_box: 'SA Po Box 34',
         type: RoleWithinTrustType.INTERESTED_PERSON,
-        date_became_interested_person_day: '01',
-        date_became_interested_person_month: '03',
+        date_became_interested_person_day: '1',
+        date_became_interested_person_month: '3',
         date_became_interested_person_year: '2020',
         is_service_address_same_as_usual_residential_address: yesNoResponse.No,
       };
@@ -149,8 +149,8 @@ describe('Update - Manage Trusts - Review individuals', () => {
       expect(resp.text).toContain('Jack');
       expect(resp.text).toContain('Frost');
       expect(resp.text).toContain('URA Locality');
-      expect(resp.text).toContain('name="dateBecameIPDay" type="text" value="01"');
-      expect(resp.text).toContain('name="dateBecameIPMonth" type="text" value="03"');
+      expect(resp.text).toContain('name="dateBecameIPDay" type="text" value="1"');
+      expect(resp.text).toContain('name="dateBecameIPMonth" type="text" value="3"');
       expect(resp.text).toContain('name="dateBecameIPYear" type="text" value="2020"');
       expect(resp.text).toContain(UPDATE_MANAGE_TRUSTS_REVIEW_INDIVIDUALS_URL);
 
@@ -175,8 +175,8 @@ describe('Update - Manage Trusts - Review individuals', () => {
         roleWithinTrust: RoleWithinTrustType.GRANTOR,
         forename: 'Trust',
         surname: 'Ee',
-        dateOfBirthDay: '01',
-        dateOfBirthMonth: '02',
+        dateOfBirthDay: '1',
+        dateOfBirthMonth: '2',
         dateOfBirthYear: '2022',
         nationality: 'Afghan',
         second_nationality: 'English',
@@ -199,8 +199,8 @@ describe('Update - Manage Trusts - Review individuals', () => {
         service_address_po_box: '',
         service_address_care_of: '',
         is_service_address_same_as_usual_residential_address: yesNoResponse.No,
-        dateBecameIPDay: '02',
-        dateBecameIPMonth: '08',
+        dateBecameIPDay: '2',
+        dateBecameIPMonth: '8',
         dateBecameIPYear: '2023',
       };
 
@@ -211,8 +211,8 @@ describe('Update - Manage Trusts - Review individuals', () => {
         forename: 'Trust',
         other_forenames: '',
         surname: 'Ee',
-        dob_day: '01',
-        dob_month: '02',
+        dob_day: '1',
+        dob_month: '2',
         dob_year: '2022',
         nationality: 'Afghan',
         second_nationality: 'English',
@@ -305,8 +305,8 @@ describe('Update - Manage Trusts - Review individuals', () => {
         roleWithinTrust: RoleWithinTrustType.BENEFICIARY,
         forename: 'Trust',
         surname: 'Ee',
-        dateOfBirthDay: '01',
-        dateOfBirthMonth: '02',
+        dateOfBirthDay: '1',
+        dateOfBirthMonth: '2',
         dateOfBirthYear: '2022',
         nationality: 'Afghan',
         second_nationality: 'English',
@@ -329,8 +329,8 @@ describe('Update - Manage Trusts - Review individuals', () => {
         service_address_po_box: '',
         service_address_care_of: '',
         is_service_address_same_as_usual_residential_address: yesNoResponse.Yes,
-        dateBecameIPDay: '02',
-        dateBecameIPMonth: '08',
+        dateBecameIPDay: '2',
+        dateBecameIPMonth: '8',
         dateBecameIPYear: '2023',
       };
 
@@ -340,8 +340,8 @@ describe('Update - Manage Trusts - Review individuals', () => {
         forename: 'Trust',
         other_forenames: '',
         surname: 'Ee',
-        dob_day: '01',
-        dob_month: '02',
+        dob_day: '1',
+        dob_month: '2',
         dob_year: '2022',
         nationality: 'Afghan',
         second_nationality: 'English',

--- a/test/controllers/update/update.trusts.tell.us.about.it.controller.spec.ts
+++ b/test/controllers/update/update.trusts.tell.us.about.it.controller.spec.ts
@@ -101,8 +101,8 @@ describe('Update - Trusts - Tell us about the trust', () => {
       mockGetApplicationData.mockReturnValue( { ...APPLICATION_DATA_MOCK } );
       const resp = await request(app).post(UPDATE_TRUSTS_TELL_US_ABOUT_IT_URL).send({
         name: 'Trust name',
-        createdDateDay: '08',
-        createdDateMonth: '07',
+        createdDateDay: '8',
+        createdDateMonth: '7',
         createdDateYear: '2023',
         beneficialOwnersIds: '45e4283c-6b05-42da-ac9d-1f7bf9fe9c85',
         hasAllInfo: '0',

--- a/test/validation/date.validation.spec.ts
+++ b/test/validation/date.validation.spec.ts
@@ -272,7 +272,7 @@ describe("test date method", () => {
   });
 
   test("should throw no errors for checkDateIPIndividualBO", () => {
-    expect(checkDateIPIndividualBO("01", "01", "2000")).toBe(true);
+    expect(checkDateIPIndividualBO("1", "1", "2000")).toBe(true);
   });
 
   test("should throw errors for no arguments checkDateIPIndividualBO", () => {
@@ -284,7 +284,7 @@ describe("test date method", () => {
   });
 
   test("should throw no errors for checkDateIPLegalEntityBO", () => {
-    expect(checkDateIPLegalEntityBO("01", "01", "2000")).toBe(true);
+    expect(checkDateIPLegalEntityBO("1", "1", "2000")).toBe(true);
   });
 
   test("should throw errors for no arguments checkDateIPLegalEntityBO", () => {
@@ -296,7 +296,7 @@ describe("test date method", () => {
   });
 
   test("should throw no errors for checkBirthDate", () => {
-    expect(checkBirthDate("01", "01", "2000")).toBe(true);
+    expect(checkBirthDate("1", "1", "2000")).toBe(true);
   });
 
   test("should throw errors for no arguments checkBirthDate", () => {
@@ -308,7 +308,7 @@ describe("test date method", () => {
   });
 
   test("should throw no errors for checkTrustDate", () => {
-    expect(checkTrustDate("01", "01", "2000")).toBe(true);
+    expect(checkTrustDate("1", "1", "2000")).toBe(true);
   });
 
   test("should throw errors for no arguments checkBirthDate", () => {
@@ -320,7 +320,7 @@ describe("test date method", () => {
   });
 
   test("should throw no errors for checkHistoricalBOStartDate", () => {
-    expect(checkHistoricalBOStartDate("01", "01", "2000")).toBe(true);
+    expect(checkHistoricalBOStartDate("1", "1", "2000")).toBe(true);
   });
 
   test("should throw errors for no arguments checkHistoricalBOStartDate", () => {
@@ -332,7 +332,7 @@ describe("test date method", () => {
   });
 
   test("should throw no errors for checkHistoricalBOEndDate", () => {
-    expect(checkHistoricalBOEndDate("01", "01", "2000")).toBe(true);
+    expect(checkHistoricalBOEndDate("1", "1", "2000")).toBe(true);
   });
 
   test("should throw errors for no arguments checkHistoricalBOEndDate", () => {
@@ -586,6 +586,30 @@ describe("should chek date functions for custom validation", () => {
   // TODO: Needs some rework
   test("should test checkIdentityDate returns true for no param", () => {
     expect(checkIdentityDate()).toBe(true);
+  });
+
+  test("should test 1/1/2001 returns true", () => {
+    expect(checkDateValueIsValid(errorMsg, "1", "1", "2001")).toBe(true);
+  });
+
+  test("should test checkDateValueIsValid throws error for 0/1/2001", () => {
+    expect(() => checkDateValueIsValid(errorMsg, "0", "1", "2001")).toThrow(errorMsg);
+  });
+
+  test("should test checkDateValueIsValid throws error for 01/1/2001", () => {
+    expect(() => checkDateValueIsValid(errorMsg, "01", "1", "2001")).toThrow(errorMsg);
+  });
+
+  test("should test checkDateValueIsValid throws error for +1/1/2001", () => {
+    expect(() => checkDateValueIsValid(errorMsg, "+1", "1", "2001")).toThrow(errorMsg);
+  });
+
+  test("should test checkDateValueIsValid throws error for 1/13/2001", () => {
+    expect(() => checkDateValueIsValid(errorMsg, "1", "13", "2001")).toThrow(errorMsg);
+  });
+
+  test("should test checkDateValueIsValid throws error for 1/1/0999", () => {
+    expect(() => checkDateValueIsValid(errorMsg, "1", "1", "0999")).toThrow(errorMsg);
   });
 
 });


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/UAR-975


### Change description
01 as day in dates was crashing the Web app. Any such crash could be a security issue so needs closer inspection. 
The validation converts days and months to ints and then checks they are valid but continue to use the unparsed strings as the day and month in the model. 
The suggested change is to check that the parsed value is strictly equal to the string. This rules out "01", "02" etc but also protects agains "+1" and other potential allowed conversions.


### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
