### PR TITLE
Uar 1500 amend check your answers and review update statement pages

### DIFF
--- a/test/__mocks__/text.mock.ts
+++ b/test/__mocks__/text.mock.ts
@@ -272,6 +272,9 @@ export const REMOVE_SECURE_REGISTER_CHANGE_LINK = "/update-an-overseas-entity/se
 export const REMOVE_CHECK_YOUR_ANSWERS_BACK_LINK = "/update-an-overseas-entity/remove/remove-confirm-statement";
 export const BEFORE_START_PAGE_LINK_AUTHENTICATION = "https://www.gov.uk/guidance/remove-an-overseas-entity#how-to-get-an-authentication-code";
 export const BEFORE_START_PAGE_LINK_VERIFICATION = "https://www.gov.uk/guidance/remove-an-overseas-entity#verify";
+export const REMOVE_WHAT_IS_RELEVANT_PROPERTY_OR_LAND_TEXT = "What does 'relevant property or land' mean?";
+export const REMOVE_RELEVANT_PROPERTY_OR_LAND_DEFINED_TEXT = "This means property or land in the UK that was bought on or after:";
+export const REMOVE_PROPERTY_BOUGHT_ON_OR_AFTER_DATE_TEXT = "1 January 1999 in England and Wales";
 
 // Manage Trusts
 export const UPDATE_MANAGE_TRUSTS_REVIEW_FORMER_BO_TITLE = "Review former beneficial owners";

--- a/test/__mocks__/text.mock.ts
+++ b/test/__mocks__/text.mock.ts
@@ -252,8 +252,7 @@ export const UPDATE_TRUSTS_ASSOCIATED_ADDED_HEADING = "What you have added so fa
 export const UPDATE_MANAGE_TRUSTS_REVIEWED_HEADING = "What you have reviewed";
 
 // Remove journey
-export const REMOVE_SOLD_ALL_LAND_FILTER_PAGE_TITLE = "Has the overseas entity disposed of all its property or land in the UK?";
-export const REMOVE_NEW_SOLD_ALL_LAND_FILTER_PAGE_TITLE = "Has the overseas entity disposed of all relevant property or land in the UK?";
+export const REMOVE_SOLD_ALL_LAND_FILTER_PAGE_TITLE = "Has the overseas entity disposed of all relevant property or land in the UK?";
 export const REMOVE_IS_ENTITY_REGISTERED_OWNER_TITLE = "Is the overseas entity currently listed on any land registry records as the registered owner of property or land in the UK?";
 export const REMOVE_INTERRUPT_CARD_TEXT = "Once an overseas entity is removed";
 export const REMOVE_USE_INFORMATION_NEED_MORE = "We’ll use this if we need more information about the application.";

--- a/test/controllers/update/remove.sold.all.land.filter.controller.spec.ts
+++ b/test/controllers/update/remove.sold.all.land.filter.controller.spec.ts
@@ -18,7 +18,10 @@ import {
   ANY_MESSAGE_ERROR,
   FOUND_REDIRECT_TO,
   PAGE_TITLE_ERROR,
+  REMOVE_PROPERTY_BOUGHT_ON_OR_AFTER_DATE_TEXT,
+  REMOVE_RELEVANT_PROPERTY_OR_LAND_DEFINED_TEXT,
   REMOVE_SOLD_ALL_LAND_FILTER_PAGE_TITLE,
+  REMOVE_WHAT_IS_RELEVANT_PROPERTY_OR_LAND_TEXT,
   SERVICE_UNAVAILABLE,
 } from "../../__mocks__/text.mock";
 import { serviceAvailabilityMiddleware } from "../../../src/middleware/service.availability.middleware";
@@ -61,9 +64,9 @@ describe("Remove sold all land filter controller", () => {
       expect(resp.text).toContain(REMOVE_SOLD_ALL_LAND_FILTER_PAGE_TITLE);
       expect(resp.text).toContain(REMOVE_SERVICE_NAME);
       expect(resp.text).not.toContain(PAGE_TITLE_ERROR);
-      expect(resp.text).toContain("What does 'relevant property or land' mean?");
-      expect(resp.text).toContain("This means property or land in the UK that was bought on or after:");
-      expect(resp.text).toContain("1 January 1999 in England and Wales");
+      expect(resp.text).toContain(REMOVE_WHAT_IS_RELEVANT_PROPERTY_OR_LAND_TEXT);
+      expect(resp.text).toContain(REMOVE_RELEVANT_PROPERTY_OR_LAND_DEFINED_TEXT);
+      expect(resp.text).toContain(REMOVE_PROPERTY_BOUGHT_ON_OR_AFTER_DATE_TEXT);
       expect(resp.text).toContain(`${config.UPDATE_AN_OVERSEAS_ENTITY_URL}sign-out?page=${config.REMOVE_SOLD_ALL_LAND_FILTER_PAGE}&amp;${config.JOURNEY_QUERY_PARAM}=${config.JourneyType.remove}`);
       expect(mockLoggerDebugRequest).toHaveBeenCalledTimes(1);
       expect(mockGetApplicationData).toHaveBeenCalledTimes(1);
@@ -77,9 +80,9 @@ describe("Remove sold all land filter controller", () => {
       expect(resp.text).toContain(REMOVE_SOLD_ALL_LAND_FILTER_PAGE_TITLE);
       expect(resp.text).toContain(REMOVE_SERVICE_NAME);
       expect(resp.text).not.toContain(PAGE_TITLE_ERROR);
-      expect(resp.text).toContain("What does 'relevant property or land' mean?");
-      expect(resp.text).toContain("This means property or land in the UK that was bought on or after:");
-      expect(resp.text).toContain("1 January 1999 in England and Wales");
+      expect(resp.text).toContain(REMOVE_WHAT_IS_RELEVANT_PROPERTY_OR_LAND_TEXT);
+      expect(resp.text).toContain(REMOVE_RELEVANT_PROPERTY_OR_LAND_DEFINED_TEXT);
+      expect(resp.text).toContain(REMOVE_PROPERTY_BOUGHT_ON_OR_AFTER_DATE_TEXT);
       expect(resp.text).toContain("value=\"1\" checked");
       expect(mockLoggerDebugRequest).toHaveBeenCalledTimes(1);
       expect(mockGetApplicationData).toHaveBeenCalledTimes(1);

--- a/test/controllers/update/remove.sold.all.land.filter.controller.spec.ts
+++ b/test/controllers/update/remove.sold.all.land.filter.controller.spec.ts
@@ -18,7 +18,7 @@ import {
   ANY_MESSAGE_ERROR,
   FOUND_REDIRECT_TO,
   PAGE_TITLE_ERROR,
-  REMOVE_NEW_SOLD_ALL_LAND_FILTER_PAGE_TITLE,
+  REMOVE_SOLD_ALL_LAND_FILTER_PAGE_TITLE,
   SERVICE_UNAVAILABLE,
 } from "../../__mocks__/text.mock";
 import { serviceAvailabilityMiddleware } from "../../../src/middleware/service.availability.middleware";
@@ -58,7 +58,7 @@ describe("Remove sold all land filter controller", () => {
       const resp = await request(app).get(`${config.REMOVE_SOLD_ALL_LAND_FILTER_URL}${config.JOURNEY_REMOVE_QUERY_PARAM}`);
 
       expect(resp.status).toEqual(200);
-      expect(resp.text).toContain(REMOVE_NEW_SOLD_ALL_LAND_FILTER_PAGE_TITLE);
+      expect(resp.text).toContain(REMOVE_SOLD_ALL_LAND_FILTER_PAGE_TITLE);
       expect(resp.text).toContain(REMOVE_SERVICE_NAME);
       expect(resp.text).not.toContain(PAGE_TITLE_ERROR);
       expect(resp.text).toContain("What does 'relevant property or land' mean?");
@@ -74,7 +74,7 @@ describe("Remove sold all land filter controller", () => {
       const resp = await request(app).get(`${config.REMOVE_SOLD_ALL_LAND_FILTER_URL}${config.JOURNEY_REMOVE_QUERY_PARAM}`);
 
       expect(resp.status).toEqual(200);
-      expect(resp.text).toContain(REMOVE_NEW_SOLD_ALL_LAND_FILTER_PAGE_TITLE);
+      expect(resp.text).toContain(REMOVE_SOLD_ALL_LAND_FILTER_PAGE_TITLE);
       expect(resp.text).toContain(REMOVE_SERVICE_NAME);
       expect(resp.text).not.toContain(PAGE_TITLE_ERROR);
       expect(resp.text).toContain("What does 'relevant property or land' mean?");
@@ -132,7 +132,7 @@ describe("Remove sold all land filter controller", () => {
       const resp = await request(app).post(`${config.REMOVE_SOLD_ALL_LAND_FILTER_URL}${config.JOURNEY_REMOVE_QUERY_PARAM}`);
 
       expect(resp.status).toEqual(200);
-      expect(resp.text).toContain(REMOVE_NEW_SOLD_ALL_LAND_FILTER_PAGE_TITLE);
+      expect(resp.text).toContain(REMOVE_SOLD_ALL_LAND_FILTER_PAGE_TITLE);
       expect(resp.text).toContain(PAGE_TITLE_ERROR);
       expect(resp.text).toContain(ErrorMessages.SELECT_IF_REMOVE_SOLD_ALL_LAND_FILTER);
       expect(resp.text).toContain(REMOVE_SERVICE_NAME);

--- a/views/update/review-update-statement.html
+++ b/views/update/review-update-statement.html
@@ -108,7 +108,7 @@
         rows: [
           {
             key: {
-              text: "Has the overseas entity disposed of all its property or land in the UK?"
+              text: "Has the overseas entity disposed of all relevant property or land in the UK?"
             },
             value: {
               text: hasSoldAllLand

--- a/views/update/update-check-your-answers.html
+++ b/views/update/update-check-your-answers.html
@@ -68,7 +68,7 @@
           rows: [
             {
               key: {
-                text: "Has the overseas entity disposed of all its property or land in the UK?"
+                text: "Has the overseas entity disposed of all relevant property or land in the UK?"
               },
               value: {
                 text: hasSoldAllLand


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/UAR-1500

### Change description

Branched off UAR-1470

REMOVE_SOLD_ALL_LAND_FILTER_PAGE_TITLE = "Has the overseas entity disposed of all relevant property or land in the UK?"

The headings on check-your-answers and review-update-statement pages now reflect the above

Previous amendments in UAR-1470 have been rectified by removing REMOVE_NEW_SOLD_ALL_LAND_FILTER_PAGE_TITLE.

Parent branch tests have been modified to use const instead of text.

### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
