### PR TITLE
ROE-2403 Add id's int url for trust individual page

### DIFF
--- a/src/controllers/trust.involved.controller.ts
+++ b/src/controllers/trust.involved.controller.ts
@@ -5,6 +5,6 @@ export const get = (req: Request, res: Response, next: NextFunction) => {
   getTrustInvolvedPage(req, res, next, false, false);
 };
 
-export const post = (req: Request, res: Response, next: NextFunction) => {
-  postTrustInvolvedPage(req, res, next, false, false);
+export const post = async (req: Request, res: Response, next: NextFunction) => {
+  await postTrustInvolvedPage(req, res, next, false, false);
 };

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -408,6 +408,16 @@ router
   .post(...validator.trustIndividualBeneficialOwner, trustIndividualbeneficialOwner.post);
 
 router
+  .route(config.TRUST_ENTRY_WITH_PARAMS_URL + config.TRUST_ID + config.TRUST_INDIVIDUAL_BENEFICIAL_OWNER_URL + config.TRUSTEE_ID + '?')
+  .all(
+    isFeatureEnabled(config.FEATURE_FLAG_ENABLE_TRUSTS_WEB),
+    authentication,
+    navigation.hasTrustWithIdRegister,
+  )
+  .get(trustIndividualbeneficialOwner.get)
+  .post(...validator.trustIndividualBeneficialOwner, trustIndividualbeneficialOwner.post);
+
+router
   .route(config.TRUST_ENTRY_URL + config.TRUST_ID + config.TRUST_LEGAL_ENTITY_BENEFICIAL_OWNER_URL + config.TRUSTEE_ID + '?')
   .all(
     isFeatureEnabled(config.FEATURE_FLAG_ENABLE_TRUSTS_WEB),

--- a/src/utils/trust.involved.ts
+++ b/src/utils/trust.involved.ts
@@ -17,6 +17,8 @@ import { saveAndContinue } from './save.and.continue';
 import { Session } from '@companieshouse/node-session-handler';
 import { mapIndividualTrusteeFromSessionToPage } from '../utils/trust/individual.trustee.mapper';
 import { mapFormerTrusteeFromSessionToPage } from '../utils/trust/historical.beneficial.owner.mapper';
+import { isActiveFeature } from './feature.flag';
+import { getUrlWithParamsToPath } from './url';
 
 export const TRUST_INVOLVED_TEXTS = {
   title: 'Individuals or entities involved in the trust',
@@ -180,7 +182,7 @@ export const postTrustInvolvedPage = async (
     // the req.params['id'] is already validated in the has.trust.middleware but sonar can not recognise this.
     let url = isUpdate
       ? `${config.UPDATE_TRUSTS_INDIVIDUALS_OR_ENTITIES_INVOLVED_URL}/${req.params[config.ROUTE_PARAM_TRUST_ID]}`
-      : `${config.TRUST_ENTRY_URL}/${req.params[config.ROUTE_PARAM_TRUST_ID]}`;
+      : `${getRegistrationTrustEntryUrl(req)}/${req.params[config.ROUTE_PARAM_TRUST_ID]}`;
 
     switch (typeOfTrustee) {
         case TrusteeType.HISTORICAL:
@@ -195,7 +197,6 @@ export const postTrustInvolvedPage = async (
         default:
           logger.info("TODO: On validation No trustee selected, re-displaying page");
     }
-
     return safeRedirect(res, url);
   } catch (error) {
     logger.errorRequest(req, error);
@@ -249,4 +250,12 @@ const getNextPage = (isUpdate: boolean, isReview: boolean) => {
   } else {
     return `${config.TRUST_ENTRY_URL + config.ADD_TRUST_URL}`;
   }
+};
+
+const getRegistrationTrustEntryUrl = (req: Request) => {
+  let url = `${config.TRUST_ENTRY_URL}`;
+  if (isActiveFeature(config.FEATURE_FLAG_ENABLE_REDIS_REMOVAL)) {
+    url = getUrlWithParamsToPath(config.TRUST_ENTRY_WITH_PARAMS_URL, req);
+  }
+  return url;
 };

--- a/test/controllers/trusts.involved.controller.spec.ts
+++ b/test/controllers/trusts.involved.controller.spec.ts
@@ -10,6 +10,8 @@ jest.mock('../../src/utils/trust/common.trust.data.mapper');
 jest.mock('../../src/utils/trust/who.is.involved.mapper');
 jest.mock('../../src/utils/trust/who.is.involved.mapper');
 jest.mock('../../src/utils/trusts');
+jest.mock('../../src/utils/feature.flag');
+jest.mock('../../src/utils/url');
 
 import { constants } from 'http2';
 import { beforeEach, describe, expect, jest, test } from '@jest/globals';
@@ -23,6 +25,7 @@ import { TRUST_WITH_ID } from '../__mocks__/session.mock';
 import { ANY_MESSAGE_ERROR, PAGE_TITLE_ERROR, TRUST_INVOLVED_TITLE } from '../__mocks__/text.mock';
 import {
   ADD_TRUST_URL,
+  REGISTER_AN_OVERSEAS_ENTITY_URL,
   TRUST_ENTRY_URL,
   TRUST_HISTORICAL_BENEFICIAL_OWNER_URL,
   TRUST_INDIVIDUAL_BENEFICIAL_OWNER_URL,
@@ -39,6 +42,15 @@ import { getApplicationData } from '../../src/utils/application.data';
 import { mapCommonTrustDataToPage } from '../../src/utils/trust/common.trust.data.mapper';
 import { mapTrustWhoIsInvolvedToPage } from '../../src/utils/trust/who.is.involved.mapper';
 import { getFormerTrusteesFromTrust, getIndividualTrusteesFromTrust } from '../../src/utils/trusts';
+import { isActiveFeature } from '../../src/utils/feature.flag';
+import { getUrlWithParamsToPath } from '../../src/utils/url';
+
+const mockIsActiveFeature = isActiveFeature as jest.Mock;
+mockIsActiveFeature.mockReturnValue(false);
+
+const MOCKED_URL = REGISTER_AN_OVERSEAS_ENTITY_URL + "MOCKED_URL";
+const mockGetUrlWithParamsToPath = getUrlWithParamsToPath as jest.Mock;
+mockGetUrlWithParamsToPath.mockReturnValue(MOCKED_URL);
 
 describe('Trust Involved controller', () => {
   const mockGetApplicationData = getApplicationData as jest.Mock;
@@ -281,6 +293,141 @@ describe('Trust Involved controller', () => {
       });
 
       post(mockReq, mockRes, mockNext);
+
+      expect(mockNext).toBeCalledTimes(1);
+      expect(mockNext).toBeCalledWith(error);
+    });
+  });
+
+  describe('POST with url params unit tests', () => {
+    // TODO - get working when trust-involved no more to add button ticket is worked on
+    // test('no more to add button pushed', async () => {
+    //   mockReq.body = {
+    //     noMoreToAdd: 'noMoreToAdd',
+    //   };
+
+    //   mockIsActiveFeature.mockReturnValueOnce(true);
+
+    //   await post(mockReq, mockRes, mockNext);
+
+    //   expect(mockRes.redirect).toBeCalledTimes(1);
+    //   expect(mockRes.redirect).toBeCalledWith(`${TRUST_ENTRY_URL + ADD_TRUST_URL}`);
+    // });
+
+    const dpPostTrustee = [
+      [
+        TrusteeType.HISTORICAL,
+        TRUST_HISTORICAL_BENEFICIAL_OWNER_URL,
+      ],
+      [
+        TrusteeType.INDIVIDUAL,
+        TRUST_INDIVIDUAL_BENEFICIAL_OWNER_URL,
+      ],
+      [
+        TrusteeType.LEGAL_ENTITY,
+        TRUST_LEGAL_ENTITY_BENEFICIAL_OWNER_URL,
+      ],
+      [
+        'unknown',
+        '',
+      ],
+    ];
+
+    test.each(dpPostTrustee)(
+      'success push with %p type',
+      async (typeOfTrustee: string, expectedUrl: string) => {
+        mockReq.body = {
+          typeOfTrustee,
+        };
+
+        (validationResult as any as jest.Mock).mockImplementationOnce(() => ({
+          isEmpty: jest.fn().mockReturnValue(true),
+        }));
+
+        mockIsActiveFeature.mockReturnValueOnce(true); // FEATURE_FLAG_ENABLE_REDIS_REMOVAL
+
+        await post(mockReq, mockRes, mockNext);
+
+        expect(mockRes.redirect).toBeCalledTimes(1);
+        expect(mockRes.redirect).toBeCalledWith(`${MOCKED_URL}/${trustId}${expectedUrl}`);
+      },
+    );
+
+    // TODO - get working when trust-involved validation ticket is worked on
+    // test('render error', async () => {
+    //   const mockValidationErrors = [
+    //     {
+    //       value: undefined,
+    //       msg: 'Select which type of individual or entity you want to add',
+    //       param: 'typeOfTrustee',
+    //       location: 'body',
+    //     }, //  as ValidationError,
+    //   ];
+    //   (validationResult as any as jest.Mock).mockImplementationOnce(() => ({
+    //     isEmpty: jest.fn().mockReturnValue(false),
+    //     array: jest.fn().mockReturnValue(mockValidationErrors),
+    //   }));
+
+    //   mockReq.body = {
+    //     dummyKey: 'dummyValue',
+    //   };
+
+    //   const mockTrustData = {
+    //     trustName: 'dummy',
+    //   };
+    //   (mapCommonTrustDataToPage as any as jest.Mock).mockReturnValue(mockTrustData);
+
+    //   const mockInvolvedData = {
+    //     involvedDummyKey: 'involvedDummyValue',
+    //   };
+    //   (mapTrustWhoIsInvolvedToPage as any as jest.Mock).mockReturnValue(mockInvolvedData);
+
+    //   await post(mockReq, mockRes, mockNext);
+
+    //   expect(mockRes.redirect).not.toBeCalled;
+
+    //   expect(mapCommonTrustDataToPage).toBeCalledTimes(1);
+    //   expect(mapCommonTrustDataToPage).toBeCalledWith(mockAppData, trustId, false);
+
+    //   expect(mapTrustWhoIsInvolvedToPage).toBeCalledTimes(1);
+    //   expect(mapTrustWhoIsInvolvedToPage).toBeCalledWith(mockAppData, trustId, false);
+
+    //   expect(mockRes.render).toBeCalledTimes(1);
+    //   expect(mockRes.render).toBeCalledWith(
+    //     TRUST_INVOLVED_PAGE,
+    //     expect.objectContaining({
+    //       pageData: expect.objectContaining({
+    //         trustData: mockTrustData,
+    //         ...mockInvolvedData,
+    //       }),
+    //       errors: {
+    //         errorList: [
+    //           {
+    //             href: '#typeOfTrustee',
+    //             text: ErrorMessages.TRUST_INVOLVED_INVALID,
+    //           },
+    //         ],
+    //         typeOfTrustee: {
+    //           text: ErrorMessages.TRUST_INVOLVED_INVALID,
+    //         },
+    //       },
+    //       formData: mockReq.body,
+    //     }),
+    //   );
+    // });
+
+    test('catch error when post data from page', async () => {
+      mockReq.body = {
+        id: 'dummyId',
+        typeOfTrustee: 'dummyTrusteeType',
+        noMoreToAdd: 'add',
+      };
+      const error = new Error(ANY_MESSAGE_ERROR);
+      (mockRes.redirect as jest.Mock).mockImplementationOnce(() => {
+        throw error;
+      });
+
+      await post(mockReq, mockRes, mockNext);
 
       expect(mockNext).toBeCalledTimes(1);
       expect(mockNext).toBeCalledWith(error);


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/ROE-2403


### Change description
Add ids into the url for the trust individual benficial owner page (also adds them to the other BO trust pages) 


### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
