### PR TITLE
Roe 2497 fix trust change link redis removal

### DIFF
--- a/test/controllers/add.trust.controller.spec.ts
+++ b/test/controllers/add.trust.controller.spec.ts
@@ -87,6 +87,16 @@ describe("Add Trust Controller Tests", () => {
           }),
         }),
       );
+      // check REDIS Removal flags not included
+      expect(mockRes.render).toBeCalledWith(
+        config.ADD_TRUST_PAGE,
+        expect.objectContaining({
+          pageData: expect.not.objectContaining({
+            FEATURE_FLAG_ENABLE_REDIS_REMOVAL: true,
+            activeSubmissionBasePath: MOCKED_URL
+          }),
+        }),
+      );
     });
 
     test('catch error when renders the page', () => {

--- a/views/includes/page-templates/add-trust.html
+++ b/views/includes/page-templates/add-trust.html
@@ -42,7 +42,6 @@
         {% set changeLink = OE_CONFIGS.UPDATE_TRUSTS_TELL_US_ABOUT_IT_PAGE %}
       {% else %}
         {% if FEATURE_FLAG_ENABLE_REDIS_REMOVAL %}
-            <b> *********** FLAG ON</b>
           {% set changeLink = OE_CONFIGS.REGISTER_AN_OVERSEAS_ENTITY_URL + activeSubmissionBasePath + OE_CONFIGS.TRUSTS_URL %}
         {% else %}
           {% set changeLink = OE_CONFIGS.TRUST_DETAILS_URL %}

--- a/views/includes/page-templates/add-trust.html
+++ b/views/includes/page-templates/add-trust.html
@@ -41,7 +41,8 @@
       {% if isUpdate %}
         {% set changeLink = OE_CONFIGS.UPDATE_TRUSTS_TELL_US_ABOUT_IT_PAGE %}
       {% else %}
-        {% if OE_CONFIGS.FEATURE_FLAG_ENABLE_REDIS_REMOVAL %}
+        {% if FEATURE_FLAG_ENABLE_REDIS_REMOVAL %}
+            <b> *********** FLAG ON</b>
           {% set changeLink = OE_CONFIGS.REGISTER_AN_OVERSEAS_ENTITY_URL + activeSubmissionBasePath + OE_CONFIGS.TRUSTS_URL %}
         {% else %}
           {% set changeLink = OE_CONFIGS.TRUST_DETAILS_URL %}


### PR DESCRIPTION
…lag is always on

### JIRA link
https://companieshouse.atlassian.net/browse/ROE-2497


### Change description

fix bug on add-trust change link where template thinks feature flag is always on and breaks the change link when flag is off.
The template was referencing OE_CONFIGS.FEATURE_FLAG_ENABLE_REDIS_REMOVAL which is a function, so when template evaluated it as a boolean, it was always true as the const is assigned to a function, it wasn't actually executing the function to get the real flag value, just evaluating the constant pointing at the function.

### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
