### PR TITLE
ROE-2395 Add ids to delete-warning-page redirects

### DIFF
--- a/src/utils/beneficial.owner.statements.ts
+++ b/src/utils/beneficial.owner.statements.ts
@@ -73,7 +73,7 @@ export const postBeneficialOwnerStatements = async (req: Request, res: Response,
         (boStatement === BeneficialOwnersStatementType.ALL_IDENTIFIED_ALL_DETAILS && checkMOsDetailsEntered(appData))
       )
     ) {
-      return res.redirect(`${config.BENEFICIAL_OWNER_DELETE_WARNING_URL}?${BeneficialOwnerStatementKey}=${boStatement}`);
+      return res.redirect(`${getWarningRedirectUrl(req)}?${BeneficialOwnerStatementKey}=${boStatement}`);
     }
 
     appData[BeneficialOwnerStatementKey] = boStatement;
@@ -86,6 +86,7 @@ export const postBeneficialOwnerStatements = async (req: Request, res: Response,
     next(error);
   }
 };
+
 const getRedirectUrl = (req: Request, registrationFlag: boolean, noChangeRedirectUrl?: string) => {
   let redirectUrl: string;
   if (noChangeRedirectUrl) {
@@ -98,5 +99,13 @@ const getRedirectUrl = (req: Request, registrationFlag: boolean, noChangeRedirec
   } else {
     redirectUrl = config.UPDATE_REGISTRABLE_BENEFICIAL_OWNER_URL;
   }
-  return redirectUrl ;
+  return redirectUrl;
+};
+
+const getWarningRedirectUrl = (req: Request) => {
+  let warningRedirectUrl = config.BENEFICIAL_OWNER_DELETE_WARNING_URL;
+  if (isActiveFeature(config.FEATURE_FLAG_ENABLE_REDIS_REMOVAL)){
+    warningRedirectUrl = getUrlWithParamsToPath(config.BENEFICIAL_OWNER_DELETE_WARNING_WITH_PARAMS_URL, req);
+  }
+  return warningRedirectUrl;
 };

--- a/test/controllers/beneficial.owner.statements.spec.ts
+++ b/test/controllers/beneficial.owner.statements.spec.ts
@@ -67,7 +67,6 @@ mockGetUrlWithParamsToPath.mockReturnValue(NEXT_PAGE_URL);
 const redirectUrl = `${config.BENEFICIAL_OWNER_DELETE_WARNING_URL}?${BeneficialOwnerStatementKey}=`;
 const redirectWithParmsUrl = `${NEXT_PAGE_URL}?${BeneficialOwnerStatementKey}=`;
 
-
 describe("BENEFICIAL OWNER STATEMENTS controller", () => {
 
   beforeEach(() => {
@@ -294,7 +293,8 @@ describe("BENEFICIAL OWNER STATEMENTS controller", () => {
 
     test(`redirects to ${config.BENEFICIAL_OWNER_DELETE_WARNING_PAGE}
               page with NONE_IDENTIFIED as beneficial owners statement type`, async () => {
-      mockIsActiveFeature.mockReturnValue(true); // For FEATURE_FLAG_ENABLE_REDIS_REMOVAL
+      mockIsActiveFeature.mockReturnValueOnce(true); // For FEATURE_FLAG_ENABLE_REDIS_REMOVAL - getRedirectURL
+      mockIsActiveFeature.mockReturnValueOnce(true); // For FEATURE_FLAG_ENABLE_REDIS_REMOVAL - getWarningRedirectURL
       mockGetApplicationData.mockReturnValueOnce(APPLICATION_DATA_MOCK);
       mockGetApplicationData.mockReturnValueOnce({
         ...APPLICATION_DATA_MOCK,
@@ -315,7 +315,8 @@ describe("BENEFICIAL OWNER STATEMENTS controller", () => {
 
     test(`redirects to ${config.BENEFICIAL_OWNER_DELETE_WARNING_PAGE}
               page with ALL_IDENTIFIED_ALL_DETAILS as beneficial owners statement type`, async () => {
-      mockIsActiveFeature.mockReturnValue(true); // For FEATURE_FLAG_ENABLE_REDIS_REMOVAL
+      mockIsActiveFeature.mockReturnValueOnce(true); // For FEATURE_FLAG_ENABLE_REDIS_REMOVAL - getRedirectURL
+      mockIsActiveFeature.mockReturnValueOnce(true); // For FEATURE_FLAG_ENABLE_REDIS_REMOVAL - getWarningRedirectURL
       mockGetApplicationData.mockReturnValueOnce({
         ...APPLICATION_DATA_MOCK,
         [BeneficialOwnerStatementKey]: BeneficialOwnersStatementType.SOME_IDENTIFIED_ALL_DETAILS

--- a/test/controllers/beneficial.owner.statements.spec.ts
+++ b/test/controllers/beneficial.owner.statements.spec.ts
@@ -65,6 +65,8 @@ const mockGetUrlWithParamsToPath = getUrlWithParamsToPath as jest.Mock;
 mockGetUrlWithParamsToPath.mockReturnValue(NEXT_PAGE_URL);
 
 const redirectUrl = `${config.BENEFICIAL_OWNER_DELETE_WARNING_URL}?${BeneficialOwnerStatementKey}=`;
+const redirectWithParmsUrl = `${NEXT_PAGE_URL}?${BeneficialOwnerStatementKey}=`;
+
 
 describe("BENEFICIAL OWNER STATEMENTS controller", () => {
 
@@ -290,10 +292,9 @@ describe("BENEFICIAL OWNER STATEMENTS controller", () => {
       expect(mockSaveAndContinue).not.toHaveBeenCalled();
     });
 
-    // TODO - UPDATE THESE TESTS, ADD PARAMETERS TO BENEFICIAL_OWNER_DELETE_WARNING_PAGE
     test(`redirects to ${config.BENEFICIAL_OWNER_DELETE_WARNING_PAGE}
               page with NONE_IDENTIFIED as beneficial owners statement type`, async () => {
-      mockIsActiveFeature.mockReturnValueOnce(true); // For FEATURE_FLAG_ENABLE_REDIS_REMOVAL
+      mockIsActiveFeature.mockReturnValue(true); // For FEATURE_FLAG_ENABLE_REDIS_REMOVAL
       mockGetApplicationData.mockReturnValueOnce(APPLICATION_DATA_MOCK);
       mockGetApplicationData.mockReturnValueOnce({
         ...APPLICATION_DATA_MOCK,
@@ -306,12 +307,15 @@ describe("BENEFICIAL OWNER STATEMENTS controller", () => {
         .post(config.BENEFICIAL_OWNER_STATEMENTS_WITH_PARAMS_URL)
         .send({ [BeneficialOwnerStatementKey]: boStatement });
 
+      expect(mockIsActiveFeature).toHaveBeenCalledTimes(2);
+      expect(mockGetUrlWithParamsToPath).toHaveBeenCalledTimes(2);
       expect(resp.status).toEqual(302);
-      expect(resp.header.location).toEqual(`${redirectUrl}${boStatement}`);
+      expect(resp.header.location).toEqual(`${redirectWithParmsUrl}${boStatement}`);
     });
-    // TODO - UPDATE THESE TESTS, ADD PARAMETERS TO BENEFICIAL_OWNER_DELETE_WARNING_PAGE
+
     test(`redirects to ${config.BENEFICIAL_OWNER_DELETE_WARNING_PAGE}
               page with ALL_IDENTIFIED_ALL_DETAILS as beneficial owners statement type`, async () => {
+      mockIsActiveFeature.mockReturnValue(true); // For FEATURE_FLAG_ENABLE_REDIS_REMOVAL
       mockGetApplicationData.mockReturnValueOnce({
         ...APPLICATION_DATA_MOCK,
         [BeneficialOwnerStatementKey]: BeneficialOwnersStatementType.SOME_IDENTIFIED_ALL_DETAILS
@@ -323,8 +327,10 @@ describe("BENEFICIAL OWNER STATEMENTS controller", () => {
         .post(config.BENEFICIAL_OWNER_STATEMENTS_WITH_PARAMS_URL)
         .send({ [BeneficialOwnerStatementKey]: boStatement });
 
+      expect(mockIsActiveFeature).toHaveBeenCalledTimes(2);
+      expect(mockGetUrlWithParamsToPath).toHaveBeenCalledTimes(2);
       expect(resp.status).toEqual(302);
-      expect(resp.header.location).toEqual(`${redirectUrl}${boStatement}`);
+      expect(resp.header.location).toEqual(`${redirectWithParmsUrl}${boStatement}`);
     });
   });
 


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/ROE-2395

### Change description
Update the warning redirect urls to contain the ids as from the beneficial owner statements page.


### Work checklist

- [x] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
