### PR TITLE
UAR-1331 remove cannot use screen dynamic back link

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -172,6 +172,7 @@ export const ROUTE_PARAM_TRANSACTION_ID = "transactionId";
 export const ROUTE_PARAM_SUBMISSION_ID = "submissionId";
 export const LANDING_PAGE_QUERY_PARAM = "start";
 export const JOURNEY_QUERY_PARAM = "journey";
+export const PREVIOUS_PAGE_QUERY_PARAM = "previousPage";
 
 export enum JourneyType {
   register = "register",

--- a/src/controllers/update/remove.cannot.use.controller.ts
+++ b/src/controllers/update/remove.cannot.use.controller.ts
@@ -1,10 +1,24 @@
-import { Request, Response } from "express";
+import { NextFunction, Request, Response } from "express";
 import * as config from "../../config";
+import { logger } from "../../utils/logger";
 
-export const get = (req: Request, res: Response) => {
-  return res.render(config.REMOVE_CANNOT_USE_PAGE, {
-    journey: config.JourneyType.remove,
-    backLinkUrl: `${config.REMOVE_SOLD_ALL_LAND_FILTER_PAGE}${config.JOURNEY_REMOVE_QUERY_PARAM}`,
-    templateName: config.REMOVE_CANNOT_USE_PAGE
-  });
+export const get = (req: Request, res: Response, next: NextFunction) => {
+  try {
+    logger.debugRequest(req, `GET ${config.SIGN_OUT_PAGE}`);
+
+    let backLinkUrl = "";
+    const previousPage = req.query[config.PREVIOUS_PAGE_QUERY_PARAM];
+    if (previousPage) {
+      backLinkUrl = previousPage + config.JOURNEY_REMOVE_QUERY_PARAM;
+    }
+
+    return res.render(config.REMOVE_CANNOT_USE_PAGE, {
+      journey: config.JourneyType.remove,
+      backLinkUrl,
+      templateName: config.REMOVE_CANNOT_USE_PAGE
+    });
+  } catch (error) {
+    logger.errorRequest(req, error);
+    next(error);
+  }
 };

--- a/src/controllers/update/remove.cannot.use.controller.ts
+++ b/src/controllers/update/remove.cannot.use.controller.ts
@@ -9,7 +9,7 @@ export const get = (req: Request, res: Response, next: NextFunction) => {
     let backLinkUrl = "";
     const previousPage = req.query[config.PREVIOUS_PAGE_QUERY_PARAM];
     if (previousPage) {
-      backLinkUrl = previousPage + config.JOURNEY_REMOVE_QUERY_PARAM;
+      backLinkUrl = `${previousPage}${config.JOURNEY_REMOVE_QUERY_PARAM}`;
     }
 
     return res.render(config.REMOVE_CANNOT_USE_PAGE, {

--- a/src/controllers/update/remove.is.entity.registered.owner.controller.ts
+++ b/src/controllers/update/remove.is.entity.registered.owner.controller.ts
@@ -22,7 +22,7 @@ export const post = (req: Request, res: Response, next: NextFunction) => {
     if (req.body["owner_disposed"] === 'no') {
       return res.redirect(`${config.SECURE_UPDATE_FILTER_URL}${config.JOURNEY_REMOVE_QUERY_PARAM}`);
     }
-    return res.redirect(config.REMOVE_CANNOT_USE_URL);
+    return res.redirect(`${config.REMOVE_CANNOT_USE_URL}?${config.PREVIOUS_PAGE_QUERY_PARAM}=${config.REMOVE_IS_ENTITY_REGISTERED_OWNER_PAGE}`);
   } catch (error) {
     next(error);
   }

--- a/src/controllers/update/remove.sold.all.land.filter.controller.ts
+++ b/src/controllers/update/remove.sold.all.land.filter.controller.ts
@@ -25,7 +25,7 @@ export const post = (req: Request, res: Response, next: NextFunction) => {
       return res.redirect(`${config.REMOVE_IS_ENTITY_REGISTERED_OWNER_PAGE}${config.JOURNEY_REMOVE_QUERY_PARAM}`);
     }
 
-    return res.redirect(config.REMOVE_CANNOT_USE_URL);
+    return res.redirect(`${config.REMOVE_CANNOT_USE_URL}?${config.PREVIOUS_PAGE_QUERY_PARAM}=${config.REMOVE_SOLD_ALL_LAND_FILTER_PAGE}`);
   } catch (error) {
     next(error);
   }

--- a/src/controllers/update/update.sign.out.controller.ts
+++ b/src/controllers/update/update.sign.out.controller.ts
@@ -22,10 +22,6 @@ export const post = (req: Request, res: Response, next: NextFunction) => {
   try {
     logger.debugRequest(req, `${req.method} ${req.route.path}`);
     const previousPage = req.body["previousPage"];
-
-    // TODO include previousPage in url for remove-cannot-use back link
-    // have a previousPageBackLink in the body and if not undefined or null add it to the redirect to previousPage
-
     if (!previousPage.startsWith(config.UPDATE_AN_OVERSEAS_ENTITY_URL)){
       throw createAndLogErrorRequest(req, `${previousPage} page is not part of the journey!`);
     }

--- a/src/controllers/update/update.sign.out.controller.ts
+++ b/src/controllers/update/update.sign.out.controller.ts
@@ -22,8 +22,10 @@ export const post = (req: Request, res: Response, next: NextFunction) => {
   try {
     logger.debugRequest(req, `${req.method} ${req.route.path}`);
     const previousPage = req.body["previousPage"];
+
     // TODO include previousPage in url for remove-cannot-use back link
     // have a previousPageBackLink in the body and if not undefined or null add it to the redirect to previousPage
+
     if (!previousPage.startsWith(config.UPDATE_AN_OVERSEAS_ENTITY_URL)){
       throw createAndLogErrorRequest(req, `${previousPage} page is not part of the journey!`);
     }

--- a/src/controllers/update/update.sign.out.controller.ts
+++ b/src/controllers/update/update.sign.out.controller.ts
@@ -22,6 +22,8 @@ export const post = (req: Request, res: Response, next: NextFunction) => {
   try {
     logger.debugRequest(req, `${req.method} ${req.route.path}`);
     const previousPage = req.body["previousPage"];
+    // TODO include previousPage in url for remove-cannot-use back link
+    // have a previousPageBackLink in the body and if not undefined or null add it to the redirect to previousPage
     if (!previousPage.startsWith(config.UPDATE_AN_OVERSEAS_ENTITY_URL)){
       throw createAndLogErrorRequest(req, `${previousPage} page is not part of the journey!`);
     }

--- a/test/controllers/update/remove.cannot.use.controller.spec.ts
+++ b/test/controllers/update/remove.cannot.use.controller.spec.ts
@@ -21,7 +21,7 @@ mockServiceAvailabilityMiddleware.mockImplementation((req: Request, res: Respons
 
 describe("Remove cannot use this service page", () => {
   test(`renders the ${config.REMOVE_CANNOT_USE_PAGE} page`, async () => {
-    const resp = await request(app).get(config.REMOVE_CANNOT_USE_URL);
+    const resp = await request(app).get(`${config.REMOVE_CANNOT_USE_URL}?${config.PREVIOUS_PAGE_QUERY_PARAM}=${config.REMOVE_SOLD_ALL_LAND_FILTER_PAGE}`);
     expect(resp.status).toEqual(200);
     expect(resp.text).toContain("You cannot apply to remove this overseas entity");
     expect(resp.text).toContain("https://www.gov.uk/government/organisations/land-registry");
@@ -30,5 +30,6 @@ describe("Remove cannot use this service page", () => {
     expect(resp.text).toContain("https://www.gov.uk/guidance/file-an-overseas-entity-update-statement");
     expect(resp.text).toContain(config.REMOVE_SERVICE_NAME);
     expect(resp.text).toContain(`${config.SIGN_OUT_PAGE}?page=${config.REMOVE_CANNOT_USE_PAGE}`);
+    expect(resp.text).toContain(`${config.REMOVE_SOLD_ALL_LAND_FILTER_PAGE}${config.JOURNEY_REMOVE_QUERY_PARAM}`);
   });
 });

--- a/test/controllers/update/remove.is.entity.registered.owner.controller.spec.ts
+++ b/test/controllers/update/remove.is.entity.registered.owner.controller.spec.ts
@@ -56,8 +56,8 @@ describe("Remove registered owner controller", () => {
         .post(`${config.REMOVE_IS_ENTITY_REGISTERED_OWNER_URL}${config.JOURNEY_REMOVE_QUERY_PARAM}`)
         .send({ owner_disposed: 'yes' });
       expect(resp.status).toEqual(302);
-      expect(resp.text).toEqual(`${FOUND_REDIRECT_TO} ${config.REMOVE_CANNOT_USE_URL}`);
-      expect(resp.header.location).toEqual(config.REMOVE_CANNOT_USE_URL);
+      expect(resp.text).toEqual(`${FOUND_REDIRECT_TO} ${config.REMOVE_CANNOT_USE_URL}?${config.PREVIOUS_PAGE_QUERY_PARAM}=${config.REMOVE_IS_ENTITY_REGISTERED_OWNER_PAGE}`);
+      expect(resp.header.location).toEqual(`${config.REMOVE_CANNOT_USE_URL}?${config.PREVIOUS_PAGE_QUERY_PARAM}=${config.REMOVE_IS_ENTITY_REGISTERED_OWNER_PAGE}`);
       expect(mockLoggerDebugRequest).toHaveBeenCalledTimes(1);
     });
 

--- a/test/controllers/update/remove.sold.all.land.filter.controller.spec.ts
+++ b/test/controllers/update/remove.sold.all.land.filter.controller.spec.ts
@@ -72,8 +72,8 @@ describe("Remove sold all land filter controller", () => {
         .send({ disposed_all_land: 'no' });
 
       expect(resp.status).toEqual(302);
-      expect(resp.text).toEqual(`${FOUND_REDIRECT_TO} ${config.REMOVE_CANNOT_USE_URL}`);
-      expect(resp.header.location).toEqual(config.REMOVE_CANNOT_USE_URL);
+      expect(resp.text).toEqual(`${FOUND_REDIRECT_TO} ${config.REMOVE_CANNOT_USE_URL}?${config.PREVIOUS_PAGE_QUERY_PARAM}=${config.REMOVE_SOLD_ALL_LAND_FILTER_PAGE}`);
+      expect(resp.header.location).toEqual(`${config.REMOVE_CANNOT_USE_URL}?${config.PREVIOUS_PAGE_QUERY_PARAM}=${config.REMOVE_SOLD_ALL_LAND_FILTER_PAGE}`);
       expect(mockLoggerDebugRequest).toHaveBeenCalledTimes(1);
     });
 


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/UAR-1331


### Change description
the remove-cannot-use screen is redirected to from 2 different places.  The back link on the remove-cannot-use screen was hardcoded to go to 1 of the screens. This PR will read the previous page from a url parameter and construct teh acklink using that param.


### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
