### PR TITLE
ROE-2480 Fix sign-out link for Trust screens

### DIFF
--- a/views/includes/sign-out-user-banner.html
+++ b/views/includes/sign-out-user-banner.html
@@ -2,7 +2,7 @@
   <ul id="navigation">
     <li class="content-email">{{ userEmail }}</li>
     <li>
-      <a href="sign-out?page={{ templateName }}" data-event-id="signout">Sign out</a>
+      <a href="{{ url }}sign-out?page={{ templateName }}" data-event-id="signout">Sign out</a>
     </li>
   </ul>
   <hr class="govuk-section-break govuk-section-break--visible">


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/ROE-2480

### Change description

* This got broken when template was changed to 'tidy up' the code.
* Reverted the part of [this](https://github.com/companieshouse/overseas-entities-web/pull/1117) PR that changed the banner template, since Trust controllers do populate the 'url' page parameter.

### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
