### PR TITLE
UAR-1289 Remove confirmation details for a change journey

### DIFF
--- a/test/controllers/update/confirmation.controller.spec.ts
+++ b/test/controllers/update/confirmation.controller.spec.ts
@@ -85,7 +85,7 @@ describe("UPDATE CONFIRMATION controller", () => {
     expect(mockDeleteApplicationData).toHaveBeenCalledTimes(1);
   });
 
-  test("renders the remove confirmation page", async () => {
+  test("renders the remove confirmation page for a 'no change' submission", async () => {
     mockGetApplicationData.mockReturnValue(
       { ...APPLICATION_DATA_REMOVE_MOCK }
     );
@@ -97,6 +97,38 @@ describe("UPDATE CONFIRMATION controller", () => {
     expect(resp.text).toContain(userMail);
     expect(resp.text).toContain(REMOVE_STATEMENT_TEXT);
     expect(resp.text).toContain(REMOVE_SURVEY_LINK);
+    expect(resp.text).toContain(UPDATE_STATEMENT_WHAT_HAPPENS_NEXT);
+
+    // This is a 'no change' scenario, so this text should not be output
+    expect(resp.text).not.toContain(UPDATE_STATEMENT_WHAT_TO_DO_NOW);
+    expect(resp.text).not.toContain(CONFIRMATION_AGENT_SPECIFIC_TEXT);
+
+    expect(mockGetApplicationData).toHaveBeenCalledTimes(2);
+    expect(mockDeleteApplicationData).toHaveBeenCalledTimes(1);
+  });
+
+  test("renders the remove confirmation page for a 'change' submission (no agent)", async () => {
+    mockGetApplicationData.mockReturnValue(
+      {
+        ...APPLICATION_DATA_REMOVE_MOCK,
+        who_is_registering: undefined,
+        update: { no_change: false }
+      }
+    );
+
+    const resp = await request(app).get(UPDATE_CONFIRMATION_URL);
+    expect(resp.status).toEqual(200);
+    expect(resp.text).toContain(REMOVE_SERVICE_NAME);
+    expect(resp.text).toContain(UPDATE_CONFIRMATION_PAGE_REFERENCE_NUMBER);
+    expect(resp.text).toContain(userMail);
+    expect(resp.text).toContain(REMOVE_STATEMENT_TEXT);
+    expect(resp.text).toContain(REMOVE_SURVEY_LINK);
+    expect(resp.text).toContain(UPDATE_STATEMENT_WHAT_HAPPENS_NEXT);
+
+    // This is a 'change' scenario, so this text should be output
+    expect(resp.text).toContain(UPDATE_STATEMENT_WHAT_TO_DO_NOW);
+    expect(resp.text).toContain(CONFIRMATION_AGENT_SPECIFIC_TEXT);
+
     expect(mockGetApplicationData).toHaveBeenCalledTimes(2);
     expect(mockDeleteApplicationData).toHaveBeenCalledTimes(1);
   });
@@ -127,7 +159,6 @@ describe("UPDATE CONFIRMATION controller", () => {
       {
         ...APPLICATION_DATA_MOCK,
         who_is_registering: undefined,
-
         update: { no_change: true }
       } );
     const resp = await request(app).get(UPDATE_CONFIRMATION_URL);

--- a/views/confirmation.html
+++ b/views/confirmation.html
@@ -53,11 +53,15 @@
           <p class="govuk-body">Once we have received the statement from the agent, we'll process the application as soon as possible. We'll email you to let you know if the update statement has been accepted or rejected. As this is a new service, we're not yet able to tell you exactly how long this will take.</p>
         {% endif %}
       {% elif isRemove %}
-        <p class="govuk-body">We'll process the application as soon as possible. This includes checking with all the UK land registries that the overseas entity is not currently listed as the registered owner of any property or land in the UK. As this is a new service, we're not able to tell you exactly how long this will take.</p>
+        {% if isAgentRegistering or noChange %}
+          <p class="govuk-body">We'll process the application as soon as possible. This includes checking with all the UK land registries that the overseas entity is not currently listed as the registered owner of any property or land in the UK. As this is a new service, we're not able to tell you exactly how long this will take.</p>
+        {% else %}
+          <p class="govuk-body">Once we have received the statement from the agent, we'll process the application as soon as possible. This includes checking with all the UK land registries that the overseas entity is not currently listed as the registered owner of any property or land in the UK. As this is a new service, we're not able to tell you exactly how long this will take.</p>
+        {% endif %}
 
-          <p class="govuk-body">Once we have processed the application, we'll email you to let you know if it has been accepted or rejected.</p>
+        <p class="govuk-body">Once we have processed the application, we'll email you to let you know if it has been accepted or rejected.</p>
 
-          <p class="govuk-body">If it is accepted, the overseas entity's status will change to 'De-registered'. Information about the entity and its beneficial owners will still be shown on the public register.</p>
+        <p class="govuk-body">If it is accepted, the overseas entity's status will change to 'De-registered'. Information about the entity and its beneficial owners will still be shown on the public register.</p>
       {% else %}
         <p class="govuk-body">We'll email you to let you know if your application to register an overseas entity has been accepted or rejected. We'll process the application as soon as possible. However, because this is a new service, we're not yet able to tell you exactly how long this will take.</p>
 


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/UAR-1289

### Change description

* If entity (not agent) details supplied, confirmation screen text now correct
* A new specific test added for this and some extra assertions added to an existing test

### Work checklist

- [X] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
