### PR TITLE
uar-1194 new bos and mos not getting displayed on resume unless more …

### DIFF
--- a/src/controllers/update/beneficial.owner.type.controller.ts
+++ b/src/controllers/update/beneficial.owner.type.controller.ts
@@ -43,7 +43,7 @@ export const get = (req: Request, res: Response, next: NextFunction) => {
       ...(appData[ManagingOfficerKey] ?? [])
     ];
 
-    const hasNewlyAddedBosMos = allBosMos.find(boMo => boMo.ch_reference === undefined) !== undefined;
+    const hasNewlyAddedBosMos = allBosMos.find(boMo => !boMo.ch_reference) !== undefined;
     const hasExistingBosMos = allBosMos.find(boMo => boMo.ch_reference) !== undefined;
 
     return res.render(config.UPDATE_BENEFICIAL_OWNER_TYPE_PAGE, {


### PR DESCRIPTION
…added

### JIRA link
https://companieshouse.atlassian.net/browse/UAR-1194


### Change description
On resume any new BOs or MOs were not getting displayed on the BO/MO type page. The ch_reference was "" and not undefined (as tested for) on resume.


### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
