### PR TITLE
UAR-1468 Fix isRemoveJourney logic to handle >1 journey url query params

### DIFF
--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -42,7 +42,11 @@ export const isRemoveJourney = (req: Request): boolean => {
     return true;
   }
 
-  return req.query[config.JOURNEY_QUERY_PARAM] === config.JourneyType.remove;
+  // if there are multiple journey query params in the url, the values will be comma separated eg remove,remove if there are 2 journey=remove in the url
+  // split(",") will convert to an array, if there is only 1 value it will be array of 1, if no journey param, it will be empty array etc.
+  // Then we can check if array contains 'remove'
+  const journeyQueryParam: string = req.query[config.JOURNEY_QUERY_PARAM]?.toString() ?? "";
+  return journeyQueryParam.split(",").includes(config.JourneyType.remove);
 };
 
 export function getPreviousPageUrl(req: Request, basePath: string) {

--- a/test/utils/url.spec.ts
+++ b/test/utils/url.spec.ts
@@ -80,11 +80,15 @@ describe("Url utils tests", () => {
 
   describe("isRemoveJourney tests", () => {
 
-    test("returns true if app data not present in session and query param journey=remove", () => {
+    test.each([
+      ['journey=remove', 'remove'],
+      ['journey=remove&journey=remove', 'remove,remove'],
+      ['journey=remove&journey=update', 'remove,update']
+    ])("returns true if app data not present in session and query param %s", (_description, reqQueryValue) => {
       mockGetApplicationData.mockReturnValueOnce(undefined);
 
       req["query"] = {
-        "journey": "remove"
+        "journey": reqQueryValue
       };
 
       const result = urlUtils.isRemoveJourney(req);
@@ -164,9 +168,12 @@ describe("Url utils tests", () => {
       expect(result).toBeFalsy();
     });
 
-    test("returns false if query param journey is a string other than remove", () => {
+    test.each([
+      ["update"],
+      ["removes"]
+    ])("returns false if query param journey is a string other than remove - %s", (journeyQueryParamValue) => {
       req["query"] = {
-        "journey": "update"
+        "journey": journeyQueryParamValue
       };
       const result = urlUtils.isRemoveJourney(req);
 


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/UAR-1468


### Change description
If there were > 1 journey=remove params in the url query, and no /remove/ in the url then isRemoveJourney() function would return false, which is incorrect.
Changing the function to handle multiple journey params (if there are multiple they get stored as comma separated values under 'journey' in the req.query object)
The function will now return true if there is at least 1 journey=remove in the url query params 


### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
