### PR TITLE
UAR-1352 Exclusive remove pages must be inaccessible for feature flag

### DIFF
--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -37,7 +37,7 @@ export const isRemoveJourney = (req: Request): boolean => {
     }
   }
 
-  // UAT-1352 Only required for remove feature flag - can be removed with it
+  // UAR-1352 Only required for remove feature flag - can be removed with it
   if (!req.query[config.JOURNEY_QUERY_PARAM] && req.url.includes("remove")) {
     return true;
   }

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -37,5 +37,10 @@ export const isRemoveJourney = (req: Request): boolean => {
     }
   }
 
+  // UAT-1352 Only required for remove feature flag - can be removed with it
+  if (!req.query[config.JOURNEY_QUERY_PARAM] && req.url.includes("remove")) {
+    return true;
+  }
+
   return req.query[config.JOURNEY_QUERY_PARAM] === config.JourneyType.remove;
 };

--- a/test/utils/navigation.spec.ts
+++ b/test/utils/navigation.spec.ts
@@ -26,6 +26,8 @@ mockRemoveRequest["query"] = {
   "journey": "remove"
 };
 
+const mockRequest = { query: {}, url: "" } as Request;
+
 describe("NAVIGATION utils", () => {
 
   test(`getEntityBackLink returns ${config.DUE_DILIGENCE_URL} when ${WhoIsRegisteringType.AGENT} selected`, () => {
@@ -60,7 +62,6 @@ describe("NAVIGATION utils", () => {
   });
 
   test(`getSecureUpdateFilterBackLink returns the correct URL when not on the Remove journey`, () => {
-    const mockRequest = { query: {} } as Request;
     const backLink = getSecureUpdateFilterBackLink(mockRequest);
     expect(backLink).toEqual(config.UPDATE_LANDING_PAGE_URL);
   });
@@ -71,7 +72,6 @@ describe("NAVIGATION utils", () => {
   });
 
   test(`getOverseasEntityPresenterBackLink returns the correct URL when not on the Remove journey`, () => {
-    const mockRequest = { query: {} } as Request;
     const backLink = getOverseasEntityPresenterBackLink(mockRequest);
     expect(backLink).toEqual(config.UPDATE_FILING_DATE_URL);
   });
@@ -203,7 +203,6 @@ describe("NAVIGATION utils", () => {
   });
 
   test(`NAVIGATION returns ${config.UPDATE_FILING_DATE_URL} when calling previousPage on ${config.OVERSEAS_ENTITY_PRESENTER_URL} object`, () => {
-    const mockRequest = { query: {} } as Request;
     const navigation = NAVIGATION[config.OVERSEAS_ENTITY_PRESENTER_URL].previousPage(undefined, mockRequest);
     expect(navigation).toEqual(config.UPDATE_FILING_DATE_URL);
   });
@@ -219,13 +218,11 @@ describe("NAVIGATION utils", () => {
   });
 
   test(`NAVIGATION returns ${config.OVERSEAS_ENTITY_QUERY_URL} when calling previousPage on ${config.UPDATE_OVERSEAS_ENTITY_CONFIRM_URL} object`, () => {
-    const mockRequest = { query: {} } as Request;
     const navigation = NAVIGATION[config.UPDATE_OVERSEAS_ENTITY_CONFIRM_URL].previousPage(undefined, mockRequest);
     expect(navigation).toEqual(config.OVERSEAS_ENTITY_QUERY_URL);
   });
 
   test(`NAVIGATION returns ${config.UPDATE_INTERRUPT_CARD_URL} when calling previousPage on ${config.OVERSEAS_ENTITY_QUERY_URL} object`, () => {
-    const mockRequest = { query: {} } as Request;
     const navigation = NAVIGATION[config.OVERSEAS_ENTITY_QUERY_URL].previousPage(undefined, mockRequest);
     expect(navigation).toEqual(config.UPDATE_INTERRUPT_CARD_URL);
   });

--- a/test/utils/url.spec.ts
+++ b/test/utils/url.spec.ts
@@ -15,6 +15,7 @@ describe("Url utils tests", () => {
 
   beforeEach(() => {
     req["query"] = {};
+    req["url"] = "";
   });
 
   describe("getUrlWithTransactionIdAndOverseasEntityId tests", () => {
@@ -119,6 +120,21 @@ describe("Url utils tests", () => {
       expect(result).toBeTruthy();
     });
 
+    test("returns true if is_remove is null in session data and query param is null but url contains remove", () => {
+      mockGetApplicationData.mockReturnValueOnce(
+        { ...APPLICATION_DATA_MOCK,
+          is_remove: null
+        }
+      );
+
+      req["query"] = {};
+      req["url"] = "/remove";
+
+      const result = urlUtils.isRemoveJourney(req);
+
+      expect(result).toBeTruthy();
+    });
+
     test("returns true if is_remove is true in session data and query param journey=register", () => {
       mockGetApplicationData.mockReturnValueOnce(
         { ...APPLICATION_DATA_MOCK,
@@ -192,6 +208,14 @@ describe("Url utils tests", () => {
 
     test("returns false if request has empty query params object", () => {
       req["query"] = {};
+      const result = urlUtils.isRemoveJourney(req);
+
+      expect(result).toBeFalsy();
+    });
+
+    test("returns false if request has empty query params object and url is not remove", () => {
+      req["query"] = {};
+      req["url"] = "/update";
       const result = urlUtils.isRemoveJourney(req);
 
       expect(result).toBeFalsy();


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/UAR-1352

### Change description

Added extra check in isRemove to seek the term "remove" in the url so as to prevent access to remove pages when the FEATURE_FLAG_ENABLE_ROE_REMOVE_24112022 is false.

If we cannot access the sold land filter page and the remove is entity registered pages then we cannot access the secure update filter from remove and this would enforce the order specified on the ticket as only the update version of this page could be accessed.


### Work checklist

- [x] Tests added where applicable
- [x] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
