### PR TITLE
UAR-1108: fix country with pascal case

### DIFF
--- a/src/utils/update/mapper.utils.ts
+++ b/src/utils/update/mapper.utils.ts
@@ -125,7 +125,7 @@ export const lowerCaseAllWordsExceptFirstLetters = (country: string | undefined)
   const wordsForAllLowerCase = ["AND", "OF", "THE", "DA", "PART"];
 
   return country.replace(/\w*/g, word => {
-    if (word === "MCDONALD") {
+    if (word === "MCDONALD" || word === "Mcdonald") {
       return "McDonald";
     }
 

--- a/src/utils/update/mapper.utils.ts
+++ b/src/utils/update/mapper.utils.ts
@@ -125,7 +125,7 @@ export const lowerCaseAllWordsExceptFirstLetters = (country: string | undefined)
   const wordsForAllLowerCase = ["AND", "OF", "THE", "DA", "PART"];
 
   return country.replace(/\w*/g, word => {
-    if (word === "MCDONALD" || word === "Mcdonald") {
+    if (word.toUpperCase() === "MCDONALD") {
       return "McDonald";
     }
 

--- a/test/utils/update/mapper.utils.spec.ts
+++ b/test/utils/update/mapper.utils.spec.ts
@@ -63,7 +63,15 @@ describe("Test mapping utils", () => {
       ["BRITISH INDIAN OCEAN TERRITORY", "British Indian Ocean Territory"],
       ["SAINT HELENA, ASCENSION AND TRISTAN DA CUNHA", "Saint Helena, Ascension and Tristan da Cunha"],
       ["SINT MAARTEN (DUTCH PART)", "Sint Maarten (Dutch part)"],
-      ["GUINEA-BISSAU", "Guinea-Bissau"]
+      ["GUINEA-BISSAU", "Guinea-Bissau"],
+      ["Svalbard And Jan Mayen", "Svalbard and Jan Mayen"],
+      ["Saint Helena, Ascension And Tristan Da Cunha", "Saint Helena, Ascension and Tristan da Cunha"],
+      ["Isle Of Mann", "Isle of Mann"],
+      ["Sint Maarten (Dutch Part)", "Sint Maarten (Dutch part)"],
+      ["Congo, The Democratic Republic Of The", "Congo, the Democratic Republic of the"],
+      ["Saint Vincent And The Grenadines", "Saint Vincent and the Grenadines"],
+      ["South Georgia And The South Sandwich Islands", "South Georgia and the South Sandwich Islands"],
+      ["Heard Island And Mcdonald Islands", "Heard Island and McDonald Islands"],
     ])(`Correctly reformats %s`, (str, expectedResult) => {
       expect(lowerCaseAllWordsExceptFirstLetters(str)).toEqual(expectedResult);
     });


### PR DESCRIPTION
### JIRA link
Jira [UAR-1108](https://companieshouse.atlassian.net/browse/UAR-1108)

### Change description
Countries returned from public api are pascal cased and hence do not match the drop down values as they don't pascal case words like "and, the, da, of, part, Mcdonald", this change ensures McDonald is not pascal cased


### Work checklist

- [x ] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.


[UAR-1108]: https://companieshouse.atlassian.net/browse/UAR-1108?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ