### PR TITLE
Bug/uar-1210 no adds/ceased statement miss match and bo add issue

### DIFF
--- a/src/utils/registrable.beneficial.owner.ts
+++ b/src/utils/registrable.beneficial.owner.ts
@@ -35,7 +35,7 @@ export const getRegistrableBeneficialOwner = (req: Request, res: Response, next:
   }
 };
 
-export const postRegistrableBeneficialOwner = (req: Request, res: Response, next: NextFunction, noChangeFlag?: boolean) => {
+export const postRegistrableBeneficialOwner = async (req: Request, res: Response, next: NextFunction, noChangeFlag?: boolean) => {
   try {
     logger.debugRequest(req, `${req.method} ${req.route.path}`);
     const isRegistrableBeneficialOwner = req.body[RegistrableBeneficialOwnerKey];
@@ -45,7 +45,7 @@ export const postRegistrableBeneficialOwner = (req: Request, res: Response, next
       appData.update.registrable_beneficial_owner = isRegistrableBeneficialOwner ? yesNoResponse.Yes : yesNoResponse.No;
     }
     setExtraData(req.session, appData);
-    saveAndContinue(req, session, false);
+    await saveAndContinue(req, session, false);
 
     if (noChangeFlag) {
       noChangeHandler(req, res);

--- a/src/utils/registrable.beneficial.owner.ts
+++ b/src/utils/registrable.beneficial.owner.ts
@@ -5,6 +5,9 @@ import { ApplicationData } from "../model/application.model";
 import { getApplicationData, setExtraData } from "../utils/application.data";
 import { RegistrableBeneficialOwnerKey } from "../model/update.type.model";
 import { isActiveFeature } from "./feature.flag";
+import { yesNoResponse } from "../model/data.types.model";
+import { Session } from "@companieshouse/node-session-handler";
+import { saveAndContinue } from "./save.and.continue";
 
 export const getRegistrableBeneficialOwner = (req: Request, res: Response, next: NextFunction, noChangeFlag?: boolean) => {
   try {
@@ -36,11 +39,13 @@ export const postRegistrableBeneficialOwner = (req: Request, res: Response, next
   try {
     logger.debugRequest(req, `${req.method} ${req.route.path}`);
     const isRegistrableBeneficialOwner = req.body[RegistrableBeneficialOwnerKey];
-    const appData: ApplicationData = getApplicationData(req.session);
+    const session = req.session as Session;
+    const appData: ApplicationData = getApplicationData(session);
     if (appData.update) {
-      appData.update.registrable_beneficial_owner = (isRegistrableBeneficialOwner) ? +isRegistrableBeneficialOwner : 0;
+      appData.update.registrable_beneficial_owner = isRegistrableBeneficialOwner ? yesNoResponse.Yes : yesNoResponse.No;
     }
     setExtraData(req.session, appData);
+    saveAndContinue(req, session, false);
 
     if (noChangeFlag) {
       noChangeHandler(req, res);

--- a/test/controllers/update/no.change.registrable.beneficial.owner.controller.spec.ts
+++ b/test/controllers/update/no.change.registrable.beneficial.owner.controller.spec.ts
@@ -6,6 +6,7 @@ jest.mock('../../../src/utils/application.data');
 jest.mock('../../../src/middleware/service.availability.middleware');
 jest.mock('../../../src/middleware/navigation/update/has.overseas.entity.middleware');
 jest.mock("../../../src/utils/feature.flag" );
+jest.mock('../../../src/utils/save.and.continue');
 
 import { NextFunction, Request, Response } from "express";
 import { beforeEach, expect, jest, test, describe } from "@jest/globals";
@@ -36,6 +37,7 @@ import {
 import { yesNoResponse } from "@companieshouse/api-sdk-node/dist/services/overseas-entities";
 import { ErrorMessages } from "../../../src/validation/error.messages";
 import { isActiveFeature } from "../../../src/utils/feature.flag";
+import { saveAndContinue } from "../../../src/utils/save.and.continue";
 
 const mockHasOverseasEntity = hasOverseasEntity as jest.Mock;
 mockHasOverseasEntity.mockImplementation((req: Request, res: Response, next: NextFunction) => next() );
@@ -55,6 +57,7 @@ mockIsActiveFeature.mockReturnValue(false);
 const mockLoggerDebugRequest = logger.debugRequest as jest.Mock;
 const mockGetApplicationData = getApplicationData as jest.Mock;
 const mockSetExtraData = setExtraData as jest.Mock;
+const mockSaveAndContinue = saveAndContinue as jest.Mock;
 
 describe("No change registrable beneficial owner", () => {
 
@@ -139,6 +142,7 @@ describe("No change registrable beneficial owner", () => {
     test(`with statement validation flag on, redirects to the update-statement-validation-errors page when 'has reasonable cause' is selected`, async () => {
       mockGetApplicationData.mockReturnValueOnce({ ...APPLICATION_DATA_MOCK });
       mockIsActiveFeature.mockReturnValueOnce(true);
+      mockSaveAndContinue.mockReturnValueOnce(Promise.resolve());
 
       const resp = await request(app)
         .post(UPDATE_NO_CHANGE_REGISTRABLE_BENEFICIAL_OWNER_URL)
@@ -147,6 +151,7 @@ describe("No change registrable beneficial owner", () => {
       expect(resp.status).toEqual(302);
       expect(resp.header.location).toEqual(UPDATE_STATEMENT_VALIDATION_ERRORS_URL);
       expect(mockSetExtraData).toHaveBeenCalledTimes(1);
+      expect(mockSaveAndContinue).toHaveBeenCalledTimes(1);
     });
 
     test("Test validation error is displayed when posting empty object", async () => {

--- a/test/controllers/update/update.registrable.beneficial.owner.controller.spec.ts
+++ b/test/controllers/update/update.registrable.beneficial.owner.controller.spec.ts
@@ -6,6 +6,7 @@ jest.mock('../../../src/utils/application.data');
 jest.mock('../../../src/middleware/service.availability.middleware');
 jest.mock('../../../src/middleware/navigation/update/has.overseas.entity.middleware');
 jest.mock("../../../src/utils/feature.flag" );
+jest.mock('../../../src/utils/save.and.continue');
 
 import { NextFunction, Request, Response } from "express";
 import { beforeEach, expect, jest, test, describe } from "@jest/globals";
@@ -38,6 +39,7 @@ import { RegistrableBeneficialOwnerKey } from "../../../src/model/update.type.mo
 import { hasOverseasEntity } from "../../../src/middleware/navigation/update/has.overseas.entity.middleware";
 import { yesNoResponse } from "../../../src/model/data.types.model";
 import { isActiveFeature } from "../../../src/utils/feature.flag";
+import { saveAndContinue } from "../../../src/utils/save.and.continue";
 
 const mockHasOverseasEntity = hasOverseasEntity as jest.Mock;
 mockHasOverseasEntity.mockImplementation((req: Request, res: Response, next: NextFunction) => next() );
@@ -57,6 +59,7 @@ mockIsActiveFeature.mockReturnValue(false);
 const mockLoggerDebugRequest = logger.debugRequest as jest.Mock;
 const mockGetApplicationData = getApplicationData as jest.Mock;
 const mockSetExtraData = setExtraData as jest.Mock;
+const mockSaveAndContinue = saveAndContinue as jest.Mock;
 
 describe("Update registrable beneficial owner controller tests", () => {
 
@@ -133,6 +136,8 @@ describe("Update registrable beneficial owner controller tests", () => {
     test(`with statement validation on, redirect to update-statement-validation-errors page when ${yesNoResponse.Yes} is selected`, async () => {
       mockGetApplicationData.mockReturnValueOnce({ ...APPLICATION_DATA_MOCK });
       mockIsActiveFeature.mockReturnValueOnce(true);
+      mockSaveAndContinue.mockReturnValueOnce(Promise.resolve());
+
       const resp = await request(app)
         .post(UPDATE_REGISTRABLE_BENEFICIAL_OWNER_URL)
         .send({ [RegistrableBeneficialOwnerKey]: yesNoResponse.Yes });
@@ -140,11 +145,14 @@ describe("Update registrable beneficial owner controller tests", () => {
       expect(resp.status).toEqual(302);
       expect(resp.header.location).toEqual(UPDATE_STATEMENT_VALIDATION_ERRORS_URL);
       expect(mockSetExtraData).toHaveBeenCalledTimes(1);
+      expect(mockSaveAndContinue).toHaveBeenCalledTimes(1);
     });
 
     test(`with statement validation on, redirects to the update-statement-validation-errors page when ${yesNoResponse.No} is selected`, async () => {
       mockGetApplicationData.mockReturnValueOnce({ ...APPLICATION_DATA_MOCK });
       mockIsActiveFeature.mockReturnValueOnce(true);
+      mockSaveAndContinue.mockReturnValueOnce(Promise.resolve());
+
       const resp = await request(app)
         .post(UPDATE_REGISTRABLE_BENEFICIAL_OWNER_URL)
         .send({ [RegistrableBeneficialOwnerKey]: yesNoResponse.No });
@@ -152,6 +160,7 @@ describe("Update registrable beneficial owner controller tests", () => {
       expect(resp.status).toEqual(302);
       expect(resp.header.location).toEqual(UPDATE_STATEMENT_VALIDATION_ERRORS_URL);
       expect(mockSetExtraData).toHaveBeenCalledTimes(1);
+      expect(mockSaveAndContinue).toHaveBeenCalledTimes(1);
     });
 
     test("POST empty object and check for error in page title", async () => {


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/UAR-1210


### Change description
The statement pages got moved to end of journey. 
The any added or ceased statement does not call saveAndContinue. 
Therefore the last change to the App Data may not get saved to MongoDb.


### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
