### PR TITLE
UAR-263: Updated manages trusts navigation to use reviewed_trust_details flag

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "@companieshouse/api-sdk-node": "^2.0.118",
+        "@companieshouse/api-sdk-node": "^2.0.121",
         "@companieshouse/node-session-handler": "^4.1.9",
         "@companieshouse/structured-logging-node": "^1.0.8",
         "@companieshouse/web-security-node": "^2.0.3",
@@ -634,9 +634,9 @@
       }
     },
     "node_modules/@companieshouse/api-sdk-node": {
-      "version": "2.0.118",
-      "resolved": "https://registry.npmjs.org/@companieshouse/api-sdk-node/-/api-sdk-node-2.0.118.tgz",
-      "integrity": "sha512-N++xdQ9cJCDlUSbz+7koGNX9NFHURT6HIqEx3CXDy9nGduM382z2QObuA04i4RAupgBTfaB9z/5hUIbbmGtsxw==",
+      "version": "2.0.121",
+      "resolved": "https://registry.npmjs.org/@companieshouse/api-sdk-node/-/api-sdk-node-2.0.121.tgz",
+      "integrity": "sha512-boaT76NOL13okbPF5b33TdEgvpPX7fnZM9f3N0x0hPTELm39SOUe2Yau2xKNw0EGyE33xNamLqrpXez10UQNnA==",
       "dependencies": {
         "axios": "^0.21.4",
         "camelcase-keys": "~6.2.2",
@@ -8142,9 +8142,9 @@
       "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ=="
     },
     "@companieshouse/api-sdk-node": {
-      "version": "2.0.118",
-      "resolved": "https://registry.npmjs.org/@companieshouse/api-sdk-node/-/api-sdk-node-2.0.118.tgz",
-      "integrity": "sha512-N++xdQ9cJCDlUSbz+7koGNX9NFHURT6HIqEx3CXDy9nGduM382z2QObuA04i4RAupgBTfaB9z/5hUIbbmGtsxw==",
+      "version": "2.0.121",
+      "resolved": "https://registry.npmjs.org/@companieshouse/api-sdk-node/-/api-sdk-node-2.0.121.tgz",
+      "integrity": "sha512-boaT76NOL13okbPF5b33TdEgvpPX7fnZM9f3N0x0hPTELm39SOUe2Yau2xKNw0EGyE33xNamLqrpXez10UQNnA==",
       "requires": {
         "axios": "^0.21.4",
         "camelcase-keys": "~6.2.2",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "license": "MIT",
   "homepage": "https://github.com/companieshouse/overseas-entities-web#readme",
   "dependencies": {
-    "@companieshouse/api-sdk-node": "^2.0.118",
+    "@companieshouse/api-sdk-node": "^2.0.121",
     "@companieshouse/node-session-handler": "^4.1.9",
     "@companieshouse/structured-logging-node": "^1.0.8",
     "@companieshouse/web-security-node": "^2.0.3",

--- a/src/model/trust.model.ts
+++ b/src/model/trust.model.ts
@@ -39,6 +39,7 @@ export interface Trust {
 
 export interface TrustReviewStatus {
   in_review: boolean;
+  reviewed_trust_details: boolean;
   reviewed_former_bos: boolean;
   reviewed_individuals: boolean;
   reviewed_legal_entities: boolean;

--- a/src/utils/trust.details.ts
+++ b/src/utils/trust.details.ts
@@ -14,7 +14,7 @@ import { validationResult } from 'express-validator/src/validation-result';
 import { FormattedValidationErrors, formatValidationError } from '../middleware/validation.middleware';
 import { saveAndContinue } from '../utils/save.and.continue';
 import { Session } from '@companieshouse/node-session-handler';
-import { beginTrustReview, getReviewTrustById, updateTrustInReviewList } from './update/review_trusts';
+import { setTrustDetailsAsReviewed, getReviewTrustById, updateTrustInReviewList } from './update/review_trusts';
 
 export const TRUST_DETAILS_TEXTS = {
   title: 'Tell us about the trust',
@@ -172,7 +172,7 @@ export const postTrustDetails = async (req: Request, res: Response, next: NextFu
 
     //  update trust  in application data at session
     if (isReview) {
-      appData = updateTrustInReviewList(appData, trust);
+      updateTrustInReviewList(appData, trust);
     } else {
       appData = saveTrustInApp(appData, trust);
     }
@@ -183,7 +183,7 @@ export const postTrustDetails = async (req: Request, res: Response, next: NextFu
 
     // // if reviewing a trust, mark trust as in review
     if (isReview) {
-      beginTrustReview(appData);
+      setTrustDetailsAsReviewed(appData);
     }
 
     //  save to session

--- a/src/utils/update/review_trusts.ts
+++ b/src/utils/update/review_trusts.ts
@@ -1,7 +1,6 @@
 import { Trust } from '../../model/trust.model';
 import { ApplicationData } from '../../model';
 import { TrusteeType } from '../../model/trustee.type.model';
-import { ReviewTrustKey, UpdateKey } from '../../model/update.type.model';
 
 export const hasTrustsToReview = (appData: ApplicationData) =>
   (appData.update?.review_trusts ?? []).length > 0;
@@ -9,48 +8,40 @@ export const hasTrustsToReview = (appData: ApplicationData) =>
 export const getTrustInReview = (appData: ApplicationData) =>
   (appData.update?.review_trusts ?? []).find(trust => !!trust.review_status?.in_review);
 
-export const getReviewTrustById = (appData: ApplicationData, trustId: string) => {
-  return appData.update?.review_trusts?.find(trust => trust.trust_id === trustId) ?? {} as Trust;
-};
+export const getReviewTrustById = (appData: ApplicationData, trustId: string) =>
+  appData.update?.review_trusts?.find(trust => trust.trust_id === trustId) ?? {};
 
 export const updateTrustInReviewList = (appData: ApplicationData, trustToSave: Trust) => {
   const trusts: Trust[] = appData.update?.review_trusts ?? [];
   const trustIndex: number = trusts.findIndex((trust: Trust) => trust.trust_id === trustToSave.trust_id);
   trusts[trustIndex] = trustToSave;
-
-  return {
-    ...appData,
-    [UpdateKey]: {
-      [ReviewTrustKey]: trusts
-    }
-  };
 };
 
-export const setupNextTrustForReview = (appData: ApplicationData) => {
+export const putNextTrustInReview = (appData: ApplicationData) => {
   const trustToReview = (appData.update?.review_trusts ?? [])[0];
 
-  if (!trustToReview) {
-    return false;
+  if (trustToReview) {
+    trustToReview.review_status = {
+      in_review: true,
+      reviewed_trust_details: false,
+      reviewed_former_bos: false,
+      reviewed_individuals: false,
+      reviewed_legal_entities: false,
+    };
   }
 
-  trustToReview.review_status = {
-    in_review: false,
-    reviewed_former_bos: false,
-    reviewed_individuals: false,
-    reviewed_legal_entities: false,
-  };
-
-  return true;
+  return trustToReview;
 };
 
-export const beginTrustReview = (appData: ApplicationData) => {
-  const trustToReview = (appData.update?.review_trusts ?? []).find(trust => trust.review_status);
+export const setTrustDetailsAsReviewed = (appData: ApplicationData) => {
+  const trust = getTrustInReview(appData);
 
-  if (!trustToReview?.review_status) {
+  if (!trust?.review_status) {
     return false;
   }
 
-  trustToReview.review_status.in_review = true;
+  trust.review_status.reviewed_trust_details = true;
+
   return true;
 };
 

--- a/test/controllers/update/update.manage.trusts.orchestrator.controller.spec.ts
+++ b/test/controllers/update/update.manage.trusts.orchestrator.controller.spec.ts
@@ -110,7 +110,13 @@ describe('Update - Manage Trusts - Orchestrator', () => {
 
     expect(resp.status).toBe(302);
     expect(resp.header.location).toEqual(UPDATE_MANAGE_TRUSTS_REVIEW_THE_TRUST_URL);
-    expect((appData.update?.review_trusts ?? [])[0].review_status?.in_review).toBe(false);
+    expect((appData.update?.review_trusts ?? [])[0].review_status).toEqual({
+      in_review: true,
+      reviewed_trust_details: false,
+      reviewed_former_bos: false,
+      reviewed_individuals: false,
+      reviewed_legal_entities: false,
+    });
     expect(mockSetExtraData).toHaveBeenCalledWith(undefined, appData);
     expect(mockSaveAndContinue).toHaveBeenCalled();
   });
@@ -118,7 +124,7 @@ describe('Update - Manage Trusts - Orchestrator', () => {
   test.each([
     ['GET', get],
     ['POST', post],
-  ])('%s - when a trust is in review, with no trustees, redirects to manage trusts individuals and entities involved page', async (_, handler) => {
+  ])('%s - when a trust is in review, with no trustees, and has reviewed trust details, redirects to manage trusts individuals and entities involved page', async (_, handler) => {
     const appData: ApplicationData = createAppData({
       reviewTrusts: [{
         HISTORICAL_BO: [],
@@ -126,6 +132,7 @@ describe('Update - Manage Trusts - Orchestrator', () => {
         CORPORATES: [],
         review_status: {
           in_review: true,
+          reviewed_trust_details: true,
           reviewed_former_bos: false,
           reviewed_individuals: false,
           reviewed_legal_entities: false,
@@ -138,7 +145,6 @@ describe('Update - Manage Trusts - Orchestrator', () => {
 
     expect(resp.status).toBe(302);
     expect(resp.header.location).toEqual(UPDATE_MANAGE_TRUSTS_INDIVIDUALS_OR_ENTITIES_INVOLVED_URL);
-    expect((appData.update?.review_trusts ?? [])[0].review_status?.in_review).toBe(true);
     expect(mockSetExtraData).not.toHaveBeenCalled();
     expect(mockSaveAndContinue).not.toHaveBeenCalled();
   });
@@ -146,7 +152,7 @@ describe('Update - Manage Trusts - Orchestrator', () => {
   test.each([
     ['GET', get],
     ['POST', post],
-  ])('%s - when a trust is in review, with trustees, redirects to review former bo page if no trustees reviewed', async (_, handler) => {
+  ])('%s - when a trust is in review, with trustees, and has reviewed trust details, redirects to review former bo page if no trustees reviewed', async (_, handler) => {
     const appData: ApplicationData = createAppData({
       reviewTrusts: [{
         HISTORICAL_BO: [{}],
@@ -154,6 +160,7 @@ describe('Update - Manage Trusts - Orchestrator', () => {
         CORPORATES: [{}],
         review_status: {
           in_review: true,
+          reviewed_trust_details: true,
           reviewed_former_bos: false,
           reviewed_individuals: false,
           reviewed_legal_entities: false,
@@ -166,7 +173,6 @@ describe('Update - Manage Trusts - Orchestrator', () => {
 
     expect(resp.status).toBe(302);
     expect(resp.header.location).toEqual(UPDATE_MANAGE_TRUSTS_REVIEW_FORMER_BO_URL);
-    expect((appData.update?.review_trusts ?? [])[0].review_status?.in_review).toBe(true);
     expect(mockSetExtraData).not.toHaveBeenCalled();
     expect(mockSaveAndContinue).not.toHaveBeenCalled();
   });
@@ -182,6 +188,7 @@ describe('Update - Manage Trusts - Orchestrator', () => {
         CORPORATES: [{}],
         review_status: {
           in_review: true,
+          reviewed_trust_details: true,
           reviewed_former_bos: true,
           reviewed_individuals: false,
           reviewed_legal_entities: false,
@@ -194,7 +201,6 @@ describe('Update - Manage Trusts - Orchestrator', () => {
 
     expect(resp.status).toBe(302);
     expect(resp.header.location).toEqual(UPDATE_MANAGE_TRUSTS_REVIEW_INDIVIDUALS_URL);
-    expect((appData.update?.review_trusts ?? [])[0].review_status?.in_review).toBe(true);
     expect(mockSetExtraData).not.toHaveBeenCalled();
     expect(mockSaveAndContinue).not.toHaveBeenCalled();
   });
@@ -210,6 +216,7 @@ describe('Update - Manage Trusts - Orchestrator', () => {
         CORPORATES: [{}],
         review_status: {
           in_review: true,
+          reviewed_trust_details: true,
           reviewed_former_bos: true,
           reviewed_individuals: true,
           reviewed_legal_entities: false,
@@ -222,7 +229,6 @@ describe('Update - Manage Trusts - Orchestrator', () => {
 
     expect(resp.status).toBe(302);
     expect(resp.header.location).toEqual(UPDATE_MANAGE_TRUSTS_REVIEW_LEGAL_ENTITIES_URL);
-    expect((appData.update?.review_trusts ?? [])[0].review_status?.in_review).toBe(true);
     expect(mockSetExtraData).not.toHaveBeenCalled();
     expect(mockSaveAndContinue).not.toHaveBeenCalled();
   });
@@ -238,6 +244,7 @@ describe('Update - Manage Trusts - Orchestrator', () => {
         CORPORATES: [{}],
         review_status: {
           in_review: true,
+          reviewed_trust_details: true,
           reviewed_former_bos: true,
           reviewed_individuals: true,
           reviewed_legal_entities: true,
@@ -250,7 +257,6 @@ describe('Update - Manage Trusts - Orchestrator', () => {
 
     expect(resp.status).toBe(302);
     expect(resp.header.location).toEqual(UPDATE_MANAGE_TRUSTS_INDIVIDUALS_OR_ENTITIES_INVOLVED_URL);
-    expect((appData.update?.review_trusts ?? [])[0].review_status?.in_review).toBe(true);
     expect(mockSetExtraData).not.toHaveBeenCalled();
     expect(mockSaveAndContinue).not.toHaveBeenCalled();
   });
@@ -266,6 +272,7 @@ describe('Update - Manage Trusts - Orchestrator', () => {
         CORPORATES: [{}],
         review_status: {
           in_review: true,
+          reviewed_trust_details: true,
           reviewed_former_bos: false,
           reviewed_individuals: false,
           reviewed_legal_entities: false,
@@ -278,7 +285,6 @@ describe('Update - Manage Trusts - Orchestrator', () => {
 
     expect(resp.status).toBe(302);
     expect(resp.header.location).toEqual(UPDATE_MANAGE_TRUSTS_REVIEW_INDIVIDUALS_URL);
-    expect((appData.update?.review_trusts ?? [])[0].review_status?.in_review).toBe(true);
     expect(mockSetExtraData).not.toHaveBeenCalled();
     expect(mockSaveAndContinue).not.toHaveBeenCalled();
   });
@@ -294,6 +300,7 @@ describe('Update - Manage Trusts - Orchestrator', () => {
         CORPORATES: [{}],
         review_status: {
           in_review: true,
+          reviewed_trust_details: true,
           reviewed_former_bos: false,
           reviewed_individuals: false,
           reviewed_legal_entities: false,
@@ -306,7 +313,6 @@ describe('Update - Manage Trusts - Orchestrator', () => {
 
     expect(resp.status).toBe(302);
     expect(resp.header.location).toEqual(UPDATE_MANAGE_TRUSTS_REVIEW_LEGAL_ENTITIES_URL);
-    expect((appData.update?.review_trusts ?? [])[0].review_status?.in_review).toBe(true);
     expect(mockSetExtraData).not.toHaveBeenCalled();
     expect(mockSaveAndContinue).not.toHaveBeenCalled();
   });
@@ -322,6 +328,7 @@ describe('Update - Manage Trusts - Orchestrator', () => {
         CORPORATES: [{}],
         review_status: {
           in_review: true,
+          reviewed_trust_details: true,
           reviewed_former_bos: true,
           reviewed_individuals: false,
           reviewed_legal_entities: false,
@@ -334,7 +341,6 @@ describe('Update - Manage Trusts - Orchestrator', () => {
 
     expect(resp.status).toBe(302);
     expect(resp.header.location).toEqual(UPDATE_MANAGE_TRUSTS_REVIEW_LEGAL_ENTITIES_URL);
-    expect((appData.update?.review_trusts ?? [])[0].review_status?.in_review).toBe(true);
     expect(mockSetExtraData).not.toHaveBeenCalled();
     expect(mockSaveAndContinue).not.toHaveBeenCalled();
   });
@@ -350,6 +356,7 @@ describe('Update - Manage Trusts - Orchestrator', () => {
         CORPORATES: [],
         review_status: {
           in_review: true,
+          reviewed_trust_details: true,
           reviewed_former_bos: true,
           reviewed_individuals: true,
           reviewed_legal_entities: false,
@@ -362,7 +369,6 @@ describe('Update - Manage Trusts - Orchestrator', () => {
 
     expect(resp.status).toBe(302);
     expect(resp.header.location).toEqual(UPDATE_MANAGE_TRUSTS_INDIVIDUALS_OR_ENTITIES_INVOLVED_URL);
-    expect((appData.update?.review_trusts ?? [])[0].review_status?.in_review).toBe(true);
     expect(mockSetExtraData).not.toHaveBeenCalled();
     expect(mockSaveAndContinue).not.toHaveBeenCalled();
   });

--- a/test/controllers/update/update.manage.trusts.review.former.bo.controller.spec.ts
+++ b/test/controllers/update/update.manage.trusts.review.former.bo.controller.spec.ts
@@ -61,6 +61,7 @@ const appDataWithReviewTrust = {
         ],
         review_status: {
           in_review: true,
+          reviewed_trust_details: false,
           reviewed_former_bos: false,
           reviewed_individuals: false,
           reviewed_legal_entities: false,

--- a/test/controllers/update/update.manage.trusts.review.the.trust.controller.spec.ts
+++ b/test/controllers/update/update.manage.trusts.review.the.trust.controller.spec.ts
@@ -34,6 +34,7 @@ const mockTrust = {
   beneficialOwnersIds: ['45e4283c-6b05-42da-ac9d-1f7bf9fe9c85'],
   review_status: {
     in_review: false,
+    reviewed_trust_details: false,
     reviewed_former_bos: false,
     reviewed_individuals: false,
     reviewed_legal_entities: false,
@@ -125,15 +126,6 @@ describe('Update - Manage Trusts - Review the trust', () => {
   describe('POST tests', () => {
     test('when feature flag is on, redirect to review former bo page', async () => {
       mockIsActiveFeature.mockReturnValueOnce(true);
-      mockUpdateTrustInReviewList.mockReturnValueOnce({
-        ...APPLICATION_DATA_MOCK,
-        [UpdateKey]: {
-          review_trusts: [{
-            ...mockTrust,
-            trust_name: "Updated Trust name"
-          }]
-        }
-      });
 
       const resp = await request(app).post(UPDATE_MANAGE_TRUSTS_REVIEW_THE_TRUST_URL)
         .send({

--- a/test/controllers/update/update.manage.trusts.tell.us.about.the.former.bo.controller.spec.ts
+++ b/test/controllers/update/update.manage.trusts.tell.us.about.the.former.bo.controller.spec.ts
@@ -62,6 +62,7 @@ mockGetApplicationData.mockReturnValue({
         ],
         review_status: {
           in_review: true,
+          reviewed_trust_details: false,
           reviewed_former_bos: false,
           reviewed_individuals: false,
           reviewed_legal_entities: false,


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/UAR-263

### Change description

Addressing a query mentioned in the PR below. In summary: the review_status didn't allow for navigating back from the review_trust page as implemented, `in_review` was modified to resolve this, and therefore made no sense being named `in_review`.

This PR undoes that change (separate PR to not block UAR-263 going in, as ROE API/api-sdk-node model changes are required too, linked below) and introduced the `reviewed_trust_details` flag in the `review_status` of a trust in review.

- PR/Query: https://github.com/companieshouse/overseas-entities-web/pull/1106/files#r1355093145

### Corresponding PRs in ROE API/api-sdk-node:
- https://github.com/companieshouse/overseas-entities-api/pull/353
- https://github.com/companieshouse/api-sdk-node/pull/621

### TODO:
- ~Target main (original PR is not in yet)~ _**Done**_
- ~Updated api-sdk-node version once the corresponding PR is merged~ _**Done - updated to v2.0.121**_ - 

### Work checklist

- [x] Tests added where applicable
- [x] UI changes meet accessibility criteria