### PR TITLE
[UAR-747/UAR-1101] update mapTrustLink to search BOs in review model

### DIFF
--- a/test/utils/update/trust.model.fetch.spec.ts
+++ b/test/utils/update/trust.model.fetch.spec.ts
@@ -46,7 +46,7 @@ describe("Test fetching and mapping of Trust data", () => {
     jest.clearAllMocks();
   });
 
-  test("should fetch and map trust data data", async () => {
+  test("should fetch and map trust data", async () => {
     const appData = FETCH_TRUST_APPLICATION_DATA_MOCK;
 
     mockGetTrustData.mockResolvedValue(FETCH_TRUST_DATA_MOCK);
@@ -332,6 +332,38 @@ describe("Test fetching and mapping of Trust data", () => {
     expect(appData.beneficial_owners_corporate).toEqual(undefined);
   });
 
+  test("should fetch and map trust links for indivdual BO still in review", async () => {
+    const appData: ApplicationData = {
+      overseas_entity_id: '1',
+      transaction_id: '1',
+      entity_number: '1'
+    };
+    appData.update = {
+      trust_data_fetched: false
+    };
+    appData.update.review_beneficial_owners_individual = [{
+      id: "bo1",
+      ch_reference: "bolink1"
+    }];
+
+    mockGetTrustData.mockResolvedValue([{
+      hashedTrustId: "1234",
+      trustName: "Test Trust",
+      creationDate: "2020-01-01",
+      unableToObtainAllTrustInfoIndicator: false
+    }]);
+    mockGetIndividualTrustees.mockResolvedValue([]);
+    mockGetCorporateTrustees.mockResolvedValue([]);
+    mockGetTrustLinks.mockResolvedValue([{
+      hashedTrustId: '1234',
+      hashedCorporateBodyAppointmentId: "bolink1"
+    }]);
+
+    await retrieveTrustData(req, appData);
+
+    expect(appData.update.review_beneficial_owners_individual[0].trust_ids).toEqual(["1"]);
+  });
+
   test("should fetch and map trust links for corporate BOs", async () => {
     const appData: ApplicationData = { ...FETCH_TRUST_APPLICATION_DATA_MOCK, update: { trust_data_fetched: false } };
     mockGetTrustData.mockResolvedValue(FETCH_TRUST_DATA_MOCK);
@@ -353,6 +385,38 @@ describe("Test fetching and mapping of Trust data", () => {
     expect(appData.beneficial_owners_corporate[1].trust_ids).toEqual(undefined);
     expect(appData.beneficial_owners_corporate[2].trust_ids).toEqual(["2"]);
     expect(appData.beneficial_owners_individual).toEqual(undefined);
+  });
+
+  test("should fetch and map trust links for corporate BO still in review", async () => {
+    const appData: ApplicationData = {
+      overseas_entity_id: '1',
+      transaction_id: '1',
+      entity_number: '1'
+    };
+    appData.update = {
+      trust_data_fetched: false
+    };
+    appData.update.review_beneficial_owners_corporate = [{
+      id: "bo1",
+      ch_reference: "bolink1"
+    }];
+
+    mockGetTrustData.mockResolvedValue([{
+      hashedTrustId: "1234",
+      trustName: "Test Trust",
+      creationDate: "2020-01-01",
+      unableToObtainAllTrustInfoIndicator: false
+    }]);
+    mockGetIndividualTrustees.mockResolvedValue([]);
+    mockGetCorporateTrustees.mockResolvedValue([]);
+    mockGetTrustLinks.mockResolvedValue([{
+      hashedTrustId: '1234',
+      hashedCorporateBodyAppointmentId: "bolink1"
+    }]);
+
+    await retrieveTrustData(req, appData);
+
+    expect(appData.update.review_beneficial_owners_corporate[0].trust_ids).toEqual(["1"]);
   });
 
   test("should fetch and not map trust links in without matching beneficial owners", async () => {
@@ -430,7 +494,7 @@ describe("Test fetching and mapping of Trust data", () => {
     expect(appData.beneficial_owners_corporate[0].trust_ids).toEqual([]);
   });
 
-  test("should fetch and not map trust links in without any tusts", async () => {
+  test("should fetch and not map trust links in without any trusts", async () => {
     const appData: ApplicationData = { ...FETCH_TRUST_APPLICATION_DATA_MOCK, update: { trust_data_fetched: false } };
     mockGetTrustData.mockResolvedValue([]);
     mockGetTrustLinks.mockResolvedValueOnce([


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/UAR-747
https://companieshouse.atlassian.net/browse/UAR-1101


### Change description
In a "No Change" scenario, any BOs will remain in the appData.update.review.... part of the model. `mapTrustLink` does not search for BOs linked to a trust in this part of the model, which resulted in the "beneficial owners involved in the trust" section of the "no change check your answers" page being blank.

Before:
<img width="303" alt="MicrosoftTeams-image (1)" src="https://github.com/companieshouse/overseas-entities-web/assets/117734784/3e6dd268-0176-45e4-b758-5d1f064443ac">

After:

<img width="303" alt="Screenshot 2023-10-31 at 16 29 06" src="https://github.com/companieshouse/overseas-entities-web/assets/117734784/cec286cb-1ff0-4d9e-982a-cca97604176c">


### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
