### PR TITLE
UAR-1283 fix sign out url

### DIFF
--- a/src/controllers/update/remove.cannot.use.controller.ts
+++ b/src/controllers/update/remove.cannot.use.controller.ts
@@ -5,6 +5,6 @@ export const get = (req: Request, res: Response) => {
   return res.render(config.REMOVE_CANNOT_USE_PAGE, {
     journey: config.JourneyType.remove,
     backLinkUrl: `${config.REMOVE_SOLD_ALL_LAND_FILTER_PAGE}${config.JOURNEY_REMOVE_QUERY_PARAM}`,
-    templateName: config.CANNOT_USE_PAGE
+    templateName: config.REMOVE_CANNOT_USE_PAGE
   });
 };

--- a/test/controllers/update/remove.cannot.use.controller.spec.ts
+++ b/test/controllers/update/remove.cannot.use.controller.spec.ts
@@ -1,3 +1,4 @@
+jest.mock("ioredis");
 jest.mock('../../../src/middleware/authentication.middleware');
 jest.mock('../../../src/middleware/service.availability.middleware');
 
@@ -9,7 +10,12 @@ import { serviceAvailabilityMiddleware } from "../../../src/middleware/service.a
 import { authentication } from "../../../src/middleware/authentication.middleware";
 
 const mockAuthenticationMiddleware = authentication as jest.Mock;
-mockAuthenticationMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => next() );
+mockAuthenticationMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => {
+  // Add userEmail to res.locals to make sign-out url appear
+  res.locals.userEmail = "userEmail";
+  return next();
+});
+
 const mockServiceAvailabilityMiddleware = serviceAvailabilityMiddleware as jest.Mock;
 mockServiceAvailabilityMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => next() );
 
@@ -22,5 +28,7 @@ describe("Remove cannot use this service page", () => {
     expect(resp.text).toContain("https://www.ros.gov.uk/our-registers/land-register-of-scotland");
     expect(resp.text).toContain("https://www.nidirect.gov.uk/articles/searching-land-registry");
     expect(resp.text).toContain("https://www.gov.uk/guidance/file-an-overseas-entity-update-statement");
+    expect(resp.text).toContain(config.REMOVE_SERVICE_NAME);
+    expect(resp.text).toContain(`${config.SIGN_OUT_PAGE}?page=${config.REMOVE_CANNOT_USE_PAGE}`);
   });
 });

--- a/views/update/remove-cannot-use.html
+++ b/views/update/remove-cannot-use.html
@@ -1,7 +1,9 @@
 {% extends "update-layout.html" %}
 
+{% set title = "You cannot apply to remove this overseas entity" %}
+
 {% block pageTitle %}
-  You cannot apply to de-register this overseas entity - {{ serviceName }} - GOV.UK
+  {% include "includes/update-page-title.html" %}
 {% endblock %}
 
 {% block backLink %} 


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/UAR-1283


### Change description
Fix the signout url and page title of remove-cannot-use, the sign-out "no" option would give a 404 as it was using CANNOT_USE_PAGE instead of REMOVE_CANNOT_USE_PAGE


### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
