### PR TITLE
add matomo to tickbox on remove confirm statement page

### DIFF
--- a/views/update/remove/remove-confirm-statement.html
+++ b/views/update/remove/remove-confirm-statement.html
@@ -32,7 +32,10 @@
           items: [
             {
               value: "removal-declaration",
-              text: "I confirm that the overseas entity is not registered as the proprietor of a relevant interest in land. "
+              text: "I confirm that the overseas entity is not registered as the proprietor of a relevant interest in land. ",
+              attributes: {
+                "data-event-id": "confirm-oe-not-proprietor-of-land-tickbox"
+              }
             }
           ]
         })}}


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/UAR-1308

### Change description

Added data-event-id on the "I confirm that the overseas entity is not registered as the proprietor of a relevant interest in land." tickbox for matomo tracking 

Showing in matomo dashboard :

![Screenshot 2024-03-06 at 12 43 41 (2)](https://github.com/companieshouse/overseas-entities-web/assets/137518530/0cbaa91d-202d-4f88-8210-0253596f6dae)
