### PR TITLE
UAR-1504 Add info for update statement date to update-filing-date page

### DIFF
--- a/src/controllers/update/update.filing.date.controller.ts
+++ b/src/controllers/update/update.filing.date.controller.ts
@@ -21,7 +21,7 @@ export const get = (req: Request, res: Response, next: NextFunction) => {
     return res.render(config.UPDATE_FILING_DATE_PAGE, {
       backLinkUrl: config.UPDATE_OVERSEAS_ENTITY_CONFIRM_URL,
       templateName: config.UPDATE_FILING_DATE_PAGE,
-      chsUrl: process.env.CHS_URL,
+      chsUrl: config.CHS_URL,
       ...appData,
       [FilingDateKey]: filingDate
     });

--- a/src/controllers/update/update.filing.date.controller.ts
+++ b/src/controllers/update/update.filing.date.controller.ts
@@ -21,6 +21,7 @@ export const get = (req: Request, res: Response, next: NextFunction) => {
     return res.render(config.UPDATE_FILING_DATE_PAGE, {
       backLinkUrl: config.UPDATE_OVERSEAS_ENTITY_CONFIRM_URL,
       templateName: config.UPDATE_FILING_DATE_PAGE,
+      chsUrl: process.env.CHS_URL,
       ...appData,
       [FilingDateKey]: filingDate
     });

--- a/test/__mocks__/text.mock.ts
+++ b/test/__mocks__/text.mock.ts
@@ -250,7 +250,7 @@ export const UPDATE_TRUSTS_ASSOCIATED_BACK_LINK = "/update-an-overseas-entity/up
 export const HOME_ADDRESS_LINE1 = "addressLine1";
 export const UPDATE_TRUSTS_ASSOCIATED_ADDED_HEADING = "What you have added so far";
 export const UPDATE_MANAGE_TRUSTS_REVIEWED_HEADING = "What you have reviewed";
-export const UPDATE_DATE_OF_UPDATE_STATEMENT_TEXT = "The date you enter must be on or before the overseas entity's update statement date";
+export const UPDATE_DATE_OF_UPDATE_STATEMENT_TEXT = "You can find the update statement date by searching for the entity on the";
 
 // Remove journey
 export const REMOVE_SOLD_ALL_LAND_FILTER_PAGE_TITLE = "Has the overseas entity disposed of all its property or land in the UK?";

--- a/test/__mocks__/text.mock.ts
+++ b/test/__mocks__/text.mock.ts
@@ -250,6 +250,7 @@ export const UPDATE_TRUSTS_ASSOCIATED_BACK_LINK = "/update-an-overseas-entity/up
 export const HOME_ADDRESS_LINE1 = "addressLine1";
 export const UPDATE_TRUSTS_ASSOCIATED_ADDED_HEADING = "What you have added so far";
 export const UPDATE_MANAGE_TRUSTS_REVIEWED_HEADING = "What you have reviewed";
+export const UPDATE_DATE_OF_UPDATE_STATEMENT_TEXT = "The date you enter must be on or before the overseas entity's update statement date";
 
 // Remove journey
 export const REMOVE_SOLD_ALL_LAND_FILTER_PAGE_TITLE = "Has the overseas entity disposed of all its property or land in the UK?";

--- a/test/controllers/update/update.filing.date.controller.spec.ts
+++ b/test/controllers/update/update.filing.date.controller.spec.ts
@@ -94,7 +94,7 @@ describe("Update Filing Date controller", () => {
       expect(resp.text).toContain(BACK_LINK_FOR_UPDATE_FILING_DATE);
       expect(resp.text).toContain(saveAndContinueButtonText);
       expect(resp.text).not.toContain(PAGE_TITLE_ERROR);
-      expect(resp.text).not.toContain(UPDATE_DATE_OF_UPDATE_STATEMENT_TEXT);
+      expect(resp.text).toContain(UPDATE_DATE_OF_UPDATE_STATEMENT_TEXT);
       expect(resp.text).toContain('href="test"');
     });
 
@@ -109,7 +109,7 @@ describe("Update Filing Date controller", () => {
       expect(resp.text).toContain(BACK_LINK_FOR_UPDATE_FILING_DATE);
       expect(resp.text).toContain(saveAndContinueButtonText);
       expect(resp.text).not.toContain(PAGE_TITLE_ERROR);
-      expect(resp.text).not.toContain(UPDATE_DATE_OF_UPDATE_STATEMENT_TEXT);
+      expect(resp.text).toContain(UPDATE_DATE_OF_UPDATE_STATEMENT_TEXT);
       expect(resp.text).toContain('href="test"');
     });
 
@@ -124,7 +124,7 @@ describe("Update Filing Date controller", () => {
       expect(resp.text).toContain(BACK_LINK_FOR_UPDATE_FILING_DATE);
       expect(resp.text).toContain(saveAndContinueButtonText);
       expect(resp.text).not.toContain(PAGE_TITLE_ERROR);
-      expect(resp.text).not.toContain(UPDATE_DATE_OF_UPDATE_STATEMENT_TEXT);
+      expect(resp.text).toContain(UPDATE_DATE_OF_UPDATE_STATEMENT_TEXT);
       expect(resp.text).toContain('href="test"');
     });
 
@@ -139,7 +139,7 @@ describe("Update Filing Date controller", () => {
       expect(resp.text).toContain(BACK_LINK_FOR_UPDATE_FILING_DATE);
       expect(resp.text).toContain(saveAndContinueButtonText);
       expect(resp.text).not.toContain(PAGE_TITLE_ERROR);
-      expect(resp.text).not.toContain(UPDATE_DATE_OF_UPDATE_STATEMENT_TEXT);
+      expect(resp.text).toContain(UPDATE_DATE_OF_UPDATE_STATEMENT_TEXT);
       expect(resp.text).toContain('href="test"');
     });
 

--- a/test/controllers/update/update.filing.date.controller.spec.ts
+++ b/test/controllers/update/update.filing.date.controller.spec.ts
@@ -41,6 +41,7 @@ import {
   FOUND_REDIRECT_TO,
   PAGE_TITLE_ERROR,
   SERVICE_UNAVAILABLE,
+  UPDATE_DATE_OF_UPDATE_STATEMENT_TEXT,
 } from "../../__mocks__/text.mock";
 
 import { FILING_DATE_REQ_BODY_MOCK } from '../../__mocks__/fields/date.mock';
@@ -93,6 +94,8 @@ describe("Update Filing Date controller", () => {
       expect(resp.text).toContain(BACK_LINK_FOR_UPDATE_FILING_DATE);
       expect(resp.text).toContain(saveAndContinueButtonText);
       expect(resp.text).not.toContain(PAGE_TITLE_ERROR);
+      expect(resp.text).not.toContain(UPDATE_DATE_OF_UPDATE_STATEMENT_TEXT);
+      expect(resp.text).toContain('href="test"');
     });
 
     test('renders the update-filing-date page with no update session data', async () => {
@@ -106,6 +109,8 @@ describe("Update Filing Date controller", () => {
       expect(resp.text).toContain(BACK_LINK_FOR_UPDATE_FILING_DATE);
       expect(resp.text).toContain(saveAndContinueButtonText);
       expect(resp.text).not.toContain(PAGE_TITLE_ERROR);
+      expect(resp.text).not.toContain(UPDATE_DATE_OF_UPDATE_STATEMENT_TEXT);
+      expect(resp.text).toContain('href="test"');
     });
 
     test('renders the update-filing-date page with update session data', async () => {
@@ -119,6 +124,8 @@ describe("Update Filing Date controller", () => {
       expect(resp.text).toContain(BACK_LINK_FOR_UPDATE_FILING_DATE);
       expect(resp.text).toContain(saveAndContinueButtonText);
       expect(resp.text).not.toContain(PAGE_TITLE_ERROR);
+      expect(resp.text).not.toContain(UPDATE_DATE_OF_UPDATE_STATEMENT_TEXT);
+      expect(resp.text).toContain('href="test"');
     });
 
     test('does not fetch private overseas entity data to app data if already exists', async () => {
@@ -132,6 +139,8 @@ describe("Update Filing Date controller", () => {
       expect(resp.text).toContain(BACK_LINK_FOR_UPDATE_FILING_DATE);
       expect(resp.text).toContain(saveAndContinueButtonText);
       expect(resp.text).not.toContain(PAGE_TITLE_ERROR);
+      expect(resp.text).not.toContain(UPDATE_DATE_OF_UPDATE_STATEMENT_TEXT);
+      expect(resp.text).toContain('href="test"');
     });
 
     test('catch error when rendering the page', async () => {

--- a/views/update/update-filing-date.html
+++ b/views/update/update-filing-date.html
@@ -23,8 +23,7 @@
 
       <div class="govuk-inset-text">
         <p>The date you enter <b>must be on or before the overseas entity's update statement date, </b>or your filing may be rejected.</p>
-        <p>You can find the update statement date by searching for the entity on the <a class="govuk-link" target="_blank"
-            rel="noopener" href="{{ chsUrl }}">Companies House register (opens in a new tab)</a></p>
+        <p>You can find the update statement date by searching for the entity on the <a class="govuk-link" target="_blank" rel="noopener" href="{{ chsUrl }}">Companies House register (opens in a new tab).</a></p>
       </div>
 
       {% set filingDateLabelText = "What is the date of the update statement for this period?" %}

--- a/views/update/update-filing-date.html
+++ b/views/update/update-filing-date.html
@@ -22,7 +22,7 @@
       Verification checks must be completed no more than 3 months before the statement date.</p>
 
       <div class="govuk-inset-text">
-        <p>The date you enter <strong> must be on or before the overseas entity's update statement date, </strong> or your filing may be rejected.</p>
+        <p>The date you enter <strong>must be on or before the overseas entity's update statement date,</strong> or your filing may be rejected.</p>
         <p>You can find the update statement date by searching for the entity on the <a class="govuk-link" target="_blank" rel="noopener" href="{{ chsUrl }}">Companies House register (opens in a new tab).</a></p>
       </div>
 

--- a/views/update/update-filing-date.html
+++ b/views/update/update-filing-date.html
@@ -22,7 +22,7 @@
       Verification checks must be completed no more than 3 months before the statement date.</p>
 
       <div class="govuk-inset-text">
-        <p>The date you enter <b>must be on or before the overseas entity's update statement date, </b>or your filing may be rejected.</p>
+        <p>The date you enter <strong>must be on or before the overseas entity's update statement date, </strong>or your filing may be rejected.</p>
         <p>You can find the update statement date by searching for the entity on the <a class="govuk-link" target="_blank" rel="noopener" href="{{ chsUrl }}">Companies House register (opens in a new tab).</a></p>
       </div>
 

--- a/views/update/update-filing-date.html
+++ b/views/update/update-filing-date.html
@@ -23,8 +23,8 @@
 
       <div class="govuk-inset-text">
         <p>The date you enter <b>must be on or before the overseas entity's update statement date, </b>or your filing may be rejected.</p>
-        <p>You can find the update statement date by searching for the entity on the <a class="govuk-link" target="_blank" rel="noopener" 
-          href="{{ chsUrl }}">Companies House register (opens in a new tab)</a></p>
+        <p>You can find the update statement date by searching for the entity on the <a class="govuk-link" target="_blank"
+            rel="noopener" href="{{ chsUrl }}">Companies House register (opens in a new tab)</a></p>
       </div>
 
       {% set filingDateLabelText = "What is the date of the update statement for this period?" %}

--- a/views/update/update-filing-date.html
+++ b/views/update/update-filing-date.html
@@ -22,7 +22,7 @@
       Verification checks must be completed no more than 3 months before the statement date.</p>
 
       <div class="govuk-inset-text">
-        <p>The date you enter <strong>must be on or before the overseas entity's update statement date, </strong>or your filing may be rejected.</p>
+        <p>The date you enter <strong> must be on or before the overseas entity's update statement date, </strong> or your filing may be rejected.</p>
         <p>You can find the update statement date by searching for the entity on the <a class="govuk-link" target="_blank" rel="noopener" href="{{ chsUrl }}">Companies House register (opens in a new tab).</a></p>
       </div>
 

--- a/views/update/update-filing-date.html
+++ b/views/update/update-filing-date.html
@@ -20,7 +20,14 @@
     <form method="post">
       <p class="govuk-body">All the information in this update statement must be correct on this date.
       Verification checks must be completed no more than 3 months before the statement date.</p>
-      {% set filingDateLabelText = "What is the date of the update statement?" %}
+
+      <div class="govuk-inset-text">
+        <p>The date you enter <b>must be on or before the overseas entity's update statement date, </b>or your filing may be rejected.</p>
+        <p>You can find the update statement date by searching for the entity on the <a class="govuk-link" target="_blank" rel="noopener" 
+          href="{{ chsUrl }}">Companies House register (opens in a new tab)</a></p>
+      </div>
+
+      {% set filingDateLabelText = "What is the date of the update statement for this period?" %}
       {% include "includes/inputs/date/filing-date-input.html" %}
       {% include "includes/save-and-continue-button.html" %}
     </form>


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/UAR-1504


### Change description

Added an inset text component from GOV.UK components https://design-system.service.gov.uk/components/inset-text/
Used config.CHS_URL instead of hardcoding the URL.
Added tests to check for some text and a url.

![Screenshot 2024-04-30 at 16 05 33](https://github.com/companieshouse/overseas-entities-web/assets/137518530/66f1a6c8-4ce3-4f83-8606-338004f922e6)

### Work checklist

- [x] Tests added where applicable
- [x] UI changes meet accessibility criteria