### PR TITLE
UAR-1161 Fix remove journey validation

### DIFF
--- a/src/middleware/validation.middleware.ts
+++ b/src/middleware/validation.middleware.ts
@@ -58,6 +58,7 @@ export function checkValidations(req: Request, res: Response, next: NextFunction
       }
       const entityNumber = appData?.[EntityNumberKey];
 
+      // The journey property may already be part of the page form data/body so get it from there and override it if we are on a remove journey
       // Then when we pass it back into the template, make sure it is below/after the req.body fields so it overrides the req.body value
       let journey = req.body["journey"];
       if (isRemoveJourney(req)){

--- a/src/middleware/validation.middleware.ts
+++ b/src/middleware/validation.middleware.ts
@@ -24,7 +24,7 @@ import { ApplicationData } from "../model/application.model";
 import { getBeneficialOwnerList } from "../utils/trusts";
 import { isActiveFeature } from "../utils/feature.flag";
 import * as config from "../config";
-import { getUrlWithParamsToPath } from "../utils/url";
+import { getUrlWithParamsToPath, isRemoveJourney } from "../utils/url";
 
 export function checkValidations(req: Request, res: Response, next: NextFunction) {
   try {
@@ -58,6 +58,12 @@ export function checkValidations(req: Request, res: Response, next: NextFunction
       }
       const entityNumber = appData?.[EntityNumberKey];
 
+      // Then when we pass it back into the template, make sure it is below/after the req.body fields so it overrides the req.body value
+      let journey = req.body["journey"];
+      if (isRemoveJourney(req)){
+        journey = config.JourneyType.remove;
+      }
+
       if (isActiveFeature(config.FEATURE_FLAG_ENABLE_REDIS_REMOVAL)) {
         // This is for the REDIS removal work, all BO / MO pages need the activeSubmissionBasePath passed into the template
         // and we also need to pass the feature flag as true so the template constructs the correct urls.
@@ -70,9 +76,10 @@ export function checkValidations(req: Request, res: Response, next: NextFunction
           ...appData,
           ...req.body,
           ...dates,
+          journey,
           errors,
           FEATURE_FLAG_ENABLE_REDIS_REMOVAL: true,
-          activeSubmissionBasePath: getUrlWithParamsToPath(config.ACTIVE_SUBMISSION_BASE_PATH, req),
+          activeSubmissionBasePath: getUrlWithParamsToPath(config.ACTIVE_SUBMISSION_BASE_PATH, req)
         });
       }
 
@@ -85,6 +92,7 @@ export function checkValidations(req: Request, res: Response, next: NextFunction
         ...appData,
         ...req.body,
         ...dates,
+        journey,
         errors
       });
     }

--- a/test/controllers/update/update.continue.saved.filing.controller.spec.ts
+++ b/test/controllers/update/update.continue.saved.filing.controller.spec.ts
@@ -116,16 +116,14 @@ describe("Continue with saved filing controller", () => {
       expect(mockLoggerDebugRequest).toHaveBeenCalledTimes(1);
     });
 
-    // TODO Uncomment this test (which should pass) when a solution to handling validation on the 'remove' journey is implemented
-    //
-    // test("renders the current page with error message and correct page title for the Remove journey", async () => {
-    //   const resp = await request(app).post(`${config.UPDATE_CONTINUE_WITH_SAVED_FILING_URL}?${JOURNEY_QUERY_PARAM}=remove`);
+    test("renders the current page with error message and correct page title for the Remove journey", async () => {
+      const resp = await request(app).post(`${config.UPDATE_CONTINUE_WITH_SAVED_FILING_URL}${config.JOURNEY_REMOVE_QUERY_PARAM}`);
 
-    //   expect(resp.status).toEqual(200);
-    //   expect(resp.text).toContain(CONTINUE_SAVED_FILING_PAGE_TITLE);
-    //   expect(resp.text).toContain(PAGE_TITLE_ERROR);
-    //   expect(resp.text).toContain(ErrorMessages.UPDATE_SELECT_IF_CONTINUE_SAVED_FILING);
-    //   expect(resp.text).toContain(REMOVE_SERVICE_NAME);
-    // });
+      expect(resp.status).toEqual(200);
+      expect(resp.text).toContain(CONTINUE_SAVED_FILING_PAGE_TITLE);
+      expect(resp.text).toContain(PAGE_TITLE_ERROR);
+      expect(resp.text).toContain(ErrorMessages.UPDATE_SELECT_IF_CONTINUE_SAVED_FILING);
+      expect(resp.text).toContain(REMOVE_SERVICE_NAME);
+    });
   });
 });


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/UAR-1161


### Change description
Add journey field into the validation.middleware so it can be re-added back to the template when we get a validation error


### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
