### PR TITLE
UAR-1366 Fix mappings for trustees

### DIFF
--- a/src/model/role.within.trust.type.model.ts
+++ b/src/model/role.within.trust.type.model.ts
@@ -5,7 +5,6 @@
  */
 
 export enum RoleWithinTrustType {
-    BENEFICIAL_OWNER = "Beneficial_Owner",
     BENEFICIARY = "Beneficiary",
     SETTLOR = "Settlor",
     GRANTOR = "Grantor",

--- a/src/model/role.within.trust.type.model.ts
+++ b/src/model/role.within.trust.type.model.ts
@@ -5,6 +5,7 @@
  */
 
 export enum RoleWithinTrustType {
+    BENEFICIAL_OWNER = "Beneficial_Owner",
     BENEFICIARY = "Beneficiary",
     SETTLOR = "Settlor",
     GRANTOR = "Grantor",

--- a/src/model/trust.model.ts
+++ b/src/model/trust.model.ts
@@ -48,7 +48,7 @@ export interface TrustReviewStatus {
 export interface TrustIndividual {
   id?: string;
   ch_references?: string;
-  type: RoleWithinTrustType;
+  type: RoleWithinTrustType | undefined;
   forename: string;
   other_forenames: string;
   surname: string;
@@ -120,7 +120,7 @@ export type TrustHistoricalBeneficialOwner =
 export type TrustCorporate = {
   id?: string
   ch_references?: string;
-  type: string;
+  type: string | undefined;
   name: string;
   date_became_interested_person_day?: string;
   date_became_interested_person_month?: string;

--- a/src/utils/update/trust.model.fetch.ts
+++ b/src/utils/update/trust.model.fetch.ts
@@ -308,7 +308,7 @@ const linkBoToTrust = (beneficialOwner: BeneficialOwnerIndividual | BeneficialOw
   beneficialOwner.trust_ids.push(trust.trust_id);
 };
 
-const mapTrusteeType = (trusteeTypeId: string): RoleWithinTrustType => {
+export const mapTrusteeType = (trusteeTypeId: string): RoleWithinTrustType => {
   switch (trusteeTypeId) {
       case "5005":
         return RoleWithinTrustType.INTERESTED_PERSON;
@@ -317,8 +317,9 @@ const mapTrusteeType = (trusteeTypeId: string): RoleWithinTrustType => {
       case "5003":
         return RoleWithinTrustType.SETTLOR;
       case "5002":
-      case "5001":
         return RoleWithinTrustType.BENEFICIARY;
+      case "5001":
+        return RoleWithinTrustType.BENEFICIAL_OWNER;
       default:
         throw new Error(`Trustee Type ${trusteeTypeId} not recognised`);
   }

--- a/src/utils/update/trust.model.fetch.ts
+++ b/src/utils/update/trust.model.fetch.ts
@@ -320,10 +320,10 @@ const mapTrusteeType = (trusteeTypeId: string): RoleWithinTrustType | undefined 
         return RoleWithinTrustType.BENEFICIARY;
       case "5001":
         /*
-          Type 5001 is not a valid type for an individuual or corporate trustee. Instances of individual or corporate
-          trustees that have this rusteeTypeId are are result of incorrect data originally submitted through the
-          trust spreadsheet (which has now been superceded by web screens). In these instances we do not display the type.
-          Data fixes shoud prevent these instances from being retrieved.
+          Type 5001 is not a valid type for an individual or corporate trustee. Instances of individual or corporate
+          trustees that have this trusteeTypeId are the result of incorrect data originally submitted through the
+          trust spreadsheet (which has now been superseded by web screens). In these instances we do not display the type.
+          Data fixes should prevent these instances from being retrieved.
         */
         logger.info(`Warning - invalid data. Trustee type ${trusteeTypeId} found when mapping trustee data`);
         return undefined;

--- a/src/utils/update/trust.model.fetch.ts
+++ b/src/utils/update/trust.model.fetch.ts
@@ -319,7 +319,12 @@ const mapTrusteeType = (trusteeTypeId: string): RoleWithinTrustType | undefined 
       case "5002":
         return RoleWithinTrustType.BENEFICIARY;
       case "5001":
-        // Type 5001 is not a valid type for an individuual or corporate trustee
+        /*
+          Type 5001 is not a valid type for an individuual or corporate trustee. Instances of individual or corporate
+          trustees that have this rusteeTypeId are are result of incorrect data originally submitted through the
+          trust spreadsheet (which has now been superceded by web screens). In these instances we do not display the type.
+          Data fixes shoud prevent these instances from being retrieved.
+        */
         logger.info(`Warning - invalid data. Trustee type ${trusteeTypeId} found when mapping trustee data`);
         return undefined;
       default:

--- a/src/utils/update/trust.model.fetch.ts
+++ b/src/utils/update/trust.model.fetch.ts
@@ -308,7 +308,7 @@ const linkBoToTrust = (beneficialOwner: BeneficialOwnerIndividual | BeneficialOw
   beneficialOwner.trust_ids.push(trust.trust_id);
 };
 
-export const mapTrusteeType = (trusteeTypeId: string): RoleWithinTrustType => {
+const mapTrusteeType = (trusteeTypeId: string): RoleWithinTrustType => {
   switch (trusteeTypeId) {
       case "5005":
         return RoleWithinTrustType.INTERESTED_PERSON;

--- a/src/utils/update/trust.model.fetch.ts
+++ b/src/utils/update/trust.model.fetch.ts
@@ -308,7 +308,7 @@ const linkBoToTrust = (beneficialOwner: BeneficialOwnerIndividual | BeneficialOw
   beneficialOwner.trust_ids.push(trust.trust_id);
 };
 
-const mapTrusteeType = (trusteeTypeId: string): RoleWithinTrustType => {
+const mapTrusteeType = (trusteeTypeId: string): RoleWithinTrustType | undefined => {
   switch (trusteeTypeId) {
       case "5005":
         return RoleWithinTrustType.INTERESTED_PERSON;
@@ -319,7 +319,9 @@ const mapTrusteeType = (trusteeTypeId: string): RoleWithinTrustType => {
       case "5002":
         return RoleWithinTrustType.BENEFICIARY;
       case "5001":
-        return RoleWithinTrustType.BENEFICIAL_OWNER;
+        // Type 5001 is not a valid type for an individuual or corporate trustee
+        logger.info(`Warning - invalid data. Trustee type ${trusteeTypeId} found when mapping trustee data`);
+        return undefined;
       default:
         throw new Error(`Trustee Type ${trusteeTypeId} not recognised`);
   }

--- a/test/controllers/update/update.manage.trusts.review.individuals.controller.spec.ts
+++ b/test/controllers/update/update.manage.trusts.review.individuals.controller.spec.ts
@@ -91,9 +91,9 @@ describe('Update - Manage Trusts - Review individuals', () => {
       const trustInReview = trusts[0];
       const appData = { update: { review_trusts: trusts } };
 
-      mockIsActiveFeature.mockReturnValue(true);
-      mockGetApplicationData.mockReturnValue(appData);
-      mockGetTrustInReview.mockReturnValue(trustInReview);
+      mockIsActiveFeature.mockReturnValueOnce(true);
+      mockGetApplicationData.mockReturnValueOnce(appData);
+      mockGetTrustInReview.mockReturnValueOnce(trustInReview);
 
       const resp = await request(app).get(UPDATE_MANAGE_TRUSTS_REVIEW_INDIVIDUALS_URL);
 
@@ -120,8 +120,29 @@ describe('Update - Manage Trusts - Review individuals', () => {
       expect(resp.text).not.toContain(PAGE_TITLE_ERROR);
     });
 
+    test.each([
+      ['Uppercase', 'BENEFICIARY'],
+      ['Camelcase', 'Beneficiary'],
+      ['Lowercase', 'beneficiary'],
+    ])('when beneficial owner type is %s string then it is mapped correctly on the page', async (_, boType) => {
+      // resuming an update journey/application causes the bo types to be set as uppercase strings instead of RoleWithinTrustType
+      const trusts = createTrusts();
+      const trustInReview = trusts[0];
+
+      trustInReview.INDIVIDUALS[0].type = boType as RoleWithinTrustType;
+      const appData = { update: { review_trusts: trusts } };
+
+      mockIsActiveFeature.mockReturnValueOnce(true);
+      mockGetApplicationData.mockReturnValueOnce(appData);
+      mockGetTrustInReview.mockReturnValueOnce(trustInReview);
+
+      const resp = await request(app).get(UPDATE_MANAGE_TRUSTS_REVIEW_INDIVIDUALS_URL);
+
+      expect(resp.text).toContain('Beneficiary');
+    });
+
     test('when feature flag is off, 404 is returned', async () => {
-      mockIsActiveFeature.mockReturnValue(false);
+      mockIsActiveFeature.mockReturnValueOnce(false);
 
       const resp = await request(app).get(UPDATE_MANAGE_TRUSTS_REVIEW_INDIVIDUALS_URL);
 
@@ -132,7 +153,7 @@ describe('Update - Manage Trusts - Review individuals', () => {
 
   describe('POST tests', () => {
     test('when req body contains addIndividual (add button has been clicked), redirects to tell us about the individual with no id param', async () => {
-      mockIsActiveFeature.mockReturnValue(true);
+      mockIsActiveFeature.mockReturnValueOnce(true);
 
       const resp = await request(app)
         .post(UPDATE_MANAGE_TRUSTS_REVIEW_INDIVIDUALS_URL)
@@ -149,7 +170,7 @@ describe('Update - Manage Trusts - Review individuals', () => {
       mockIsActiveFeature.mockReturnValue(true);
       const appData = { entity_number: 'OE999876', entity_name: 'Test OE' };
 
-      mockGetApplicationData.mockReturnValue(appData);
+      mockGetApplicationData.mockReturnValueOnce(appData);
 
       const resp = await request(app).post(UPDATE_MANAGE_TRUSTS_REVIEW_INDIVIDUALS_URL);
 
@@ -162,7 +183,7 @@ describe('Update - Manage Trusts - Review individuals', () => {
     });
 
     test('when feature flag is off, 404 is returned', async () => {
-      mockIsActiveFeature.mockReturnValue(false);
+      mockIsActiveFeature.mockReturnValueOnce(false);
 
       const resp = await request(app).post(UPDATE_MANAGE_TRUSTS_REVIEW_INDIVIDUALS_URL);
 

--- a/test/utils/update/mocks.ts
+++ b/test/utils/update/mocks.ts
@@ -304,7 +304,7 @@ export const FETCH_INDIVIDUAL_TRUSTEE_DATA_MOCK: IndividualTrusteeData[] = [
     dateOfBirth: "1988-12-01",
     nationality: "German",
     corporateIndicator: "N",
-    trusteeTypeId: "5001",
+    trusteeTypeId: "5002",
     appointmentDate: "2022-01-01",
     usualResidentialAddress: {
       addressLine1: "Park lane",

--- a/test/utils/update/trust.model.fetch.spec.ts
+++ b/test/utils/update/trust.model.fetch.spec.ts
@@ -843,7 +843,7 @@ describe("Test fetching and mapping of Trust data", () => {
     trusteeData.trusteeTypeId = "5001";
     mapIndividualTrusteeData(trusteeData, trustMock);
     if (trustMock.INDIVIDUALS) {
-      expect(trustMock.INDIVIDUALS[0].type).toEqual(RoleWithinTrustType.BENEFICIAL_OWNER);
+      expect(trustMock.INDIVIDUALS[0].type).toEqual(undefined);
     } else {
       fail();
     }

--- a/test/utils/update/trust.model.fetch.spec.ts
+++ b/test/utils/update/trust.model.fetch.spec.ts
@@ -832,4 +832,57 @@ describe("Test fetching and mapping of Trust data", () => {
       fail();
     }
   });
+
+  test("mapTrusteeType should return correct role for the given trusteeTypeId", () => {
+
+    const trusteeData = {
+      hashedTrusteeId: "1",
+    } as unknown as IndividualTrusteeData;
+
+    trustMock.INDIVIDUALS = [];
+    trusteeData.trusteeTypeId = "5001";
+    mapIndividualTrusteeData(trusteeData, trustMock);
+    if (trustMock.INDIVIDUALS) {
+      expect(trustMock.INDIVIDUALS[0].type).toEqual(RoleWithinTrustType.BENEFICIAL_OWNER);
+    } else {
+      fail();
+    }
+
+    trustMock.INDIVIDUALS = [];
+    trusteeData.trusteeTypeId = "5002";
+    mapIndividualTrusteeData(trusteeData, trustMock);
+    if (trustMock.INDIVIDUALS) {
+      expect(trustMock.INDIVIDUALS[0].type).toEqual(RoleWithinTrustType.BENEFICIARY);
+    } else {
+      fail();
+    }
+
+    trustMock.INDIVIDUALS = [];
+    trusteeData.trusteeTypeId = "5003";
+    mapIndividualTrusteeData(trusteeData, trustMock);
+    if (trustMock.INDIVIDUALS) {
+      expect(trustMock.INDIVIDUALS[0].type).toEqual(RoleWithinTrustType.SETTLOR);
+    } else {
+      fail();
+    }
+
+    trustMock.INDIVIDUALS = [];
+    trusteeData.trusteeTypeId = "5004";
+    mapIndividualTrusteeData(trusteeData, trustMock);
+    if (trustMock.INDIVIDUALS) {
+      expect(trustMock.INDIVIDUALS[0].type).toEqual(RoleWithinTrustType.GRANTOR);
+    } else {
+      fail();
+    }
+
+    trustMock.INDIVIDUALS = [];
+    trusteeData.trusteeTypeId = "5005";
+    mapIndividualTrusteeData(trusteeData, trustMock);
+    if (trustMock.INDIVIDUALS) {
+      expect(trustMock.INDIVIDUALS[0].type).toEqual(RoleWithinTrustType.INTERESTED_PERSON);
+    } else {
+      fail();
+    }
+  });
+
 });

--- a/views/includes/trustee-macros.html
+++ b/views/includes/trustee-macros.html
@@ -1,13 +1,13 @@
 {% macro readableTrusteeRole(role) %}
-  {% if role === 'Beneficial_Owner' %}
+  {% if role === 'BENEFICIAL_OWNER' %}
     Beneficial Owner
-  {% elif role === 'Beneficiary' %}
+  {% elif role === 'BENEFICIARY' %}
     Beneficiary
-  {% elif role === 'Grantor' %}
+  {% elif role === 'GRANTOR' %}
     Grantor
-  {% elif role === 'Settlor' %}
+  {% elif role === 'SETTLOR' %}
     Settlor
-  {% elif role === 'Interested_Person' %}
+  {% elif role === 'INTERESTED_PERSON' %}
     Interested Person
   {% endif %}
 {% endmacro %}

--- a/views/includes/trustee-macros.html
+++ b/views/includes/trustee-macros.html
@@ -1,5 +1,7 @@
 {% macro readableTrusteeRole(role) %}
-  {% if role === 'Beneficiary' %}
+  {% if role === 'Beneficial_Owner' %}
+    Beneficial Owner
+  {% elif role === 'Beneficiary' %}
     Beneficiary
   {% elif role === 'Grantor' %}
     Grantor

--- a/views/includes/trustee-macros.html
+++ b/views/includes/trustee-macros.html
@@ -1,7 +1,5 @@
 {% macro readableTrusteeRole(role) %}
-  {% if role === 'BENEFICIAL_OWNER' %}
-    Beneficial Owner
-  {% elif role === 'BENEFICIARY' %}
+  {% if role === 'BENEFICIARY' %}
     Beneficiary
   {% elif role === 'GRANTOR' %}
     Grantor

--- a/views/update/update-manage-trusts-review-individuals.html
+++ b/views/update/update-manage-trusts-review-individuals.html
@@ -10,7 +10,7 @@
 
 {% for trustee in pageData.individuals %}
   {% set trusteeName = trustee.forename + ' ' + trustee.surname %}
-  {% set trusteeRole = trusteeMacros.readableTrusteeRole(trustee.type) %}
+  {% set trusteeRole = trusteeMacros.readableTrusteeRole(trustee.type | upper) %}
   {% set changeLink = OE_CONFIGS.UPDATE_MANAGE_TRUSTS_TELL_US_ABOUT_THE_INDIVIDUAL_URL + '/' + trustee.id %}
 
   {% set rows = (rows.push([

--- a/views/update/update-manage-trusts-review-legal-entities.html
+++ b/views/update/update-manage-trusts-review-legal-entities.html
@@ -21,7 +21,7 @@
         text: trustee.name
       },
       {
-        text: trusteeMacros.readableTrusteeRole(trustee.type)
+        text: trusteeMacros.readableTrusteeRole(trustee.type | upper)
       },
       {
         html: "<a href=" + changeLink + ">Change</a>",


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/UAR-1366

### Change description

Fix Part 1 -  Set mapping for trustee with trustee type id 5001 to be undefined rather than incorrectly map as Beneficiary. Ultimately a data fix will be required to prevent trustees with type 5001 mapped in the first place. 
Fix Part 2 - correct mapping for trustee types read from Mongo (for save and resume)

### Work checklist

- [x] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
