### PR TITLE
UAR-1211: Statement date validations

### DIFF
--- a/src/validation/beneficial.owner.gov.validation.ts
+++ b/src/validation/beneficial.owner.gov.validation.ts
@@ -4,7 +4,7 @@ import { ErrorMessages } from "./error.messages";
 import { principal_address_validations, principal_service_address_validations } from "./fields/address.validation";
 import { VALID_CHARACTERS } from "./regex/regex.validation";
 import { checkAtLeastOneFieldHasValue } from "./custom.validation";
-import { start_date_validations, ceased_date_validations } from "./fields/date.validation";
+import { start_date_validations, ceased_date_validations, filingPeriodStartDateValidations } from "./fields/date.validation";
 
 export const beneficial_owner_gov_name_validation = [
   body("name")
@@ -68,7 +68,9 @@ export const updateBeneficialOwnerGov = [
 
   body("is_still_bo").not().isEmpty().withMessage(ErrorMessages.SELECT_IF_STILL_BENEFICIAL_OWNER),
 
-  ...ceased_date_validations
+  ...ceased_date_validations,
+
+  ...filingPeriodStartDateValidations
 ];
 
 export const updateReviewBeneficialOwnerGovValidator = [

--- a/src/validation/beneficial.owner.individual.validation.ts
+++ b/src/validation/beneficial.owner.individual.validation.ts
@@ -8,7 +8,7 @@ import {
 } from "./fields/address.validation";
 import { nature_of_control_validations } from "./fields/nature-of-control.validation";
 import { second_nationality_validations } from "./fields/second-nationality.validation";
-import { date_of_birth_validations, start_date_validations, ceased_date_validations } from "./fields/date.validation";
+import { date_of_birth_validations, start_date_validations, ceased_date_validations, filingPeriodStartDateValidations } from "./fields/date.validation";
 
 export const beneficialOwnerIndividual = [
   body("first_name")
@@ -48,5 +48,7 @@ export const updateBeneficialOwnerIndividual = [
 
   body("is_still_bo").not().isEmpty().withMessage(ErrorMessages.SELECT_IF_STILL_BENEFICIAL_OWNER),
 
-  ...ceased_date_validations
+  ...ceased_date_validations,
+
+  ...filingPeriodStartDateValidations
 ];

--- a/src/validation/beneficial.owner.other.validation.ts
+++ b/src/validation/beneficial.owner.other.validation.ts
@@ -5,7 +5,7 @@ import { VALID_CHARACTERS } from "./regex/regex.validation";
 import { principal_address_validations, principal_service_address_validations } from "./fields/address.validation";
 import { public_register_validations } from "./fields/public-register.validation";
 import { nature_of_control_validations } from "./fields/nature-of-control.validation";
-import { start_date_validations, ceased_date_validations } from "./fields/date.validation";
+import { start_date_validations, ceased_date_validations, filingPeriodStartDateValidations } from "./fields/date.validation";
 
 export const beneficialOwnerOther = [
   body("name")
@@ -48,5 +48,7 @@ export const updateBeneficialOwnerOther = [
 
   body("is_still_bo").not().isEmpty().withMessage(ErrorMessages.SELECT_IF_STILL_BENEFICIAL_OWNER),
 
-  ...ceased_date_validations
+  ...ceased_date_validations,
+
+  ...filingPeriodStartDateValidations
 ];

--- a/src/validation/custom.validation.ts
+++ b/src/validation/custom.validation.ts
@@ -258,6 +258,8 @@ export const checkFirstDateOnOrAfterSecondDate = (
   return true;
 };
 
+export const checkCeasedDateOnOrAfterStartDate = checkFirstDateOnOrAfterSecondDate;
+
 export const checkDateOfBirth = (dayStr: string = "", monthStr: string = "", yearStr: string = "") => {
   // to prevent more than 1 error reported on the date fields we check if the year is correct length or missing before doing the date check as a whole.
   if (checkMoreThanOneDateFieldIsNotMissing(dayStr, monthStr, yearStr)
@@ -517,7 +519,7 @@ export const checkBeneficialOwnersSubmission = (req) => {
   return true;
 };
 
-export const checkFilingPeriod = (req, secondDateDay: string, secondDateMonth: string, secondDateYear: string, errorMessage: string) => {
+export const checkDatePreviousToFilingDate = (req, dateDay: string, dateMonth: string, dateYear: string, errorMessage: string) => {
   const appData: ApplicationData = getApplicationData(req.session);
 
   const filingDateDay = appData?.update?.[FilingDateKey]?.day;
@@ -526,7 +528,7 @@ export const checkFilingPeriod = (req, secondDateDay: string, secondDateMonth: s
 
   if (!checkFirstDateOnOrAfterSecondDate(
     filingDateDay, filingDateMonth, filingDateYear,
-    secondDateDay, secondDateMonth, secondDateYear,
+    dateDay, dateMonth, dateYear,
     errorMessage
   )) {
     throw new Error(errorMessage);

--- a/src/validation/custom.validation.ts
+++ b/src/validation/custom.validation.ts
@@ -526,14 +526,10 @@ export const checkDatePreviousToFilingDate = (req, dateDay: string, dateMonth: s
   const filingDateMonth = appData?.update?.[FilingDateKey]?.month;
   const filingDateYear = appData?.update?.[FilingDateKey]?.year;
 
-  if (!checkFirstDateOnOrAfterSecondDate(
+  return checkFirstDateOnOrAfterSecondDate(
     filingDateDay, filingDateMonth, filingDateYear,
     dateDay, dateMonth, dateYear,
-    errorMessage
-  )) {
-    throw new Error(errorMessage);
-  }
-  return true;
+    errorMessage);
 };
 
 const hasBeneficialOwners = (appData: ApplicationData) => {

--- a/src/validation/custom.validation.ts
+++ b/src/validation/custom.validation.ts
@@ -7,6 +7,7 @@ import { ApplicationData, trustType } from "../model";
 import { BeneficialOwnersStatementType } from "../model/beneficial.owner.statement.model";
 import { CONCATENATED_VALUES_SEPARATOR } from "../config";
 import { getApplicationData } from "../utils/application.data";
+import { FilingDateKey } from '../model/date.model';
 import { DefaultErrorsSecondNationality } from "./models/second.nationality.error.model";
 
 export const checkFieldIfRadioButtonSelected = (selected: boolean, errMsg: string, value: string = "") => {
@@ -242,15 +243,15 @@ export const checkMoreThanOneDateFieldIsNotMissing = (dayStr: string = "", month
   return true;
 };
 
-export const checkCeasedDateOnOrAfterStartDate = (
-  ceaseDayStr: string = "", ceaseMonthStr: string = "", ceaseYearStr: string = "",
-  startDayStr: string = "", startMonthStr: string = "", startYearStr: string = "",
+export const checkFirstDateOnOrAfterSecondDate = (
+  firstDayStr: string = "", firstMonthStr: string = "", firstYearStr: string = "",
+  secondDayStr: string = "", secondMonthStr: string = "", secondYearStr: string = "",
   errorMessage: string = ErrorMessages.DATE_BEFORE_START_DATE
 ): boolean => {
-  const ceaseDate = DateTime.utc(Number(ceaseYearStr), Number(ceaseMonthStr), Number(ceaseDayStr));
-  const startDate = DateTime.utc(Number(startYearStr), Number(startMonthStr), Number(startDayStr));
+  const firstDate = DateTime.utc(Number(firstYearStr), Number(firstMonthStr), Number(firstDayStr));
+  const secondDate = DateTime.utc(Number(secondYearStr), Number(secondMonthStr), Number(secondDayStr));
 
-  if (startDate && startDate > ceaseDate) {
+  if (secondDate && secondDate > firstDate) {
     throw new Error(errorMessage);
   }
 
@@ -512,6 +513,23 @@ export const checkBeneficialOwnersSubmission = (req) => {
     if (!hasManagingOfficers(appData)) {
       throw new Error(ErrorMessages.MUST_ADD_MANAGING_OFFICER);
     }
+  }
+  return true;
+};
+
+export const checkFilingPeriod = (req, secondDateDay: string, secondDateMonth: string, secondDateYear: string, errorMessage: string) => {
+  const appData: ApplicationData = getApplicationData(req.session);
+
+  const filingDateDay = appData?.update?.[FilingDateKey]?.day;
+  const filingDateMonth = appData?.update?.[FilingDateKey]?.month;
+  const filingDateYear = appData?.update?.[FilingDateKey]?.year;
+
+  if (!checkFirstDateOnOrAfterSecondDate(
+    filingDateDay, filingDateMonth, filingDateYear,
+    secondDateDay, secondDateMonth, secondDateYear,
+    errorMessage
+  )) {
+    throw new Error(errorMessage);
   }
   return true;
 };

--- a/src/validation/error.messages.ts
+++ b/src/validation/error.messages.ts
@@ -160,6 +160,7 @@ export enum ErrorMessages {
   CEASED_DATE_BEFORE_START_DATE = "Ceased date must be on or after the appointed date",
   TRUST_CEASED_DATE_BEFORE_START_DATE = "Ceased date must be on or after the start date",
   RESIGNED_ON_BEFORE_START_DATE = "Resigned on date must be on or after the appointed date",
+  START_DATE_BEFORE_FILING_DATE = "Start date must be before or on the date of the update statement",
 
   // No radio selected
   SELECT_IF_ENTITY_HAS_SOLD_LAND = "Select yes if the entity has disposed of UK property or land since 28 February 2022",

--- a/src/validation/fields/date.validation.ts
+++ b/src/validation/fields/date.validation.ts
@@ -19,6 +19,8 @@ import {
   checkDateIPLegalEntityBO,
   checkCeasedDateOnOrAfterStartDate,
   checkStartDateBeforeDOB
+  checkFirstDateOnOrAfterSecondDate,
+  checkFilingPeriod
 } from "../custom.validation";
 import { ErrorMessages } from "../error.messages";
 import { conditionalDateValidations, dateContext, dateContextWithCondition, dateValidations } from "./helper/date.validation.helper";
@@ -67,9 +69,18 @@ const is_still_active_validations = (date_field_id: string, radio_button_id: str
 
 const is_trust_still_active_validation = (error_message: string) => [
   body("endDate")
-    .custom((value, { req }) => checkCeasedDateOnOrAfterStartDate(
+    .custom((value, { req }) => checkFirstDateOnOrAfterSecondDate(
       req.body["endDateDay"], req.body["endDateMonth"], req.body["endDateYear"],
       req.body["startDateDay"], req.body["startDateMonth"], req.body["startDateYear"],
+      error_message
+    )),
+];
+
+const is_date_within_filing_period = (date_field_id: string, error_message: string) => [
+  body(date_field_id)
+    .custom((value, { req }) => checkFilingPeriod(
+      req,
+      req.body[date_field_id + "-day"], req.body[date_field_id + "-month"], req.body[date_field_id + "-year"],
       error_message
     )),
 ];
@@ -79,6 +90,8 @@ export const ceased_date_validations = is_still_active_validations("ceased_date"
 export const resigned_on_validations = is_still_active_validations("resigned_on", "is_still_mo", ErrorMessages.RESIGNED_ON_BEFORE_START_DATE);
 
 export const trustFormerBODateValidations = is_trust_still_active_validation(ErrorMessages.TRUST_CEASED_DATE_BEFORE_START_DATE);
+
+export const filingPeriodStartDateValidations = is_date_within_filing_period("start_date", ErrorMessages.START_DATE_BEFORE_FILING_DATE);
 
 // to prevent more than 1 error reported on the date fields we check if the year is valid before doing some checks.
 // This means that the year check is checked before some others

--- a/src/validation/fields/date.validation.ts
+++ b/src/validation/fields/date.validation.ts
@@ -18,9 +18,9 @@ import {
   YearFieldErrors,
   checkDateIPLegalEntityBO,
   checkCeasedDateOnOrAfterStartDate,
-  checkStartDateBeforeDOB
+  checkStartDateBeforeDOB,
   checkFirstDateOnOrAfterSecondDate,
-  checkFilingPeriod
+  checkDatePreviousToFilingDate
 } from "../custom.validation";
 import { ErrorMessages } from "../error.messages";
 import { conditionalDateValidations, dateContext, dateContextWithCondition, dateValidations } from "./helper/date.validation.helper";
@@ -78,7 +78,7 @@ const is_trust_still_active_validation = (error_message: string) => [
 
 const is_date_within_filing_period = (date_field_id: string, error_message: string) => [
   body(date_field_id)
-    .custom((value, { req }) => checkFilingPeriod(
+    .custom((value, { req }) => checkDatePreviousToFilingDate(
       req,
       req.body[date_field_id + "-day"], req.body[date_field_id + "-month"], req.body[date_field_id + "-year"],
       error_message

--- a/src/validation/managing.officer.corporate.validation.ts
+++ b/src/validation/managing.officer.corporate.validation.ts
@@ -5,7 +5,7 @@ import { principal_address_validations, principal_service_address_validations } 
 import { public_register_validations } from "./fields/public-register.validation";
 import { VALID_CHARACTERS, VALID_CHARACTERS_FOR_TEXT_BOX } from "./regex/regex.validation";
 import { contact_email_validations } from "./fields/email.validation";
-import { resigned_on_validations, start_date_validations } from "./fields/date.validation";
+import { resigned_on_validations, start_date_validations, filingPeriodStartDateValidations } from "./fields/date.validation";
 
 const contact_name_and_email_validations = [
   body("contact_full_name")
@@ -63,7 +63,8 @@ export const updateManagingOfficerCorporate = [
   ...start_date_validations,
   ...isStillMoValidation,
   ...resigned_on_validations,
-  ...contact_name_and_email_validations
+  ...contact_name_and_email_validations,
+  ...filingPeriodStartDateValidations
 ];
 
 export const reviewManagingOfficerCorporate = [

--- a/src/validation/managing.officer.validation.ts
+++ b/src/validation/managing.officer.validation.ts
@@ -9,7 +9,7 @@ import { ErrorMessages } from "./error.messages";
 import { usual_residential_service_address_validations, usual_residential_address_validations } from "./fields/address.validation";
 import { second_nationality_validations } from "./fields/second-nationality.validation";
 import { VALID_CHARACTERS, VALID_CHARACTERS_FOR_TEXT_BOX } from "./regex/regex.validation";
-import { date_of_birth_validations, resigned_on_validations, start_date_validations } from "./fields/date.validation";
+import { date_of_birth_validations, resigned_on_validations, start_date_validations, filingPeriodStartDateValidations } from "./fields/date.validation";
 
 export const managing_officer_name_validation = [
   body("first_name").not().isEmpty({ ignore_whitespace: true })
@@ -66,7 +66,8 @@ export const updateManagingOfficerIndividual = [
   ...managingOfficerIndividual,
   ...start_date_validations,
   body("is_still_mo").not().isEmpty().withMessage(ErrorMessages.SELECT_IF_STILL_MANAGING_OFFICER),
-  ...resigned_on_validations
+  ...resigned_on_validations,
+  ...filingPeriodStartDateValidations
 ];
 
 export const reviewManagingOfficers = [

--- a/test/controllers/update/update.review.beneficial.owner.gov.spec.ts
+++ b/test/controllers/update/update.review.beneficial.owner.gov.spec.ts
@@ -120,7 +120,7 @@ describe(`Update review beneficial owner Gov`, () => {
     });
 
     test(`redirect to ${config.UPDATE_BENEFICIAL_OWNER_TYPE_PAGE} page on successful submission`, async () => {
-      mockGetApplicationData.mockReturnValueOnce({
+      mockGetApplicationData.mockReturnValue({
         ...APPLICATION_DATA_MOCK
       });
       mockPrepareData.mockImplementationOnce( () => UPDATE_REVIEW_BENEFICIAL_OWNER_MOCK_DATA );

--- a/test/controllers/update/update.review.beneficial.owner.individual.spec.ts
+++ b/test/controllers/update/update.review.beneficial.owner.individual.spec.ts
@@ -110,7 +110,7 @@ describe(`Update review beneficial owner individual controller`, () => {
     });
 
     test(`redirect to beneficial owner type page ${config.UPDATE_BENEFICIAL_OWNER_TYPE_PAGE} on successful submission`, async () => {
-      mockGetApplicationData.mockReturnValueOnce({
+      mockGetApplicationData.mockReturnValue({
         ...APPLICATION_DATA_MOCK
       });
       mockPrepareData.mockImplementationOnce( () => REVIEW_BENEFICIAL_OWNER_INDIVIDUAL_REQ_BODY_OBJECT_MOCK_WITH_FULL_DATA );

--- a/test/controllers/update/update.review.beneficial.owner.other.spec.ts
+++ b/test/controllers/update/update.review.beneficial.owner.other.spec.ts
@@ -92,7 +92,7 @@ describe(`Update review beneficial owner other`, () => {
 
   describe(`POST tests`, () => {
     test(`redirect to ${UPDATE_BENEFICIAL_OWNER_TYPE_PAGE} page on successful submission`, async () => {
-      mockGetApplicationData.mockReturnValueOnce({
+      mockGetApplicationData.mockReturnValue({
         ...APPLICATION_DATA_UPDATE_BO_MOCK
       });
 

--- a/test/validation/custom.validation.spec.ts
+++ b/test/validation/custom.validation.spec.ts
@@ -11,27 +11,27 @@ import { Session } from '@companieshouse/node-session-handler';
 const public_register_name = MAX_80 + "1";
 const public_register_jurisdiction = MAX_80;
 
-describe('checkFirstDateOnOrAfterSecondDate', () => {
+describe('checkCeasedDateOnOrAfterStartDate', () => {
 
   test('should throw error if ceased date before start date', () => {
     const ceaseDate = ["2", "2", "2023"];
     const startDate = ["3", "3", "2023"];
 
-    expect(() => custom.checkFirstDateOnOrAfterSecondDate(...ceaseDate, ...startDate, ErrorMessages.CEASED_DATE_BEFORE_START_DATE)).toThrowError(ErrorMessages.CEASED_DATE_BEFORE_START_DATE);
+    expect(() => custom.checkCeasedDateOnOrAfterStartDate(...ceaseDate, ...startDate, ErrorMessages.CEASED_DATE_BEFORE_START_DATE)).toThrowError(ErrorMessages.CEASED_DATE_BEFORE_START_DATE);
   });
 
   test('should return true if ceased date after start date', () => {
     const ceaseDate = ["3", "3", "2023"];
     const startDate = ["2", "2", "2023"];
 
-    expect(custom.checkFirstDateOnOrAfterSecondDate(...ceaseDate, ...startDate)).toBe(true);
+    expect(custom.checkCeasedDateOnOrAfterStartDate(...ceaseDate, ...startDate)).toBe(true);
   });
 
   test('should return true if ceased date = start date', () => {
     const ceaseDate = ["3", "3", "2023"];
     const startDate = ["3", "3", "2023"];
 
-    expect(custom.checkFirstDateOnOrAfterSecondDate(...ceaseDate, ...startDate)).toBe(true);
+    expect(custom.checkCeasedDateOnOrAfterStartDate(...ceaseDate, ...startDate)).toBe(true);
   });
 
   test('should throw error if filing date before start date', () => {
@@ -107,8 +107,8 @@ describe('tests for custom Date fields', () => {
     expect(custom.checkMoreThanOneDateFieldIsNotMissing()).toBe(true);
   });
 
-  test('should be true for checkFirstDateOnOrAfterSecondDate default date values', () => {
-    expect(custom.checkFirstDateOnOrAfterSecondDate()).toBe(true);
+  test('should be true for checkCeasedDateOnOrAfterStartDate default date values', () => {
+    expect(custom.checkCeasedDateOnOrAfterStartDate()).toBe(true);
   });
 
   test('should be false for checkDateOfBirthFieldsArePresent default date values', () => {
@@ -141,7 +141,7 @@ describe('tests for custom Date fields', () => {
   });
 });
 
-describe('tests for checkFilingPeriod ', () => {
+describe('tests for checkDatePreviousToFilingDate ', () => {
 
   let mockAppData = {};
   let mockReq = {} as Request;
@@ -171,14 +171,14 @@ describe('tests for checkFilingPeriod ', () => {
   test("should return error if startDate is after filingDate", () => {
     (getApplicationData as jest.Mock).mockReturnValue(mockAppData);
 
-    expect(() => custom.checkFilingPeriod(mockReq, "15", "6", "2023", ErrorMessages.START_DATE_BEFORE_FILING_DATE))
+    expect(() => custom.checkDatePreviousToFilingDate(mockReq, "15", "6", "2023", ErrorMessages.START_DATE_BEFORE_FILING_DATE))
       .toBeTruthy();
   });
 
   test("should return error if startDate is after filingDate", () => {
     (getApplicationData as jest.Mock).mockReturnValue(mockAppData);
 
-    expect(() => custom.checkFilingPeriod(mockReq, "3", "8", "2023", ErrorMessages.START_DATE_BEFORE_FILING_DATE))
+    expect(() => custom.checkDatePreviousToFilingDate(mockReq, "3", "8", "2023", ErrorMessages.START_DATE_BEFORE_FILING_DATE))
       .toThrowError(ErrorMessages.START_DATE_BEFORE_FILING_DATE);
   });
 });

--- a/test/validation/custom.validation.spec.ts
+++ b/test/validation/custom.validation.spec.ts
@@ -34,6 +34,28 @@ describe('checkFirstDateOnOrAfterSecondDate', () => {
     expect(custom.checkFirstDateOnOrAfterSecondDate(...ceaseDate, ...startDate)).toBe(true);
   });
 
+  test('should throw error if filing date before start date', () => {
+    const filingDate = ["2", "2", "2023"];
+    const startDate = ["3", "3", "2023"];
+
+    expect(() => custom.checkFirstDateOnOrAfterSecondDate(...filingDate, ...startDate, ErrorMessages.START_DATE_BEFORE_FILING_DATE))
+      .toThrowError(ErrorMessages.START_DATE_BEFORE_FILING_DATE);
+  });
+
+  test('should return true if filing date = start date', () => {
+    const filingDate = ["3", "3", "2023"];
+    const startDate = ["3", "3", "2023"];
+
+    expect(custom.checkFirstDateOnOrAfterSecondDate(...filingDate, ...startDate)).toBe(true);
+  });
+
+  test('should return true if filing date after start date', () => {
+    const filingDate = ["3", "3", "2023"];
+    const startDate = ["2", "2", "2023"];
+
+    expect(custom.checkFirstDateOnOrAfterSecondDate(...filingDate, ...startDate)).toBe(true);
+  });
+
   test("should test checkFieldIfRadioButtonSelectedAndFieldsEmpty validity", () => {
     const errorMsg = "kaput";
     expect(() => custom.checkFieldIfRadioButtonSelectedAndFieldsEmpty(true, true, true, errorMsg)).toThrowError("Enter their correspondence address");


### PR DESCRIPTION
### JIRA link
Jira [UAR-1108](https://companieshouse.atlassian.net/browse/UAR-1108)

### Change description
Add validations so that start date of BO is before the filing date, as the filing date is not present in the BO page, filing date is retrieved from session.

Renamed checkCeasedDateOnOrAfterStartDate to checkFirstDateOnOrAfterSecondDate as its now used to check for dates other than ceasedDate and startDate


### Work checklist

- [x] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.


[UAR-1108]: https://companieshouse.atlassian.net/browse/UAR-1108?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ