### PR TITLE
UAR-1152: Update dev dockerfile to use image node:18-alpine

### DIFF
--- a/dev.dockerfile
+++ b/dev.dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-alpine
+FROM node:18-alpine
 
 WORKDIR /app
 


### PR DESCRIPTION
### JIRA link

Filed under https://companieshouse.atlassian.net/browse/UAR-1152

### Change description

When running the ROE web app locally, as outlined in `use-nodemon-in-docker-chs-development-dev-mode.md`, the `dev.dockerfile` is used.

It's base image is `node:16-alpine`, which results in an error during startup as the environment doesn't meet the minimum requirements specified in the settings. This change simply updates the base image to `node:18-alpine` to meet the new requirements.