### PR TITLE
roe-2489 set title in the tab/window for trust-details page

### DIFF
--- a/views/trust-details.html
+++ b/views/trust-details.html
@@ -1,5 +1,7 @@
 {% extends "layout.html" %}
 
+{% set title = "Tell us about the trust" %}
+
 {% block pageTitle %}
   {% include "includes/page-title.html" %}
 {% endblock %}


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/ROE-2489

### Change description

The tab title was missing on trust-details page, so added {% set title = "Tell us about the trust" %}
No test added, there are currently ones testing for page heading. Cannot see examples for any that test for tab/window name.

### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
