### PR TITLE
uar-1073 ac3 show OE ID page when on remove journey

### DIFF
--- a/src/controllers/update/update.interrupt.card.controller.ts
+++ b/src/controllers/update/update.interrupt.card.controller.ts
@@ -30,7 +30,9 @@ export const get = (req: Request, res: Response, next: NextFunction) => {
 export const post = (req: Request, res: Response, next: NextFunction) => {
   try {
     logger.debugRequest(req, `${req.method} ${req.route.path}`);
-
+    if (isRemoveJourney(req)){
+      return res.redirect(`${config.OVERSEAS_ENTITY_QUERY_PAGE}${config.JOURNEY_REMOVE_QUERY_PARAM}`);
+    }
     return res.redirect(config.OVERSEAS_ENTITY_QUERY_PAGE);
   } catch (error) {
     logger.errorRequest(req, error);

--- a/test/controllers/update/update.interrupt.card.controller.spec.ts
+++ b/test/controllers/update/update.interrupt.card.controller.spec.ts
@@ -97,6 +97,12 @@ describe("UPDATE INTERRUPT CARD controller", () => {
       expect(resp.text).toContain("overseas-entity-query");
     });
 
+    test(`redirect to ${OVERSEAS_ENTITY_QUERY_URL}${JOURNEY_REMOVE_QUERY_PARAM} for remove journey`, async () => {
+      const resp = await request(app).post(`${UPDATE_INTERRUPT_CARD_URL}${JOURNEY_REMOVE_QUERY_PARAM}`);
+      expect(resp.status).toEqual(302);
+      expect(resp.text).toContain("overseas-entity-query" + JOURNEY_REMOVE_QUERY_PARAM);
+    });
+
     test("catch error when posting the page", async () => {
       mockLoggerDebugRequest.mockImplementationOnce( () => { throw new Error(ANY_MESSAGE_ERROR); });
       const resp = await request(app)

--- a/test/controllers/update/update.interrupt.card.controller.spec.ts
+++ b/test/controllers/update/update.interrupt.card.controller.spec.ts
@@ -107,7 +107,6 @@ describe("UPDATE INTERRUPT CARD controller", () => {
       mockLoggerDebugRequest.mockImplementationOnce( () => { throw new Error(ANY_MESSAGE_ERROR); });
       const resp = await request(app)
         .post(UPDATE_INTERRUPT_CARD_URL);
-
       expect(resp.status).toEqual(500);
       expect(resp.text).toContain(SERVICE_UNAVAILABLE);
     });


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/UAR-1073

### Change description

For AC3:

Given that I am on the ‘Before you start’ page
When I select continue
Then I am taken to the What is the Overseas Entity ID? page.

Tested locally and **?journey=remove** is present at the end of the URL

### Work checklist

- [x] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
