### PR TITLE
UAR-1502 Make 'property name or number' field optional

### DIFF
--- a/src/validation/custom.validation.ts
+++ b/src/validation/custom.validation.ts
@@ -630,6 +630,29 @@ export const validateEmail = (email: string, maxLength: number) => {
   return true;
 };
 
+export const checkPropertyNameOrNumberIfRadioButtonSelected = (selected: boolean, propertyNameOrNumber: string, req) => {
+  if (selected) {
+    return checkPresenceOfPropertyNameOrNumber(propertyNameOrNumber, req);
+  }
+
+  return true;
+};
+
+export const checkPresenceOfPropertyNameOrNumber = (propertyNameOrNumber: string, req) => {
+  if (propertyNameOrNumber === undefined || propertyNameOrNumber === "") {
+    const appData: ApplicationData = getApplicationData(req.session);
+
+    // If this is a Registration journey, a property name or number must be entered, if not,
+    // a validation error must be shown to the user (the field is optional on the Update and Remove
+    // journeys, as value is moved into the 'Address Line 1' field)
+    if (!appData.entity_number) {
+      throw new Error(ErrorMessages.PROPERTY_NAME_OR_NUMBER);
+    }
+  }
+
+  return true;
+};
+
 export const checkNoChangeStatementSubmission = (value: any, req) => {
   if (value === undefined) {
     if (isRemoveJourney(req)) {

--- a/src/validation/entity.validation.ts
+++ b/src/validation/entity.validation.ts
@@ -1,7 +1,7 @@
 import { body } from "express-validator";
 
 import { ErrorMessages } from "./error.messages";
-import { principal_address_validations, principal_service_address_validations } from "./fields/address.validation";
+import { overseas_entity_address_validations, overseas_entity_service_address_validations } from "./fields/address.validation";
 import { entity_public_register_validations } from "./fields/public-register.validation";
 import { VALID_CHARACTERS } from "./regex/regex.validation";
 import { email_validations } from "./fields/email.validation";
@@ -9,10 +9,10 @@ import { email_validations } from "./fields/email.validation";
 export const entity = [
   body("incorporation_country").not().isEmpty({ ignore_whitespace: true }).withMessage(ErrorMessages.COUNTRY),
 
-  ...principal_address_validations(),
+  ...overseas_entity_address_validations(),
   body("is_service_address_same_as_principal_address").not().isEmpty().withMessage(ErrorMessages.SELECT_IF_SERVICE_ADDRESS_SAME_AS_PRINCIPAL_ADDRESS),
 
-  ...principal_service_address_validations,
+  ...overseas_entity_service_address_validations,
   ...email_validations,
 
   body("legal_form")

--- a/src/validation/fields/address.validation.ts
+++ b/src/validation/fields/address.validation.ts
@@ -3,13 +3,44 @@ import { defaultRequiredErrorMessages, defaultOptionalErrorMessages, ErrorMessag
 
 import {
   addressFieldsHaveNoValue,
+  checkPropertyNameOrNumberIfRadioButtonSelected,
   checkFieldIfRadioButtonSelected,
   checkFieldIfRadioButtonSelectedAndFieldsEmpty,
   checkInvalidCharactersIfRadioButtonSelected,
-  checkMaxFieldIfRadioButtonSelected
+  checkMaxFieldIfRadioButtonSelected,
+  checkPresenceOfPropertyNameOrNumber
 } from "../custom.validation";
 import { ErrorMessages } from "../error.messages";
 import { VALID_CHARACTERS } from "../regex/regex.validation";
+
+export const overseas_entity_address_validations = (errors: ErrorMessagesOptional = defaultOptionalErrorMessages) => {
+  errors = { ...defaultOptionalErrorMessages, ...errors };
+  return [
+    body("principal_address_property_name_number")
+      .custom((value, { req }) => checkPresenceOfPropertyNameOrNumber(value, req) )
+      .isLength({ max: 50 }).withMessage(errors.maxPropertyValueLengthError)
+      .matches(VALID_CHARACTERS).withMessage(errors.propertyNameInvalidError),
+    body("principal_address_line_1")
+      .not().isEmpty({ ignore_whitespace: true }).withMessage(errors.addressLine1Error)
+      .isLength({ max: 50 }).withMessage(errors.addressLine1LengthError)
+      .matches(VALID_CHARACTERS).withMessage(errors.addressLine1InvalidCharacterError),
+    body("principal_address_line_2")
+      .isLength({ max: 50 }).withMessage(errors.addressLine2LengthError)
+      .matches(VALID_CHARACTERS).withMessage(errors.addressLine2InvalidCharacterError),
+    body("principal_address_town")
+      .not().isEmpty({ ignore_whitespace: true }).withMessage(errors.townValueError)
+      .isLength({ max: 50 }).withMessage(errors.maxTownValueLengthError)
+      .matches(VALID_CHARACTERS).withMessage(errors.townInvalidCharacterError),
+    body("principal_address_county")
+      .isLength({ max: 50 }).withMessage(errors.maxCountyValueLengthError)
+      .matches(VALID_CHARACTERS).withMessage(errors.countyInvalidCharacterError),
+    body("principal_address_country")
+      .not().isEmpty({ ignore_whitespace: true }).withMessage(errors.countryValueError),
+    body("principal_address_postcode")
+      .isLength({ max: 15 }).withMessage(errors.postcodeLengthError)
+      .matches(VALID_CHARACTERS).withMessage(errors.postcodeInvalidCharacterError)
+  ];
+};
 
 export const principal_address_validations = (errors: ErrorMessagesOptional = defaultOptionalErrorMessages) => {
   errors = { ...defaultOptionalErrorMessages, ...errors };
@@ -39,6 +70,32 @@ export const principal_address_validations = (errors: ErrorMessagesOptional = de
       .matches(VALID_CHARACTERS).withMessage(errors.postcodeInvalidCharacterError)
   ];
 };
+
+export const overseas_entity_service_address_validations = [
+  body("service_address_property_name_number")
+    .custom((value, { req }) => checkPropertyNameOrNumberIfRadioButtonSelected(req.body.is_service_address_same_as_principal_address === '0', value, req) )
+    .custom((value, { req }) => checkMaxFieldIfRadioButtonSelected(req.body.is_service_address_same_as_principal_address === '0', ErrorMessages.MAX_PROPERTY_NAME_OR_NUMBER_LENGTH, 50, value) )
+    .custom((value, { req }) => checkInvalidCharactersIfRadioButtonSelected(req.body.is_service_address_same_as_principal_address === '0', ErrorMessages.PROPERTY_NAME_OR_NUMBER_INVALID_CHARACTERS, value) ),
+  body("service_address_line_1")
+    .custom((value, { req }) => checkFieldIfRadioButtonSelected(req.body.is_service_address_same_as_principal_address === '0', ErrorMessages.ADDRESS_LINE1, value) )
+    .custom((value, { req }) => checkMaxFieldIfRadioButtonSelected(req.body.is_service_address_same_as_principal_address === '0', ErrorMessages.MAX_ADDRESS_LINE1_LENGTH, 50, value) )
+    .custom((value, { req }) => checkInvalidCharactersIfRadioButtonSelected(req.body.is_service_address_same_as_principal_address === '0', ErrorMessages.ADDRESS_LINE_1_INVALID_CHARACTERS, value) ),
+  body("service_address_line_2")
+    .custom((value, { req }) => checkMaxFieldIfRadioButtonSelected(req.body.is_service_address_same_as_principal_address === '0', ErrorMessages.MAX_ADDRESS_LINE2_LENGTH, 50, value) )
+    .custom((value, { req }) => checkInvalidCharactersIfRadioButtonSelected(req.body.is_service_address_same_as_principal_address === '0', ErrorMessages.ADDRESS_LINE_2_INVALID_CHARACTERS, value) ),
+  body("service_address_town")
+    .custom((value, { req }) => checkFieldIfRadioButtonSelected(req.body.is_service_address_same_as_principal_address === '0', ErrorMessages.CITY_OR_TOWN, value) )
+    .custom((value, { req }) => checkMaxFieldIfRadioButtonSelected(req.body.is_service_address_same_as_principal_address === '0', ErrorMessages.MAX_CITY_OR_TOWN_LENGTH, 50, value) )
+    .custom((value, { req }) => checkInvalidCharactersIfRadioButtonSelected(req.body.is_service_address_same_as_principal_address === '0', ErrorMessages.CITY_OR_TOWN_INVALID_CHARACTERS, value) ),
+  body("service_address_county")
+    .custom((value, { req }) => checkMaxFieldIfRadioButtonSelected(req.body.is_service_address_same_as_principal_address === '0', ErrorMessages.MAX_COUNTY_LENGTH, 50, value) )
+    .custom((value, { req }) => checkInvalidCharactersIfRadioButtonSelected(req.body.is_service_address_same_as_principal_address === '0', ErrorMessages.COUNTY_STATE_PROVINCE_REGION_INVALID_CHARACTERS, value) ),
+  body("service_address_country")
+    .custom((value, { req }) => checkFieldIfRadioButtonSelected(req.body.is_service_address_same_as_principal_address === '0', ErrorMessages.COUNTRY, value) ),
+  body("service_address_postcode")
+    .custom((value, { req }) => checkMaxFieldIfRadioButtonSelected(req.body.is_service_address_same_as_principal_address === '0', ErrorMessages.MAX_POSTCODE_LENGTH, 15, value) )
+    .custom((value, { req }) => checkInvalidCharactersIfRadioButtonSelected(req.body.is_service_address_same_as_principal_address === '0', ErrorMessages.POSTCODE_ZIPCODE_INVALID_CHARACTERS, value) ),
+];
 
 export const principal_service_address_validations = [
   body("service_address_property_name_number")


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/UAR-1502

### Change description

* data entry in this field is now optional for the Update and Remove journeys
* a value must still be entered if on the Registration journey

Change is for a spike - no unit-tests added

### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
