### PR TITLE
UAR-1253 Query parameter on call to on register page

### DIFF
--- a/src/controllers/update/remove.sold.all.land.filter.controller.ts
+++ b/src/controllers/update/remove.sold.all.land.filter.controller.ts
@@ -22,7 +22,7 @@ export const post = (req: Request, res: Response, next: NextFunction) => {
     logger.debugRequest(req, `POST ${config.REMOVE_SOLD_ALL_LAND_FILTER_PAGE}`);
 
     if (req.body["disposed_all_land"] === 'yes') {
-      return res.redirect(config.REMOVE_IS_ENTITY_REGISTERED_OWNER_PAGE);
+      return res.redirect(`${config.REMOVE_IS_ENTITY_REGISTERED_OWNER_PAGE}${config.JOURNEY_REMOVE_QUERY_PARAM}`);
     }
 
     return res.redirect(config.REMOVE_CANNOT_USE_URL);

--- a/test/controllers/update/remove.sold.all.land.filter.controller.spec.ts
+++ b/test/controllers/update/remove.sold.all.land.filter.controller.spec.ts
@@ -61,8 +61,8 @@ describe("Remove sold all land filter controller", () => {
         .send({ disposed_all_land: 'yes' });
 
       expect(resp.status).toEqual(302);
-      expect(resp.text).toEqual(`${FOUND_REDIRECT_TO} ${config.REMOVE_IS_ENTITY_REGISTERED_OWNER_PAGE}`);
-      expect(resp.header.location).toEqual(config.REMOVE_IS_ENTITY_REGISTERED_OWNER_PAGE);
+      expect(resp.text).toEqual(`${FOUND_REDIRECT_TO} ${config.REMOVE_IS_ENTITY_REGISTERED_OWNER_PAGE}${config.JOURNEY_REMOVE_QUERY_PARAM}`);
+      expect(resp.header.location).toEqual(`${config.REMOVE_IS_ENTITY_REGISTERED_OWNER_PAGE}${config.JOURNEY_REMOVE_QUERY_PARAM}`);
       expect(mockLoggerDebugRequest).toHaveBeenCalledTimes(1);
     });
 


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/UAR-1253


### Change description

Bugfix - remove parameter required when moving form sold land filter page to the land registry page.

### Work checklist

- [x] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
