### PR TITLE
ROE-2404 Add id's into url for trust legal owner page

### DIFF
--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -441,6 +441,16 @@ router
   .post(...validator.trustLegalEntityBeneficialOwnerValidator, trustLegalEntitybeneficialOwner.post);
 
 router
+  .route(config.TRUST_ENTRY_WITH_PARAMS_URL + config.TRUST_ID + config.TRUST_LEGAL_ENTITY_BENEFICIAL_OWNER_URL + config.TRUSTEE_ID + '?')
+  .all(
+    isFeatureEnabled(config.FEATURE_FLAG_ENABLE_TRUSTS_WEB),
+    authentication,
+    navigation.hasTrustWithIdRegister,
+  )
+  .get(trustLegalEntitybeneficialOwner.get)
+  .post(...validator.trustLegalEntityBeneficialOwnerValidator, trustLegalEntitybeneficialOwner.post);
+
+router
   .route(config.TRUST_ENTRY_URL + config.TRUST_ID + config.TRUST_BENEFICIAL_OWNER_DETACH_URL + config.BO_ID)
   .get((_req, res) => {
     return res.render('#TODO BENEFICIAL OWNER DETACH FROM TRUST PAGE');

--- a/src/utils/trust.legal.entity.bo.ts
+++ b/src/utils/trust.legal.entity.bo.ts
@@ -13,6 +13,8 @@ import { Session } from '@companieshouse/node-session-handler';
 import { saveAndContinue } from './save.and.continue';
 import { FormattedValidationErrors, formatValidationError } from '../middleware/validation.middleware';
 import { validationResult } from 'express-validator';
+import { isActiveFeature } from './feature.flag';
+import { getUrlWithParamsToPath } from './url';
 
 export const LEGAL_ENTITY_BO_TEXTS = {
   title: 'Tell us about the legal entity',
@@ -42,7 +44,7 @@ const getPageProperties = (
 ): TrustLegalEntityBeneificalOwnerPageProperties => {
 
   return {
-    backLinkUrl: getTrustInvolvedUrl(isUpdate, trustId),
+    backLinkUrl: getTrustInvolvedUrl(isUpdate, trustId, req),
     templateName: getPageTemplate(isUpdate),
     pageParams: {
       title: LEGAL_ENTITY_BO_TEXTS.title,
@@ -121,7 +123,7 @@ export const postTrustLegalEntityBo = async (req: Request, res: Response, next: 
 
     await saveAndContinue(req, session, true);
 
-    return safeRedirect(res, getTrustInvolvedUrl(isUpdate, trustId));
+    return safeRedirect(res, getTrustInvolvedUrl(isUpdate, trustId, req));
   } catch (error) {
     logger.errorRequest(req, error);
 
@@ -129,11 +131,17 @@ export const postTrustLegalEntityBo = async (req: Request, res: Response, next: 
   }
 };
 
-const getTrustInvolvedUrl = (isUpdate: boolean, trustId: string) => (
-  isUpdate
-    ? `${config.UPDATE_TRUSTS_INDIVIDUALS_OR_ENTITIES_INVOLVED_URL}/${trustId}${config.TRUST_INVOLVED_URL}`
-    : `${config.TRUST_ENTRY_URL}/${trustId}${config.TRUST_INVOLVED_URL}`
-);
+const getTrustInvolvedUrl = (isUpdate: boolean, trustId: string, req: Request) => {
+  if (isUpdate) {
+    return `${config.UPDATE_TRUSTS_INDIVIDUALS_OR_ENTITIES_INVOLVED_URL}/${trustId}${config.TRUST_INVOLVED_URL}`;
+  } else {
+    let entryUrl = `${config.TRUST_ENTRY_URL}`;
+    if (isActiveFeature(config.FEATURE_FLAG_ENABLE_REDIS_REMOVAL)) {
+      entryUrl = getUrlWithParamsToPath(config.TRUST_ENTRY_WITH_PARAMS_URL, req);
+    }
+    return entryUrl + `/${trustId}${config.TRUST_INVOLVED_URL}`;
+  }
+};
 
 const getPageTemplate = (isUpdate: boolean) => (
   isUpdate

--- a/test/controllers/trust.legal.entity.beneficial.owner.controller.int.spec.ts
+++ b/test/controllers/trust.legal.entity.beneficial.owner.controller.int.spec.ts
@@ -7,10 +7,13 @@ jest.mock('../../src/middleware/is.feature.enabled.middleware', () => ({
   isFeatureEnabled: () => (_, __, next: NextFunction) => next(),
 }));
 jest.mock('../../src/utils/trusts');
+jest.mock('../../src/utils/feature.flag');
+jest.mock('../../src/middleware/service.availability.middleware');
+jest.mock('../../src/utils/url');
 
 import { NextFunction } from "express";
 import app from "../../src/app";
-import { TRUST_ENTRY_URL, TRUST_LEGAL_ENTITY_BENEFICIAL_OWNER_PAGE, TRUST_LEGAL_ENTITY_BENEFICIAL_OWNER_URL } from "../../src/config";
+import { TRUST_ENTRY_URL, TRUST_ENTRY_WITH_PARAMS_URL, TRUST_LEGAL_ENTITY_BENEFICIAL_OWNER_PAGE, TRUST_LEGAL_ENTITY_BENEFICIAL_OWNER_URL, TRUST_INVOLVED_URL } from "../../src/config";
 import { authentication } from "../../src/middleware/authentication.middleware";
 import { hasTrustWithIdRegister } from "../../src/middleware/navigation/has.trust.middleware";
 import { Trust } from "../../src/model/trust.model";
@@ -23,12 +26,24 @@ import { ErrorMessages } from "../../src/validation/error.messages";
 import { TrustLegalEntityForm } from "../../src/model/trust.page.model";
 import { RoleWithinTrustType } from "../../src/model/role.within.trust.type.model";
 
+import { isActiveFeature } from '../../src/utils/feature.flag';
+import { serviceAvailabilityMiddleware } from '../../src/middleware/service.availability.middleware';
+import { getUrlWithParamsToPath } from '../../src/utils/url';
+
+const MOCKED_URL = "MOCKED_URL";
 const mockSaveAndContinue = saveAndContinue as jest.Mock;
+const mockIsActiveFeature = isActiveFeature as jest.Mock;
+const mockGetUrlWithParamsToPath = getUrlWithParamsToPath as jest.Mock;
+mockGetUrlWithParamsToPath.mockImplementation(() => MOCKED_URL);
+
+const mockServiceAvailabilityMiddleware = serviceAvailabilityMiddleware as jest.Mock;
+mockServiceAvailabilityMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => next() );
 
 describe("Legal entity beneficial owner integration tests", () => {
 
   const trustId = TRUST_WITH_ID.trust_id;
   const pageUrl = TRUST_ENTRY_URL + "/" + trustId + TRUST_LEGAL_ENTITY_BENEFICIAL_OWNER_URL;
+  const pageWithParamsUrl = TRUST_ENTRY_WITH_PARAMS_URL + "/" + trustId + TRUST_LEGAL_ENTITY_BENEFICIAL_OWNER_URL;
   let legalEntityWithMissingFields: Partial<TrustLegalEntityForm> & Partial<{is_service_address_same_as_principal_address, is_on_register_in_country_formed_in}>;
 
   beforeEach(() => {
@@ -38,134 +53,278 @@ describe("Legal entity beneficial owner integration tests", () => {
     (hasTrustWithIdRegister as jest.Mock).mockImplementation((_, __, next: NextFunction) => next());
   });
 
-  test(`renders the ${TRUST_LEGAL_ENTITY_BENEFICIAL_OWNER_PAGE} page with missing mandatory field messages`, async () => {
+  describe("POST tests", () => {
 
-    // Arrange
-    const mockTrust = <Trust>{};
-    (getTrustByIdFromApp as jest.Mock).mockReturnValue(mockTrust);
+    test(`renders the ${TRUST_LEGAL_ENTITY_BENEFICIAL_OWNER_PAGE} page with missing mandatory field messages`, async () => {
 
-    // Act
-    const resp = await request(app).post(pageUrl).send(legalEntityWithMissingFields);
-    const decodedHTML = decodeHTML(resp.text);
+      // Arrange
+      const mockTrust = <Trust>{};
+      (getTrustByIdFromApp as jest.Mock).mockReturnValue(mockTrust);
 
-    // Assert
-    expect(resp.status).toEqual(constants.HTTP_STATUS_OK);
-    expect(mockSaveAndContinue).not.toHaveBeenCalled();
-    expect(decodedHTML).toContain(ErrorMessages.LEGAL_ENTITY_BO_NAME);
-    expect(decodedHTML).toContain(ErrorMessages.LEGAL_ENTITY_BO_ROLE);
-    expect(decodedHTML).toContain(ErrorMessages.SELECT_IF_SERVICE_ADDRESS_SAME_AS_USER_RESIDENTIAL_ADDRESS_LEGAL_ENTITY_BO);
-    expect(decodedHTML).toContain(ErrorMessages.LEGAL_FORM_LEGAL_ENTITY_BO);
-    expect(decodedHTML).toContain(ErrorMessages.LAW_GOVERNED);
-    expect(decodedHTML).toContain(ErrorMessages.SELECT_IF_ON_PUBLIC_REGISTER_IN_COUNTRY_FORMED_IN);
-    expect(decodedHTML).toContain(ErrorMessages.PROPERTY_NAME_OR_NUMBER_LEGAL_ENTITY_BO);
-    expect(decodedHTML).toContain(ErrorMessages.ADDRESS_LINE1_LEGAL_ENTITY_BO);
-    expect(decodedHTML).toContain(ErrorMessages.CITY_OR_TOWN_LEGAL_ENTITY_BO);
-    expect(decodedHTML).toContain(ErrorMessages.COUNTRY_LEGAL_ENTITY_BO);
-    expect(decodedHTML).not.toContain(ErrorMessages.PUBLIC_REGISTER_JURISDICTION);
-    expect(decodedHTML).not.toContain(ErrorMessages.ENTITY_REGISTRATION_NUMBER);
-    expect(decodedHTML).not.toContain(ErrorMessages.PUBLIC_REGISTER_NAME);
+      // Act
+      const resp = await request(app).post(pageUrl).send(legalEntityWithMissingFields);
+      const decodedHTML = decodeHTML(resp.text);
+
+      // Assert
+      expect(resp.status).toEqual(constants.HTTP_STATUS_OK);
+      expect(mockSaveAndContinue).not.toHaveBeenCalled();
+      expect(decodedHTML).toContain(ErrorMessages.LEGAL_ENTITY_BO_NAME);
+      expect(decodedHTML).toContain(ErrorMessages.LEGAL_ENTITY_BO_ROLE);
+      expect(decodedHTML).toContain(ErrorMessages.SELECT_IF_SERVICE_ADDRESS_SAME_AS_USER_RESIDENTIAL_ADDRESS_LEGAL_ENTITY_BO);
+      expect(decodedHTML).toContain(ErrorMessages.LEGAL_FORM_LEGAL_ENTITY_BO);
+      expect(decodedHTML).toContain(ErrorMessages.LAW_GOVERNED);
+      expect(decodedHTML).toContain(ErrorMessages.SELECT_IF_ON_PUBLIC_REGISTER_IN_COUNTRY_FORMED_IN);
+      expect(decodedHTML).toContain(ErrorMessages.PROPERTY_NAME_OR_NUMBER_LEGAL_ENTITY_BO);
+      expect(decodedHTML).toContain(ErrorMessages.ADDRESS_LINE1_LEGAL_ENTITY_BO);
+      expect(decodedHTML).toContain(ErrorMessages.CITY_OR_TOWN_LEGAL_ENTITY_BO);
+      expect(decodedHTML).toContain(ErrorMessages.COUNTRY_LEGAL_ENTITY_BO);
+      expect(decodedHTML).not.toContain(ErrorMessages.PUBLIC_REGISTER_JURISDICTION);
+      expect(decodedHTML).not.toContain(ErrorMessages.ENTITY_REGISTRATION_NUMBER);
+      expect(decodedHTML).not.toContain(ErrorMessages.PUBLIC_REGISTER_NAME);
+    });
+
+    test(`renders the ${TRUST_LEGAL_ENTITY_BENEFICIAL_OWNER_PAGE} page with errors for service address field and interested person date fields`, async () => {
+      // Arrange
+      const mockTrust = <Trust>{};
+      (getTrustByIdFromApp as jest.Mock).mockReturnValue(mockTrust);
+      legalEntityWithMissingFields.legalEntityName = 'The Sherlock Holmes Museum';
+      legalEntityWithMissingFields.roleWithinTrust = RoleWithinTrustType.INTERESTED_PERSON;
+      legalEntityWithMissingFields.is_service_address_same_as_principal_address = '0';
+      legalEntityWithMissingFields.principal_address_property_name_number = '221B';
+      legalEntityWithMissingFields.principal_address_line_1 = 'Baker Street';
+      legalEntityWithMissingFields.principal_address_town = 'London';
+      legalEntityWithMissingFields.principal_address_country = 'United Kingdom';
+      legalEntityWithMissingFields.legalForm = 'Private Limited Company (Ltd)';
+      legalEntityWithMissingFields.governingLaw = 'Legal Ownership Act';
+      legalEntityWithMissingFields.is_on_register_in_country_formed_in = '1';
+      legalEntityWithMissingFields.registration_number = "007";
+      legalEntityWithMissingFields.public_register_name = "Alpha and Omega, the beginning and the end";
+      legalEntityWithMissingFields.public_register_jurisdiction = "Wakanda";
+
+      // Act
+      const resp = await request(app).post(pageUrl).send(legalEntityWithMissingFields);
+      const decodedHTML = decodeHTML(resp.text);
+
+      // Assert
+      expect(resp.status).toEqual(constants.HTTP_STATUS_OK);
+      expect(mockSaveAndContinue).not.toHaveBeenCalled();
+      expect(decodedHTML).not.toContain(ErrorMessages.LEGAL_ENTITY_BO_NAME);
+      expect(decodedHTML).not.toContain(ErrorMessages.LEGAL_ENTITY_BO_ROLE);
+      expect(decodedHTML).not.toContain(ErrorMessages.LEGAL_FORM_LEGAL_ENTITY_BO);
+      expect(decodedHTML).not.toContain(ErrorMessages.LAW_GOVERNED);
+      expect(decodedHTML).not.toContain(ErrorMessages.SELECT_IF_ON_PUBLIC_REGISTER_IN_COUNTRY_FORMED_IN);
+      expect(decodedHTML).not.toContain(ErrorMessages.SELECT_IF_SERVICE_ADDRESS_SAME_AS_USER_RESIDENTIAL_ADDRESS_LEGAL_ENTITY_BO);
+      expect(decodedHTML).not.toContain(ErrorMessages.ENTITY_REGISTRATION_NUMBER);
+      expect(decodedHTML).not.toContain(ErrorMessages.PUBLIC_REGISTER_NAME);
+      expect(decodedHTML).not.toContain(ErrorMessages.PUBLIC_REGISTER_JURISDICTION);
+
+      // Service Address Errors
+      expect(decodedHTML).toContain(ErrorMessages.PROPERTY_NAME_OR_NUMBER_LEGAL_ENTITY_BO);
+      expect(decodedHTML).toContain(ErrorMessages.ADDRESS_LINE1_LEGAL_ENTITY_BO);
+      expect(decodedHTML).toContain(ErrorMessages.CITY_OR_TOWN_LEGAL_ENTITY_BO);
+      expect(decodedHTML).toContain(ErrorMessages.COUNTRY_LEGAL_ENTITY_BO);
+
+      // Date Interested Person Errors
+      expect(decodedHTML).toContain(ErrorMessages.ENTER_DATE_INTERESTED_PERSON_LEGAL_ENTITY_BO);
+    });
+
+    test(`renders the ${TRUST_LEGAL_ENTITY_BENEFICIAL_OWNER_PAGE} page with errors if public register name and public register jurisdiction add up to over 160`, async () => {
+      // Arrange
+      const mockTrust = <Trust>{};
+      (getTrustByIdFromApp as jest.Mock).mockReturnValue(mockTrust);
+      legalEntityWithMissingFields.is_on_register_in_country_formed_in = '1';
+      legalEntityWithMissingFields.public_register_name = "o1U2bHyHD4D7NqERnvhfq8Edd0FEJkretjmoYvNjEZxPs7BDvG4n5udaMaAzcTJhSkby1qWtt6c30A5yXwfVsXe0tEPNae4OF19x";
+      legalEntityWithMissingFields.public_register_jurisdiction = "o1U2bHyHD4D7NqERnvhfq8Edd0FEJkretjmoYvNjEZxPs7BDvG4n5udaMaAzcTJhSkby1qWtt6c30A5yXwfVsXe0tEPNae4OF19x";
+
+      // Act
+      const resp = await request(app).post(pageUrl).send(legalEntityWithMissingFields);
+      const decodedHTML = decodeHTML(resp.text);
+
+      // Assert
+      expect(resp.status).toEqual(constants.HTTP_STATUS_OK);
+      expect(mockSaveAndContinue).not.toHaveBeenCalled();
+      expect(decodedHTML).toContain(ErrorMessages.NAME_REGISTRATION_JURISDICTION_LEGAL_ENTITY_BO);
+    });
+
+    test(`renders the ${TRUST_LEGAL_ENTITY_BENEFICIAL_OWNER_PAGE} page without errors if public register name and public register jurisdiction add up to less than 160`, async () => {
+      // Arrange
+      const mockTrust = <Trust>{};
+      (getTrustByIdFromApp as jest.Mock).mockReturnValue(mockTrust);
+      legalEntityWithMissingFields.is_on_register_in_country_formed_in = '1';
+      legalEntityWithMissingFields.public_register_name = "Deliverer";
+      legalEntityWithMissingFields.public_register_jurisdiction = "Alpha and Omega, the beginning and the end";
+
+      // Act
+      const resp = await request(app).post(pageUrl).send(legalEntityWithMissingFields);
+      const decodedHTML = decodeHTML(resp.text);
+
+      // Assert
+      expect(resp.status).toEqual(constants.HTTP_STATUS_OK);
+      expect(mockSaveAndContinue).not.toHaveBeenCalled();
+      expect(decodedHTML).not.toContain(ErrorMessages.NAME_REGISTRATION_JURISDICTION_LEGAL_ENTITY_BO);
+    });
+
+    test(`renders the ${TRUST_LEGAL_ENTITY_BENEFICIAL_OWNER_PAGE} page without errors interested person date`, async () => {
+      // Arrange
+      const mockTrust = <Trust>{};
+      (getTrustByIdFromApp as jest.Mock).mockReturnValue(mockTrust);
+      legalEntityWithMissingFields.roleWithinTrust = RoleWithinTrustType.INTERESTED_PERSON;
+      legalEntityWithMissingFields.interestedPersonStartDateDay = "02";
+      legalEntityWithMissingFields.interestedPersonStartDateMonth = "08";
+      legalEntityWithMissingFields.interestedPersonStartDateYear = "2012";
+
+      // Act
+      const resp = await request(app).post(pageUrl).send(legalEntityWithMissingFields);
+      const decodedHTML = decodeHTML(resp.text);
+
+      // Assert
+      expect(resp.status).toEqual(constants.HTTP_STATUS_OK);
+      expect(mockSaveAndContinue).not.toHaveBeenCalled();
+      expect(decodedHTML).not.toContain(ErrorMessages.ENTER_DATE_INTERESTED_PERSON_LEGAL_ENTITY_BO);
+      expect(decodedHTML).not.toContain(ErrorMessages.INVALID_DATE);
+      expect(decodedHTML).not.toContain(ErrorMessages.DATE_NOT_IN_THE_PAST_INTERESTED_PERSON);
+    });
   });
 
-  test(`renders the ${TRUST_LEGAL_ENTITY_BENEFICIAL_OWNER_PAGE} page with errors for service address field and interested person date fields`, async () => {
-    // Arrange
-    const mockTrust = <Trust>{};
-    (getTrustByIdFromApp as jest.Mock).mockReturnValue(mockTrust);
-    legalEntityWithMissingFields.legalEntityName = 'The Sherlock Holmes Museum';
-    legalEntityWithMissingFields.roleWithinTrust = RoleWithinTrustType.INTERESTED_PERSON;
-    legalEntityWithMissingFields.is_service_address_same_as_principal_address = '0';
-    legalEntityWithMissingFields.principal_address_property_name_number = '221B';
-    legalEntityWithMissingFields.principal_address_line_1 = 'Baker Street';
-    legalEntityWithMissingFields.principal_address_town = 'London';
-    legalEntityWithMissingFields.principal_address_country = 'United Kingdom';
-    legalEntityWithMissingFields.legalForm = 'Private Limited Company (Ltd)';
-    legalEntityWithMissingFields.governingLaw = 'Legal Ownership Act';
-    legalEntityWithMissingFields.is_on_register_in_country_formed_in = '1';
-    legalEntityWithMissingFields.registration_number = "007";
-    legalEntityWithMissingFields.public_register_name = "Alpha and Omega, the beginning and the end";
-    legalEntityWithMissingFields.public_register_jurisdiction = "Wakanda";
+  describe("POST with params url tests", () => {
 
-    // Act
-    const resp = await request(app).post(pageUrl).send(legalEntityWithMissingFields);
-    const decodedHTML = decodeHTML(resp.text);
+    test(`renders the ${TRUST_LEGAL_ENTITY_BENEFICIAL_OWNER_PAGE} page with missing mandatory field messages`, async () => {
+      mockIsActiveFeature.mockReturnValueOnce(true); // FEATURE_FLAG_ENABLE_REDIS_REMOVAL
 
-    // Assert
-    expect(resp.status).toEqual(constants.HTTP_STATUS_OK);
-    expect(mockSaveAndContinue).not.toHaveBeenCalled();
-    expect(decodedHTML).not.toContain(ErrorMessages.LEGAL_ENTITY_BO_NAME);
-    expect(decodedHTML).not.toContain(ErrorMessages.LEGAL_ENTITY_BO_ROLE);
-    expect(decodedHTML).not.toContain(ErrorMessages.LEGAL_FORM_LEGAL_ENTITY_BO);
-    expect(decodedHTML).not.toContain(ErrorMessages.LAW_GOVERNED);
-    expect(decodedHTML).not.toContain(ErrorMessages.SELECT_IF_ON_PUBLIC_REGISTER_IN_COUNTRY_FORMED_IN);
-    expect(decodedHTML).not.toContain(ErrorMessages.SELECT_IF_SERVICE_ADDRESS_SAME_AS_USER_RESIDENTIAL_ADDRESS_LEGAL_ENTITY_BO);
-    expect(decodedHTML).not.toContain(ErrorMessages.ENTITY_REGISTRATION_NUMBER);
-    expect(decodedHTML).not.toContain(ErrorMessages.PUBLIC_REGISTER_NAME);
-    expect(decodedHTML).not.toContain(ErrorMessages.PUBLIC_REGISTER_JURISDICTION);
+      // Arrange
+      const mockTrust = <Trust>{};
+      (getTrustByIdFromApp as jest.Mock).mockReturnValue(mockTrust);
 
-    // Service Address Errors
-    expect(decodedHTML).toContain(ErrorMessages.PROPERTY_NAME_OR_NUMBER_LEGAL_ENTITY_BO);
-    expect(decodedHTML).toContain(ErrorMessages.ADDRESS_LINE1_LEGAL_ENTITY_BO);
-    expect(decodedHTML).toContain(ErrorMessages.CITY_OR_TOWN_LEGAL_ENTITY_BO);
-    expect(decodedHTML).toContain(ErrorMessages.COUNTRY_LEGAL_ENTITY_BO);
+      // Act
+      const resp = await request(app).post(pageWithParamsUrl).send(legalEntityWithMissingFields);
+      const decodedHTML = decodeHTML(resp.text);
 
-    // Date Interested Person Errors
-    expect(decodedHTML).toContain(ErrorMessages.ENTER_DATE_INTERESTED_PERSON_LEGAL_ENTITY_BO);
-  });
+      // Assert
+      expect(resp.status).toEqual(constants.HTTP_STATUS_OK);
+      expect(mockSaveAndContinue).not.toHaveBeenCalled();
+      expect(mockGetUrlWithParamsToPath).toHaveBeenCalledTimes(1);
+      expect(mockGetUrlWithParamsToPath.mock.calls[0][0]).toEqual(TRUST_ENTRY_WITH_PARAMS_URL);
+      expect(resp.text).toContain(MOCKED_URL + `/${trustId}${TRUST_INVOLVED_URL}`); // back link
+      expect(decodedHTML).toContain(ErrorMessages.LEGAL_ENTITY_BO_NAME);
+      expect(decodedHTML).toContain(ErrorMessages.LEGAL_ENTITY_BO_ROLE);
+      expect(decodedHTML).toContain(ErrorMessages.SELECT_IF_SERVICE_ADDRESS_SAME_AS_USER_RESIDENTIAL_ADDRESS_LEGAL_ENTITY_BO);
+      expect(decodedHTML).toContain(ErrorMessages.LEGAL_FORM_LEGAL_ENTITY_BO);
+      expect(decodedHTML).toContain(ErrorMessages.LAW_GOVERNED);
+      expect(decodedHTML).toContain(ErrorMessages.SELECT_IF_ON_PUBLIC_REGISTER_IN_COUNTRY_FORMED_IN);
+      expect(decodedHTML).toContain(ErrorMessages.PROPERTY_NAME_OR_NUMBER_LEGAL_ENTITY_BO);
+      expect(decodedHTML).toContain(ErrorMessages.ADDRESS_LINE1_LEGAL_ENTITY_BO);
+      expect(decodedHTML).toContain(ErrorMessages.CITY_OR_TOWN_LEGAL_ENTITY_BO);
+      expect(decodedHTML).toContain(ErrorMessages.COUNTRY_LEGAL_ENTITY_BO);
+      expect(decodedHTML).not.toContain(ErrorMessages.PUBLIC_REGISTER_JURISDICTION);
+      expect(decodedHTML).not.toContain(ErrorMessages.ENTITY_REGISTRATION_NUMBER);
+      expect(decodedHTML).not.toContain(ErrorMessages.PUBLIC_REGISTER_NAME);
+    });
 
-  test(`renders the ${TRUST_LEGAL_ENTITY_BENEFICIAL_OWNER_PAGE} page with errors if public register name and public register jurisdiction add up to over 160`, async () => {
-    // Arrange
-    const mockTrust = <Trust>{};
-    (getTrustByIdFromApp as jest.Mock).mockReturnValue(mockTrust);
-    legalEntityWithMissingFields.is_on_register_in_country_formed_in = '1';
-    legalEntityWithMissingFields.public_register_name = "o1U2bHyHD4D7NqERnvhfq8Edd0FEJkretjmoYvNjEZxPs7BDvG4n5udaMaAzcTJhSkby1qWtt6c30A5yXwfVsXe0tEPNae4OF19x";
-    legalEntityWithMissingFields.public_register_jurisdiction = "o1U2bHyHD4D7NqERnvhfq8Edd0FEJkretjmoYvNjEZxPs7BDvG4n5udaMaAzcTJhSkby1qWtt6c30A5yXwfVsXe0tEPNae4OF19x";
+    test(`renders the ${TRUST_LEGAL_ENTITY_BENEFICIAL_OWNER_PAGE} page with errors for service address field and interested person date fields`, async () => {
+      // Arrange
+      const mockTrust = <Trust>{};
+      (getTrustByIdFromApp as jest.Mock).mockReturnValue(mockTrust);
+      legalEntityWithMissingFields.legalEntityName = 'The Sherlock Holmes Museum';
+      legalEntityWithMissingFields.roleWithinTrust = RoleWithinTrustType.INTERESTED_PERSON;
+      legalEntityWithMissingFields.is_service_address_same_as_principal_address = '0';
+      legalEntityWithMissingFields.principal_address_property_name_number = '221B';
+      legalEntityWithMissingFields.principal_address_line_1 = 'Baker Street';
+      legalEntityWithMissingFields.principal_address_town = 'London';
+      legalEntityWithMissingFields.principal_address_country = 'United Kingdom';
+      legalEntityWithMissingFields.legalForm = 'Private Limited Company (Ltd)';
+      legalEntityWithMissingFields.governingLaw = 'Legal Ownership Act';
+      legalEntityWithMissingFields.is_on_register_in_country_formed_in = '1';
+      legalEntityWithMissingFields.registration_number = "007";
+      legalEntityWithMissingFields.public_register_name = "Alpha and Omega, the beginning and the end";
+      legalEntityWithMissingFields.public_register_jurisdiction = "Wakanda";
 
-    // Act
-    const resp = await request(app).post(pageUrl).send(legalEntityWithMissingFields);
-    const decodedHTML = decodeHTML(resp.text);
+      // Act
+      const resp = await request(app).post(pageWithParamsUrl).send(legalEntityWithMissingFields);
+      const decodedHTML = decodeHTML(resp.text);
 
-    // Assert
-    expect(resp.status).toEqual(constants.HTTP_STATUS_OK);
-    expect(mockSaveAndContinue).not.toHaveBeenCalled();
-    expect(decodedHTML).toContain(ErrorMessages.NAME_REGISTRATION_JURISDICTION_LEGAL_ENTITY_BO);
-  });
+      // Assert
+      expect(resp.status).toEqual(constants.HTTP_STATUS_OK);
+      expect(mockSaveAndContinue).not.toHaveBeenCalled();
+      expect(decodedHTML).not.toContain(ErrorMessages.LEGAL_ENTITY_BO_NAME);
+      expect(decodedHTML).not.toContain(ErrorMessages.LEGAL_ENTITY_BO_ROLE);
+      expect(decodedHTML).not.toContain(ErrorMessages.LEGAL_FORM_LEGAL_ENTITY_BO);
+      expect(decodedHTML).not.toContain(ErrorMessages.LAW_GOVERNED);
+      expect(decodedHTML).not.toContain(ErrorMessages.SELECT_IF_ON_PUBLIC_REGISTER_IN_COUNTRY_FORMED_IN);
+      expect(decodedHTML).not.toContain(ErrorMessages.SELECT_IF_SERVICE_ADDRESS_SAME_AS_USER_RESIDENTIAL_ADDRESS_LEGAL_ENTITY_BO);
+      expect(decodedHTML).not.toContain(ErrorMessages.ENTITY_REGISTRATION_NUMBER);
+      expect(decodedHTML).not.toContain(ErrorMessages.PUBLIC_REGISTER_NAME);
+      expect(decodedHTML).not.toContain(ErrorMessages.PUBLIC_REGISTER_JURISDICTION);
 
-  test(`renders the ${TRUST_LEGAL_ENTITY_BENEFICIAL_OWNER_PAGE} page without errors if public register name and public register jurisdiction add up to less than 160`, async () => {
-    // Arrange
-    const mockTrust = <Trust>{};
-    (getTrustByIdFromApp as jest.Mock).mockReturnValue(mockTrust);
-    legalEntityWithMissingFields.is_on_register_in_country_formed_in = '1';
-    legalEntityWithMissingFields.public_register_name = "Deliverer";
-    legalEntityWithMissingFields.public_register_jurisdiction = "Alpha and Omega, the beginning and the end";
+      // Service Address Errors
+      expect(decodedHTML).toContain(ErrorMessages.PROPERTY_NAME_OR_NUMBER_LEGAL_ENTITY_BO);
+      expect(decodedHTML).toContain(ErrorMessages.ADDRESS_LINE1_LEGAL_ENTITY_BO);
+      expect(decodedHTML).toContain(ErrorMessages.CITY_OR_TOWN_LEGAL_ENTITY_BO);
+      expect(decodedHTML).toContain(ErrorMessages.COUNTRY_LEGAL_ENTITY_BO);
 
-    // Act
-    const resp = await request(app).post(pageUrl).send(legalEntityWithMissingFields);
-    const decodedHTML = decodeHTML(resp.text);
+      // Date Interested Person Errors
+      expect(decodedHTML).toContain(ErrorMessages.ENTER_DATE_INTERESTED_PERSON_LEGAL_ENTITY_BO);
+    });
 
-    // Assert
-    expect(resp.status).toEqual(constants.HTTP_STATUS_OK);
-    expect(mockSaveAndContinue).not.toHaveBeenCalled();
-    expect(decodedHTML).not.toContain(ErrorMessages.NAME_REGISTRATION_JURISDICTION_LEGAL_ENTITY_BO);
-  });
+    test(`renders the ${TRUST_LEGAL_ENTITY_BENEFICIAL_OWNER_PAGE} page with errors if public register name and public register jurisdiction add up to over 160`, async () => {
+      // Arrange
+      mockIsActiveFeature.mockReturnValueOnce(true); // FEATURE_FLAG_ENABLE_REDIS_REMOVAL
 
-  test(`renders the ${TRUST_LEGAL_ENTITY_BENEFICIAL_OWNER_PAGE} page without errors interested person date`, async () => {
-    // Arrange
-    const mockTrust = <Trust>{};
-    (getTrustByIdFromApp as jest.Mock).mockReturnValue(mockTrust);
-    legalEntityWithMissingFields.roleWithinTrust = RoleWithinTrustType.INTERESTED_PERSON;
-    legalEntityWithMissingFields.interestedPersonStartDateDay = "02";
-    legalEntityWithMissingFields.interestedPersonStartDateMonth = "08";
-    legalEntityWithMissingFields.interestedPersonStartDateYear = "2012";
+      const mockTrust = <Trust>{};
+      (getTrustByIdFromApp as jest.Mock).mockReturnValue(mockTrust);
+      legalEntityWithMissingFields.is_on_register_in_country_formed_in = '1';
+      legalEntityWithMissingFields.public_register_name = "o1U2bHyHD4D7NqERnvhfq8Edd0FEJkretjmoYvNjEZxPs7BDvG4n5udaMaAzcTJhSkby1qWtt6c30A5yXwfVsXe0tEPNae4OF19x";
+      legalEntityWithMissingFields.public_register_jurisdiction = "o1U2bHyHD4D7NqERnvhfq8Edd0FEJkretjmoYvNjEZxPs7BDvG4n5udaMaAzcTJhSkby1qWtt6c30A5yXwfVsXe0tEPNae4OF19x";
 
-    // Act
-    const resp = await request(app).post(pageUrl).send(legalEntityWithMissingFields);
-    const decodedHTML = decodeHTML(resp.text);
+      // Act
+      const resp = await request(app).post(pageWithParamsUrl).send(legalEntityWithMissingFields);
+      const decodedHTML = decodeHTML(resp.text);
 
-    // Assert
-    expect(resp.status).toEqual(constants.HTTP_STATUS_OK);
-    expect(mockSaveAndContinue).not.toHaveBeenCalled();
-    expect(decodedHTML).not.toContain(ErrorMessages.ENTER_DATE_INTERESTED_PERSON_LEGAL_ENTITY_BO);
-    expect(decodedHTML).not.toContain(ErrorMessages.INVALID_DATE);
-    expect(decodedHTML).not.toContain(ErrorMessages.DATE_NOT_IN_THE_PAST_INTERESTED_PERSON);
+      // Assert
+      expect(resp.status).toEqual(constants.HTTP_STATUS_OK);
+      expect(mockSaveAndContinue).not.toHaveBeenCalled();
+      expect(mockGetUrlWithParamsToPath).toHaveBeenCalledTimes(1);
+      expect(mockGetUrlWithParamsToPath.mock.calls[0][0]).toEqual(TRUST_ENTRY_WITH_PARAMS_URL);
+      expect(decodedHTML).toContain(ErrorMessages.NAME_REGISTRATION_JURISDICTION_LEGAL_ENTITY_BO);
+    });
+
+    test(`renders the ${TRUST_LEGAL_ENTITY_BENEFICIAL_OWNER_PAGE} page without errors if public register name and public register jurisdiction add up to less than 160`, async () => {
+      // Arrange
+      const mockTrust = <Trust>{};
+      (getTrustByIdFromApp as jest.Mock).mockReturnValue(mockTrust);
+      legalEntityWithMissingFields.is_on_register_in_country_formed_in = '1';
+      legalEntityWithMissingFields.public_register_name = "Deliverer";
+      legalEntityWithMissingFields.public_register_jurisdiction = "Alpha and Omega, the beginning and the end";
+
+      // Act
+      const resp = await request(app).post(pageWithParamsUrl).send(legalEntityWithMissingFields);
+      const decodedHTML = decodeHTML(resp.text);
+
+      // Assert
+      expect(resp.status).toEqual(constants.HTTP_STATUS_OK);
+      expect(mockSaveAndContinue).not.toHaveBeenCalled();
+      expect(decodedHTML).not.toContain(ErrorMessages.NAME_REGISTRATION_JURISDICTION_LEGAL_ENTITY_BO);
+    });
+
+    test(`renders the ${TRUST_LEGAL_ENTITY_BENEFICIAL_OWNER_PAGE} page without errors interested person date`, async () => {
+      // Arrange
+      const mockTrust = <Trust>{};
+      (getTrustByIdFromApp as jest.Mock).mockReturnValue(mockTrust);
+      legalEntityWithMissingFields.roleWithinTrust = RoleWithinTrustType.INTERESTED_PERSON;
+      legalEntityWithMissingFields.interestedPersonStartDateDay = "02";
+      legalEntityWithMissingFields.interestedPersonStartDateMonth = "08";
+      legalEntityWithMissingFields.interestedPersonStartDateYear = "2012";
+
+      // Act
+      const resp = await request(app).post(pageWithParamsUrl).send(legalEntityWithMissingFields);
+      const decodedHTML = decodeHTML(resp.text);
+
+      // Assert
+      expect(resp.status).toEqual(constants.HTTP_STATUS_OK);
+      expect(mockSaveAndContinue).not.toHaveBeenCalled();
+      expect(decodedHTML).not.toContain(ErrorMessages.ENTER_DATE_INTERESTED_PERSON_LEGAL_ENTITY_BO);
+      expect(decodedHTML).not.toContain(ErrorMessages.INVALID_DATE);
+      expect(decodedHTML).not.toContain(ErrorMessages.DATE_NOT_IN_THE_PAST_INTERESTED_PERSON);
+    });
   });
 });
 


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/ROE-2404

### Change description

* Navigation to legal entity trust screen now works, with ids present
* Page validation also, with redisplayed page URL correct
* Tests added and amended

### Work checklist

- [X] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
