### PR TITLE
UAR-1287 add correct backlink and test for check-your-answers page

### DIFF
--- a/src/utils/check.your.answers.ts
+++ b/src/utils/check.your.answers.ts
@@ -154,7 +154,11 @@ const getBackLinkUrl = (isNoChangeJourney: boolean, hasAnyBosWithTrusteeNocs: bo
   } else {
     let backLinkUrl: string;
     backLinkUrl = (isActiveFeature(FEATURE_FLAG_ENABLE_UPDATE_TRUSTS) && hasAnyBosWithTrusteeNocs) ? UPDATE_TRUSTS_ASSOCIATED_WITH_THE_OVERSEAS_ENTITY_URL : UPDATE_BENEFICIAL_OWNER_TYPE_URL;
-    backLinkUrl = isActiveFeature(FEATURE_FLAG_ENABLE_UPDATE_STATEMENT_VALIDATION) ? UPDATE_REGISTRABLE_BENEFICIAL_OWNER_URL : backLinkUrl;
+    if (isRemove) {
+      backLinkUrl = isActiveFeature(FEATURE_FLAG_ENABLE_UPDATE_STATEMENT_VALIDATION) ? REMOVE_CONFIRM_STATEMENT_URL : backLinkUrl;
+    } else {
+      backLinkUrl = isActiveFeature(FEATURE_FLAG_ENABLE_UPDATE_STATEMENT_VALIDATION) ? UPDATE_REGISTRABLE_BENEFICIAL_OWNER_URL : backLinkUrl;
+    }
     return backLinkUrl;
   }
 };

--- a/test/__mocks__/text.mock.ts
+++ b/test/__mocks__/text.mock.ts
@@ -269,6 +269,7 @@ export const REMOVE_STATEMENT_DECLARATION = "I confirm that the overseas entity 
 export const REMOVE_SOLD_ALL_LAND_CHANGE_LINK = "/update-an-overseas-entity/remove/remove-sold-all-land-filter";
 export const REMOVE_IS_OE_REGISTERED_OWNER_CHANGE_LINK = "/update-an-overseas-entity/remove/remove-is-entity-registered-owner";
 export const REMOVE_SECURE_REGISTER_CHANGE_LINK = "/update-an-overseas-entity/secure-update-filter";
+export const REMOVE_CHECK_YOUR_ANSWERS_BACK_LINK = "/update-an-overseas-entity/remove/remove-confirm-statement";
 
 // Manage Trusts
 export const UPDATE_MANAGE_TRUSTS_REVIEW_FORMER_BO_TITLE = "Review former beneficial owners";

--- a/test/controllers/update/check.your.answers.controller.spec.ts
+++ b/test/controllers/update/check.your.answers.controller.spec.ts
@@ -72,6 +72,7 @@ import {
   REMOVE_SOLD_ALL_LAND_CHANGE_LINK,
   REMOVE_IS_OE_REGISTERED_OWNER_CHANGE_LINK,
   REMOVE_SECURE_REGISTER_CHANGE_LINK,
+  REMOVE_CHECK_YOUR_ANSWERS_BACK_LINK,
 } from "../../__mocks__/text.mock";
 import {
   ERROR,
@@ -460,6 +461,7 @@ describe("CHECK YOUR ANSWERS controller", () => {
       expect(resp.text).toContain(REMOVE_SECURE_REGISTER_CHANGE_LINK);
       expect(resp.text).toContain(OVERSEAS_NAME_MOCK);
       expect(resp.text).toContain(COMPANY_NUMBER);
+      expect(resp.text).toContain(REMOVE_CHECK_YOUR_ANSWERS_BACK_LINK);
 
     });
 


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/UAR-1287

### Change description

As part of UAR-1287 the backlink needed to go to remove-confirm-statement. This was missed but added in this new branch.
Test also added for backlink

### Work checklist

- [x] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
