### PR TITLE
UAR-1326 Add a new 'is_remove' field to the OE session data

### DIFF
--- a/src/controllers/update/update.interrupt.card.controller.ts
+++ b/src/controllers/update/update.interrupt.card.controller.ts
@@ -9,7 +9,7 @@ export const get = (req: Request, res: Response, next: NextFunction) => {
   try {
     logger.debugRequest(req, `${req.method} ${req.route.path}`);
 
-    if (isRemoveJourney(req)){
+    if (isRemoveJourney(req)) {
       return res.render(config.UPDATE_INTERRUPT_CARD_PAGE, {
         journey: config.JourneyType.remove,
         backLinkUrl: (isActiveFeature(config.FEATURE_FLAG_ENABLE_UPDATE_TRUSTS) ? config.SECURE_UPDATE_FILTER_URL : config.UPDATE_ANY_TRUSTS_INVOLVED_URL) + config.JOURNEY_REMOVE_QUERY_PARAM,

--- a/src/model/application.model.ts
+++ b/src/model/application.model.ts
@@ -38,6 +38,7 @@ export interface ApplicationData {
     is_secure_register?: string;
     who_is_registering?: string;
     update?: updateType.Update;
+    is_remove?: boolean;
 }
 
 export const ApplicationDataArrayType = [

--- a/src/model/data.types.model.ts
+++ b/src/model/data.types.model.ts
@@ -83,3 +83,6 @@ export const EntityNumberKey = "entity_number";
 export const UpdateModelKey = "update";
 export const DoYouWantToRemoveKey = "do_you_want_to_remove";
 export const AnyTrustsInvolvedKey = "any_trusts_involved";
+
+// Remove Journey
+export const IsRemoveKey = "is_remove";

--- a/src/utils/presenter.ts
+++ b/src/utils/presenter.ts
@@ -2,9 +2,13 @@ import { NextFunction, Request, Response } from "express";
 import { Session } from "@companieshouse/node-session-handler";
 import { ApplicationData } from "../model";
 import { PresenterKey, PresenterKeys } from "../model/presenter.model";
+import { IsRemoveKey, OverseasEntityKey, Transactionkey } from '../model/data.types.model';
 import { getApplicationData, prepareData, setApplicationData } from "./application.data";
 import { logger } from "./logger";
 import { saveAndContinue } from "./save.and.continue";
+import { isRemoveJourney } from "../utils/url";
+import { postTransaction } from "../service/transaction.service";
+import { createOverseasEntity } from "../service/overseas.entities.service";
 
 export const getPresenterPage = (req: Request, res: Response, next: NextFunction, templateName: string, backLinkUrl: string): void => {
   try {
@@ -29,6 +33,17 @@ export const postPresenterPage = async (req: Request, res: Response, next: NextF
     logger.debugRequest(req, `${req.method} ${req.route.path}`);
 
     const session = req.session as Session;
+
+    if (isRemoveJourney(req)) {
+      const appData: ApplicationData = getApplicationData(session);
+      if (!appData[Transactionkey]) {
+        const transactionID = await postTransaction(req, session);
+        appData[Transactionkey] = transactionID;
+        appData[IsRemoveKey] = true;
+        appData[OverseasEntityKey] = await createOverseasEntity(req, session, transactionID, true);
+      }
+    }
+
     const data = prepareData(req.body, PresenterKeys);
     setApplicationData(session, data, PresenterKey);
 

--- a/src/utils/presenter.ts
+++ b/src/utils/presenter.ts
@@ -3,7 +3,7 @@ import { Session } from "@companieshouse/node-session-handler";
 import { ApplicationData } from "../model";
 import { PresenterKey, PresenterKeys } from "../model/presenter.model";
 import { IsRemoveKey, OverseasEntityKey, Transactionkey } from '../model/data.types.model';
-import { getApplicationData, prepareData, setApplicationData } from "./application.data";
+import { getApplicationData, prepareData, setApplicationData, setExtraData } from "./application.data";
 import { logger } from "./logger";
 import { saveAndContinue } from "./save.and.continue";
 import { isRemoveJourney } from "../utils/url";
@@ -41,6 +41,7 @@ export const postPresenterPage = async (req: Request, res: Response, next: NextF
         appData[Transactionkey] = transactionID;
         appData[IsRemoveKey] = true;
         appData[OverseasEntityKey] = await createOverseasEntity(req, session, transactionID, true);
+        setExtraData(req.session, appData);
       }
     }
 

--- a/test/controllers/update/overseas.entity.presenter.controller.spec.ts
+++ b/test/controllers/update/overseas.entity.presenter.controller.spec.ts
@@ -22,7 +22,7 @@ import {
   UPDATE_DO_YOU_WANT_TO_MAKE_OE_CHANGE_PAGE,
   UPDATE_DO_YOU_WANT_TO_MAKE_OE_CHANGE_URL,
 } from "../../../src/config";
-import { getApplicationData, prepareData, setApplicationData } from "../../../src/utils/application.data";
+import { getApplicationData, prepareData, setApplicationData, setExtraData } from "../../../src/utils/application.data";
 import { ApplicationDataType } from '../../../src/model';
 import {
   ANY_MESSAGE_ERROR,
@@ -58,6 +58,7 @@ const mockGetApplicationData = getApplicationData as jest.Mock;
 mockGetApplicationData.mockReturnValue(APPLICATION_DATA_MOCK);
 
 const mockSetApplicationData = setApplicationData as jest.Mock;
+const mockSetExtraData = setExtraData as jest.Mock;
 const mockAuthenticationMiddleware = authentication as jest.Mock;
 mockAuthenticationMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => next() );
 
@@ -214,6 +215,7 @@ describe("OVERSEAS ENTITY PRESENTER controller", () => {
       expect(mockTransactionService).toHaveBeenCalledTimes(1);
       expect(mockCreateOverseasEntity).toHaveBeenCalledTimes(1);
       expect(mockSaveAndContinue).toHaveBeenCalledTimes(1);
+      expect(mockSetExtraData).toHaveBeenCalledTimes(1);
 
       expect(resp.text).toContain(`${FOUND_REDIRECT_TO} ${UPDATE_DO_YOU_WANT_TO_MAKE_OE_CHANGE_URL}`);
     });


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/UAR-1326

### Change description

* Field data also sent to API
* Transaction and OE submission created on 'presenter' screen if remove journey

Note: No unit tests added yet - still in draft

### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
