### PR TITLE
add trim to oe number to remove entered whitespaces

### DIFF
--- a/src/validation/overseas.entity.query.validation.ts
+++ b/src/validation/overseas.entity.query.validation.ts
@@ -7,6 +7,7 @@ export const overseasEntityQuery = [
   body("entity_number")
     .not().isEmpty({ ignore_whitespace: true })
     .withMessage(ErrorMessages.OE_QUERY_NUMBER)
+    .trim()
     .matches(VALID_OE_NUMBER_FORMAT)
     .withMessage(ErrorMessages.INVALID_OE_NUMBER),
 ];

--- a/test/controllers/update/overseas.entity.query.controller.spec.ts
+++ b/test/controllers/update/overseas.entity.query.controller.spec.ts
@@ -181,5 +181,26 @@ describe("OVERSEAS ENTITY QUERY controller", () => {
       expect(resp.status).toEqual(500);
       expect(resp.text).toContain(SERVICE_UNAVAILABLE);
     });
+
+    const values_without_trim = [' OE123456', 'OE123456 ', ' OE123456 '];
+
+    test.each(values_without_trim)(
+      "trims the whitespaces and allows user to continue", async (input_value) => {
+        const resp = await request(app)
+          .post(config.OVERSEAS_ENTITY_QUERY_URL)
+          .send({ entity_number: input_value.trim() });
+        expect(resp.status).toEqual(200);
+        expect(resp.text).not.toContain(invalidOENUmberError);
+      });
+
+    test.each(values_without_trim)(
+      "trims the whitespaces and allows user to continue", async (input_value) => {
+        const resp = await request(app)
+          .post(`${config.OVERSEAS_ENTITY_QUERY_URL}?${config.JOURNEY_QUERY_PARAM}=remove`)
+          .send({ entity_number: input_value.trim() });
+        expect(resp.status).toEqual(200);
+        expect(resp.text).not.toContain(invalidOENUmberError);
+      });
   });
+
 });

--- a/test/controllers/update/overseas.entity.query.controller.spec.ts
+++ b/test/controllers/update/overseas.entity.query.controller.spec.ts
@@ -194,7 +194,7 @@ describe("OVERSEAS ENTITY QUERY controller", () => {
       });
 
     test.each(values_without_trim)(
-      "trims the whitespaces and allows user to continue", async (input_value) => {
+      "trims the whitespaces and allows user to continue when on remove journey", async (input_value) => {
         const resp = await request(app)
           .post(`${config.OVERSEAS_ENTITY_QUERY_URL}?${config.JOURNEY_QUERY_PARAM}=remove`)
           .send({ entity_number: input_value.trim() });


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/UAR-1024

### Change description

Added a .trim() to the OE number so validation doesn't fire when OE number entered is correct. No tests added as they are already testing for OE number?


### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
