### PR TITLE
UAR-1425 filter out ceased bos on trust details screen

### DIFF
--- a/src/utils/trusts.ts
+++ b/src/utils/trusts.ts
@@ -158,14 +158,16 @@ const getBoIndividualAssignableToTrust = (
   appData: ApplicationData,
 ): BeneficialOwnerIndividual[] => {
   return (appData[BeneficialOwnerIndividualKey] ?? [])
-    .filter((bo: BeneficialOwnerOther) => bo.trustees_nature_of_control_types?.length);
+    .filter((bo: BeneficialOwnerIndividual) => bo.trustees_nature_of_control_types?.length)
+    .filter((bo: BeneficialOwnerIndividual) => Object.keys(bo.ceased_date || {}).length === 0);
 };
 
 const getBoOtherAssignableToTrust = (
   appData: ApplicationData,
 ): BeneficialOwnerOther[] => {
   return (appData[BeneficialOwnerOtherKey] ?? [])
-    .filter((bo: BeneficialOwnerOther) => bo.trustees_nature_of_control_types?.length);
+    .filter((bo: BeneficialOwnerOther) => bo.trustees_nature_of_control_types?.length)
+    .filter((bo: BeneficialOwnerOther) => Object.keys(bo.ceased_date || {}).length === 0);
 };
 
 const hasNoBoAssignableToTrust = (appData: ApplicationData): boolean => {

--- a/test/utils/trust.spec.ts
+++ b/test/utils/trust.spec.ts
@@ -73,7 +73,7 @@ describe('Trust Utils method tests', () => {
     id: '9002',
   } as BeneficialOwnerIndividual;
 
-  const mockBoIndividualCeasedWithTrusteeNoc = {
+  const mockBoCeasedIndividualWithTrusteeNoc = {
     id: '9003',
     trustees_nature_of_control_types: ['dummyType' as NatureOfControlType],
     trust_ids: [
@@ -98,7 +98,7 @@ describe('Trust Utils method tests', () => {
     ],
   } as BeneficialOwnerOther;
 
-  const mockBoOleCeasedWithTrusteeNoc = {
+  const mockBoCeasedOleWithTrusteeNoc = {
     id: '8003',
     trustees_nature_of_control_types: ['dummyType' as NatureOfControlType],
     trust_ids: [
@@ -138,7 +138,7 @@ describe('Trust Utils method tests', () => {
     const mockAppDataWithACeasedIndividualBO = {
       ...mockAppData
     };
-    mockAppDataWithACeasedIndividualBO[BeneficialOwnerIndividualKey].push(mockBoIndividualCeasedWithTrusteeNoc);
+    mockAppDataWithACeasedIndividualBO[BeneficialOwnerIndividualKey].push(mockBoCeasedIndividualWithTrusteeNoc);
 
     expect(getBoIndividualAssignableToTrust(mockAppDataWithACeasedIndividualBO)).toEqual([mockBoIndividual1]);
   });
@@ -151,7 +151,7 @@ describe('Trust Utils method tests', () => {
     const mockAppDataWithACeasedOtherBO = {
       ...mockAppData
     };
-    mockAppDataWithACeasedOtherBO[BeneficialOwnerOtherKey].push(mockBoOleCeasedWithTrusteeNoc);
+    mockAppDataWithACeasedOtherBO[BeneficialOwnerOtherKey].push(mockBoCeasedOleWithTrusteeNoc);
 
     expect(getBoOtherAssignableToTrust(mockAppDataWithACeasedOtherBO)).toEqual([mockBoOle2]);
   });

--- a/test/utils/trust.spec.ts
+++ b/test/utils/trust.spec.ts
@@ -140,7 +140,7 @@ describe('Trust Utils method tests', () => {
     };
     mockAppDataWithACeasedIndividualBO[BeneficialOwnerIndividualKey].push(mockBoIndividualCeasedWithTrusteeNoc);
 
-    expect(getBoIndividualAssignableToTrust(mockAppData)).toEqual([mockBoIndividual1]);
+    expect(getBoIndividualAssignableToTrust(mockAppDataWithACeasedIndividualBO)).toEqual([mockBoIndividual1]);
   });
 
   test('test get Bo other legal assigned to trust', () => {
@@ -153,7 +153,7 @@ describe('Trust Utils method tests', () => {
     };
     mockAppDataWithACeasedOtherBO[BeneficialOwnerOtherKey].push(mockBoOleCeasedWithTrusteeNoc);
 
-    expect(getBoOtherAssignableToTrust(mockAppData)).toEqual([mockBoOle2]);
+    expect(getBoOtherAssignableToTrust(mockAppDataWithACeasedOtherBO)).toEqual([mockBoOle2]);
   });
 
   test('test get Bo other legal assigned to trust', () => {

--- a/test/utils/trust.spec.ts
+++ b/test/utils/trust.spec.ts
@@ -73,6 +73,19 @@ describe('Trust Utils method tests', () => {
     id: '9002',
   } as BeneficialOwnerIndividual;
 
+  const mockBoIndividualCeasedWithTrusteeNoc = {
+    id: '9003',
+    trustees_nature_of_control_types: ['dummyType' as NatureOfControlType],
+    trust_ids: [
+      trustId,
+    ],
+    ceased_date: {
+      day: "1",
+      month: "2",
+      year: "2020"
+    }
+  } as BeneficialOwnerIndividual;
+
   const mockBoOle1 = {
     id: '8001',
   } as BeneficialOwnerOther;
@@ -83,6 +96,19 @@ describe('Trust Utils method tests', () => {
     trust_ids: [
       trustId,
     ],
+  } as BeneficialOwnerOther;
+
+  const mockBoOleCeasedWithTrusteeNoc = {
+    id: '8003',
+    trustees_nature_of_control_types: ['dummyType' as NatureOfControlType],
+    trust_ids: [
+      trustId,
+    ],
+    ceased_date: {
+      day: "1",
+      month: "2",
+      year: "2020"
+    }
   } as BeneficialOwnerOther;
 
   let mockAppData = {};
@@ -109,6 +135,11 @@ describe('Trust Utils method tests', () => {
   });
 
   test('test get Bo Individuals assignable to Trust', () => {
+    const mockAppDataWithACeasedIndividualBO = {
+      ...mockAppData
+    };
+    mockAppDataWithACeasedIndividualBO[BeneficialOwnerIndividualKey].push(mockBoIndividualCeasedWithTrusteeNoc);
+
     expect(getBoIndividualAssignableToTrust(mockAppData)).toEqual([mockBoIndividual1]);
   });
 
@@ -117,6 +148,11 @@ describe('Trust Utils method tests', () => {
   });
 
   test('test get Bo other legal assignable to Trust', () => {
+    const mockAppDataWithACeasedOtherBO = {
+      ...mockAppData
+    };
+    mockAppDataWithACeasedOtherBO[BeneficialOwnerOtherKey].push(mockBoOleCeasedWithTrusteeNoc);
+
     expect(getBoOtherAssignableToTrust(mockAppData)).toEqual([mockBoOle2]);
   });
 


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/UAR-1425


### Change description
Needed to exclude ceased BOs from the list of BOs that are assignable to trusts, so they don't appear in the checkbox list on the trust details screen


### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
