### PR TITLE
UAR-1505 update statement date next mud date checks

### DIFF
--- a/src/controllers/update/update.filing.date.controller.ts
+++ b/src/controllers/update/update.filing.date.controller.ts
@@ -63,7 +63,10 @@ const getFilingDate = async (req: Request, appData: ApplicationData): Promise<{}
   let filingDate = appData.update?.[FilingDateKey] ? mapDataObjectToFields(appData.update[FilingDateKey], FilingDateKeys, InputDateKeys) : undefined;
 
   // otherwise use the next made up to date from confirmation statement in company profile
-  if (!filingDate && appData.entity_number) {
+  if (!filingDate) {
+    if (!appData.entity_number) {
+      throw createAndLogErrorRequest(req, `update.filing.controller unable to find entity_number in application data for entity_name ${appData.entity_name}`);
+    }
     logger.debugRequest(req, `Getting confirmation statement next made up to date for entity number = ${appData.entity_number}`);
     const nextMudIsoString = await getConfirmationStatementNextMadeUpToDateAsIsoString(req, appData.entity_number);
     if (!nextMudIsoString) {

--- a/src/controllers/update/update.filing.date.controller.ts
+++ b/src/controllers/update/update.filing.date.controller.ts
@@ -10,7 +10,7 @@ import { createOverseasEntity, updateOverseasEntity } from "../../service/overse
 import { OverseasEntityKey, Transactionkey, InputDateKeys } from '../../model/data.types.model';
 import { FilingDateKey, FilingDateKeys } from '../../model/date.model';
 import { ApplicationData } from "../../model/application.model";
-import { getConfirmationStatementNextMadeUpToDate } from "../../service/company.profile.service";
+import { getConfirmationStatementNextMadeUpToDateAsISoString } from "../../service/company.profile.service";
 import { convertIsoDateToInputDate } from "../../utils/date";
 
 export const get = async (req: Request, res: Response, next: NextFunction) => {
@@ -26,8 +26,6 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
       [FilingDateKey]: await getFilingDate(req, appData)
     });
   } catch (error) {
-    console.log("&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&");
-    console.log(JSON.stringify(error));
     logger.errorRequest(req, error);
     next(error);
   }
@@ -67,7 +65,7 @@ const getFilingDate = async (req: Request, appData: ApplicationData): Promise<{}
   // otherwise use the next made up to date from confirmation statement in company profile
   if (!filingDate && appData.entity_number) {
     logger.debugRequest(req, `Getting confirmation statement next made up to date for entity number = ${appData.entity_number}`);
-    const nextMudIsoString = await getConfirmationStatementNextMadeUpToDate(req, appData.entity_number);
+    const nextMudIsoString = await getConfirmationStatementNextMadeUpToDateAsISoString(req, appData.entity_number);
     if (!nextMudIsoString) {
       throw createAndLogErrorRequest(req, `No confirmation statement next made up to date found on company profile for entity number = ${appData.entity_number}; transaction id = ${appData.transaction_id}`);
     }

--- a/src/controllers/update/update.filing.date.controller.ts
+++ b/src/controllers/update/update.filing.date.controller.ts
@@ -59,10 +59,11 @@ export const post = async(req: Request, res: Response, next: NextFunction) => {
 };
 
 const getFilingDate = async (req: Request, appData: ApplicationData): Promise<{} | undefined> => {
-  // use date stored in appData if present
+  // use date stored in appData if present, indicates that a value has already been entered on this page by user.
   let filingDate = appData.update?.[FilingDateKey] ? mapDataObjectToFields(appData.update[FilingDateKey], FilingDateKeys, InputDateKeys) : undefined;
 
-  // otherwise use the next made up to date from confirmation statement in company profile
+  // otherwise use the next made up to date from confirmation statement in company profile, this is the first visit to the page so they wouldn't
+  //  have already enetered a date, so pre-populate page with the next made up to date. User can then use that or change it to a different date.
   if (!filingDate) {
     if (!appData.entity_number) {
       throw createAndLogErrorRequest(req, `update.filing.controller unable to find entity_number in application data for entity_name ${appData.entity_name}`);

--- a/src/controllers/update/update.filing.date.controller.ts
+++ b/src/controllers/update/update.filing.date.controller.ts
@@ -66,7 +66,7 @@ const getFilingDate = async (req: Request, appData: ApplicationData): Promise<{}
   //  have already enetered a date, so pre-populate page with the next made up to date. User can then use that or change it to a different date.
   if (!filingDate) {
     if (!appData.entity_number) {
-      throw createAndLogErrorRequest(req, `update.filing.controller unable to find entity_number in application data for entity_name ${appData.entity_name}`);
+      throw createAndLogErrorRequest(req, `update.filing.date.controller unable to find entity_number in application data for entity_name ${appData.entity_name}`);
     }
     logger.debugRequest(req, `Getting confirmation statement next made up to date for entity number = ${appData.entity_number}`);
     const nextMudIsoString = await getConfirmationStatementNextMadeUpToDateAsIsoString(req, appData.entity_number);

--- a/src/controllers/update/update.filing.date.controller.ts
+++ b/src/controllers/update/update.filing.date.controller.ts
@@ -10,7 +10,7 @@ import { createOverseasEntity, updateOverseasEntity } from "../../service/overse
 import { OverseasEntityKey, Transactionkey, InputDateKeys } from '../../model/data.types.model';
 import { FilingDateKey, FilingDateKeys } from '../../model/date.model';
 import { ApplicationData } from "../../model/application.model";
-import { getConfirmationStatementNextMadeUpToDateAsISoString } from "../../service/company.profile.service";
+import { getConfirmationStatementNextMadeUpToDateAsIsoString } from "../../service/company.profile.service";
 import { convertIsoDateToInputDate } from "../../utils/date";
 
 export const get = async (req: Request, res: Response, next: NextFunction) => {
@@ -65,7 +65,7 @@ const getFilingDate = async (req: Request, appData: ApplicationData): Promise<{}
   // otherwise use the next made up to date from confirmation statement in company profile
   if (!filingDate && appData.entity_number) {
     logger.debugRequest(req, `Getting confirmation statement next made up to date for entity number = ${appData.entity_number}`);
-    const nextMudIsoString = await getConfirmationStatementNextMadeUpToDateAsISoString(req, appData.entity_number);
+    const nextMudIsoString = await getConfirmationStatementNextMadeUpToDateAsIsoString(req, appData.entity_number);
     if (!nextMudIsoString) {
       throw createAndLogErrorRequest(req, `No confirmation statement next made up to date found on company profile for entity number = ${appData.entity_number}; transaction id = ${appData.transaction_id}`);
     }

--- a/src/service/company.profile.service.ts
+++ b/src/service/company.profile.service.ts
@@ -31,7 +31,7 @@ export const getCompanyProfile = async (
   return response.resource;
 };
 
-export const getConfirmationStatementNextMadeUpToDateAsISoString = async (req: Request, oeNumber: string): Promise<string | undefined> => {
+export const getConfirmationStatementNextMadeUpToDateAsIsoString = async (req: Request, oeNumber: string): Promise<string | undefined> => {
   const companyProfile: CompanyProfile | undefined = await getCompanyProfile(req, oeNumber);
   return companyProfile?.confirmationStatement?.nextMadeUpTo;
 };

--- a/src/service/company.profile.service.ts
+++ b/src/service/company.profile.service.ts
@@ -30,3 +30,8 @@ export const getCompanyProfile = async (
   logger.debugRequest(req, `Overseas Entity Retrieved - ${infoMsg}`);
   return response.resource;
 };
+
+export const getConfirmationStatementNextMadeUpToDate = async (req: Request, oeNumber: string): Promise<string | undefined> => {
+  const companyProfile: CompanyProfile | undefined = await getCompanyProfile(req, oeNumber);
+  return companyProfile?.confirmationStatement?.nextMadeUpTo;
+};

--- a/src/service/company.profile.service.ts
+++ b/src/service/company.profile.service.ts
@@ -31,7 +31,7 @@ export const getCompanyProfile = async (
   return response.resource;
 };
 
-export const getConfirmationStatementNextMadeUpToDate = async (req: Request, oeNumber: string): Promise<string | undefined> => {
+export const getConfirmationStatementNextMadeUpToDateAsISoString = async (req: Request, oeNumber: string): Promise<string | undefined> => {
   const companyProfile: CompanyProfile | undefined = await getCompanyProfile(req, oeNumber);
   return companyProfile?.confirmationStatement?.nextMadeUpTo;
 };

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -9,3 +9,11 @@ export const getTodaysDate = (): InputDate => {
     year: "" + now.year
   };
 };
+
+export const convertIsoDateToInputDate = (isoDateString: string): InputDate => {
+  const parsedDate = DateTime.fromISO(isoDateString);
+  const day = parsedDate.day.toString().padStart(2, "0"); // Ensure two-digit day
+  const month = parsedDate.month.toString().padStart(2, "0"); // Ensure two-digit month
+  const year = parsedDate.year.toString();
+  return { day, month, year };
+};

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -12,8 +12,8 @@ export const getTodaysDate = (): InputDate => {
 
 export const convertIsoDateToInputDate = (isoDateString: string): InputDate => {
   const parsedDate = DateTime.fromISO(isoDateString);
-  const day = parsedDate.day.toString().padStart(2, "0"); // Ensure two-digit day
-  const month = parsedDate.month.toString().padStart(2, "0"); // Ensure two-digit month
-  const year = parsedDate.year.toString();
+  const day = parsedDate.toFormat('dd'); // Ensure two-digit day
+  const month = parsedDate.toFormat('LL'); // Ensure two-digit month
+  const year = parsedDate.toFormat('yyyy');
   return { day, month, year };
 };

--- a/src/validation/custom.validation.ts
+++ b/src/validation/custom.validation.ts
@@ -700,7 +700,7 @@ export const checkFieldIfRadioButtonSelectedAndFieldsEmpty = (isPrimaryField: bo
   }
 };
 
-export const checkDateIsBeforeNextMadeUpToDate = async (req, dayStr: string = "", monthStr: string = "", yearStr: string = ""): Promise<boolean> => {
+export const checkDateIsBeforeOrOnNextMadeUpToDate = async (req, dayStr: string = "", monthStr: string = "", yearStr: string = ""): Promise<boolean> => {
   const appData: ApplicationData = getApplicationData(req.session);
   if (!appData.entity_number) {
     logger.errorRequest(req, "checkDateBeforeNextMadeUpToDate validation - Unable to find entity number in application data.");

--- a/src/validation/custom.validation.ts
+++ b/src/validation/custom.validation.ts
@@ -13,7 +13,7 @@ import { isRemoveJourney } from "../utils/url";
 import { getTrustByIdFromApp } from "../utils/trusts" ;
 import { getTrustInReview, hasTrustsToReview } from "../utils/update/review_trusts";
 import { logger } from "../utils/logger";
-import { getConfirmationStatementNextMadeUpToDateAsISoString } from "../service/company.profile.service";
+import { getConfirmationStatementNextMadeUpToDateAsIsoString } from "../service/company.profile.service";
 
 export const checkFieldIfRadioButtonSelected = (selected: boolean, errMsg: string, value: string = "") => {
   if ( selected && !value.trim() ) {
@@ -707,12 +707,14 @@ export const checkDateIsBeforeNextMadeUpToDate = async (req, dayStr: string = ""
     throw new Error(ErrorMessages.UNABLE_TO_RETRIEVE_ENTITY_NUMBER);
   }
 
-  const nextMadeUpToDateIsoString = await getConfirmationStatementNextMadeUpToDateAsISoString(req, appData.entity_number);
+  const nextMadeUpToDateIsoString = await getConfirmationStatementNextMadeUpToDateAsIsoString(req, appData.entity_number);
   if (!nextMadeUpToDateIsoString) {
     logger.errorRequest(req, `checkDateBeforeNextMadeUpToDate validation - Unable to find next made up to date for entity ${appData.entity_number}`);
     throw new Error(ErrorMessages.UNABLE_TO_RETRIEVE_EXPECTED_DATE);
   }
+
   const madeUpToDate = DateTime.fromISO(nextMadeUpToDateIsoString);
+  // TODO create a toIsoString()?
   const userEnteredDate = DateTime.fromISO(`${yearStr}-${monthStr.padStart(2, "0")}-${dayStr.padStart(2, "0")}`);
 
   if (userEnteredDate.startOf('day') > madeUpToDate.startOf('day')) {

--- a/src/validation/custom.validation.ts
+++ b/src/validation/custom.validation.ts
@@ -720,7 +720,7 @@ export const checkFieldIfRadioButtonSelectedAndFieldsEmpty = (isPrimaryField: bo
   }
 };
 
-export const checkDateIsBeforeOrOnOtherDate = (req: Request, dayStr: string, monthStr: string, yearStr: string, otherDayStr: string, otherMonthStr: string, otherYearStr: string, errorMessage: string): boolean => {
+export function checkDateIsBeforeOrOnOtherDate(req: Request, dayStr: string, monthStr: string, yearStr: string, otherDayStr: string, otherMonthStr: string, otherYearStr: string, errorMessage: string): boolean {
   const date = DateTime.fromObject({ year: Number(yearStr), month: Number(monthStr), day: Number(dayStr) });
   const otherDate = DateTime.fromObject({ year: Number(otherYearStr), month: Number(otherMonthStr), day: Number(otherDayStr) });
 
@@ -733,5 +733,4 @@ export const checkDateIsBeforeOrOnOtherDate = (req: Request, dayStr: string, mon
     throw new Error(errorMessage);
   }
   return true;
-};
-
+}

--- a/src/validation/custom.validation.ts
+++ b/src/validation/custom.validation.ts
@@ -717,7 +717,7 @@ export const checkDateIsBeforeOrOnNextMadeUpToDate = async (req, dayStr: string 
   const userEnteredDate = DateTime.fromISO(`${yearStr}-${monthStr.padStart(2, "0")}-${dayStr.padStart(2, "0")}`);
 
   if (userEnteredDate.startOf('day') > madeUpToDate.startOf('day')) {
-    const message = ErrorMessages.STATEMENT_DATE_AFTER_MADE_UP_TO_DATE.replace('%s', `${madeUpToDate.day.toString().padStart(2, "0")} ${madeUpToDate.month.toString().padStart(2, "0")} ${madeUpToDate.year}`);
+    const message = ErrorMessages.DATE_AFTER_MADE_UP_TO_DATE.replace('%s', `${madeUpToDate.day.toString().padStart(2, "0")} ${madeUpToDate.month.toString().padStart(2, "0")} ${madeUpToDate.year}`);
     throw new Error(message);
   }
   return true;

--- a/src/validation/custom.validation.ts
+++ b/src/validation/custom.validation.ts
@@ -714,7 +714,7 @@ export const checkDateIsBeforeOrOnNextMadeUpToDate = async (req, dayStr: string,
   }
 
   const nextMadeUpToDate = DateTime.fromISO(nextMadeUpToDateIsoString);
-  const userEnteredDate = DateTime.fromISO(`${yearStr}-${monthStr.padStart(2, "0")}-${dayStr.padStart(2, "0")}`);
+  const userEnteredDate = DateTime.fromObject({ year: Number(yearStr), month: Number(monthStr), day: Number(dayStr) });
 
   if (userEnteredDate.startOf('day') > nextMadeUpToDate.startOf('day')) {
     const message = ErrorMessages.DATE_AFTER_MADE_UP_TO_DATE.replace('%s', nextMadeUpToDate.toFormat('dd LL yyyy'));

--- a/src/validation/custom.validation.ts
+++ b/src/validation/custom.validation.ts
@@ -14,6 +14,7 @@ import { getTrustByIdFromApp } from "../utils/trusts" ;
 import { getTrustInReview, hasTrustsToReview } from "../utils/update/review_trusts";
 import { logger } from "../utils/logger";
 import { Request } from "express";
+import { InputDate } from "../model/data.types.model";
 
 export const checkFieldIfRadioButtonSelected = (selected: boolean, errMsg: string, value: string = "") => {
   if ( selected && !value.trim() ) {
@@ -720,17 +721,17 @@ export const checkFieldIfRadioButtonSelectedAndFieldsEmpty = (isPrimaryField: bo
   }
 };
 
-export function checkDateIsBeforeOrOnOtherDate(req: Request, dayStr: string, monthStr: string, yearStr: string, otherDayStr: string, otherMonthStr: string, otherYearStr: string, errorMessage: string): boolean {
-  const date = DateTime.fromObject({ year: Number(yearStr), month: Number(monthStr), day: Number(dayStr) });
-  const otherDate = DateTime.fromObject({ year: Number(otherYearStr), month: Number(otherMonthStr), day: Number(otherDayStr) });
+export const checkDateIsBeforeOrOnOtherDate = (req: Request, date: InputDate, otherDate: InputDate, errorMessage: string): boolean => {
+  const dateTime = DateTime.fromObject({ year: Number(date.year), month: Number(date.month), day: Number(date.day) });
+  const otherDateTime = DateTime.fromObject({ year: Number(otherDate.year), month: Number(otherDate.month), day: Number(otherDate.day) });
 
-  if (!date.isValid || !otherDate.isValid) {
+  if (!dateTime.isValid || !otherDateTime.isValid) {
     logger.errorRequest(req, 'Invalid date found in checkDateIsBeforeOrOnOtherDate');
     throw new Error(errorMessage);
   }
 
-  if (date.startOf('day') > otherDate.startOf('day')) {
+  if (dateTime.startOf('day') > otherDateTime.startOf('day')) {
     throw new Error(errorMessage);
   }
   return true;
-}
+};

--- a/src/validation/custom.validation.ts
+++ b/src/validation/custom.validation.ts
@@ -714,7 +714,6 @@ export const checkDateIsBeforeOrOnNextMadeUpToDate = async (req, dayStr: string 
   }
 
   const madeUpToDate = DateTime.fromISO(nextMadeUpToDateIsoString);
-  // TODO create a toIsoString()?
   const userEnteredDate = DateTime.fromISO(`${yearStr}-${monthStr.padStart(2, "0")}-${dayStr.padStart(2, "0")}`);
 
   if (userEnteredDate.startOf('day') > madeUpToDate.startOf('day')) {

--- a/src/validation/custom.validation.ts
+++ b/src/validation/custom.validation.ts
@@ -170,7 +170,7 @@ export const checkAllDateFields = (dayStr: string = "", monthStr: string = "", y
   }
 };
 
-export const checkDateForFilingDate = (dayStr: string = "", monthStr: string = "", yearStr: string = ""): boolean => {
+export const checkFilingDate = (dayStr: string = "", monthStr: string = "", yearStr: string = ""): boolean => {
   // to prevent more than 1 error reported on the date fields we first check for multiple empty fields and then check if the year is correct length or missing before doing the date check as a whole.
   if (!checkMoreThanOneDateFieldIsNotMissing(dayStr, monthStr, yearStr)) {
     return false;

--- a/src/validation/custom.validation.ts
+++ b/src/validation/custom.validation.ts
@@ -700,7 +700,7 @@ export const checkFieldIfRadioButtonSelectedAndFieldsEmpty = (isPrimaryField: bo
   }
 };
 
-export const checkDateIsBeforeOrOnNextMadeUpToDate = async (req, dayStr: string = "", monthStr: string = "", yearStr: string = ""): Promise<boolean> => {
+export const checkDateIsBeforeOrOnNextMadeUpToDate = async (req, dayStr: string, monthStr: string, yearStr: string): Promise<boolean> => {
   const appData: ApplicationData = getApplicationData(req.session);
   if (!appData.entity_number) {
     logger.errorRequest(req, "checkDateBeforeNextMadeUpToDate validation - Unable to find entity number in application data.");

--- a/src/validation/custom.validation.ts
+++ b/src/validation/custom.validation.ts
@@ -713,11 +713,11 @@ export const checkDateIsBeforeOrOnNextMadeUpToDate = async (req, dayStr: string,
     throw new Error(ErrorMessages.UNABLE_TO_RETRIEVE_EXPECTED_DATE);
   }
 
-  const madeUpToDate = DateTime.fromISO(nextMadeUpToDateIsoString);
+  const nextMadeUpToDate = DateTime.fromISO(nextMadeUpToDateIsoString);
   const userEnteredDate = DateTime.fromISO(`${yearStr}-${monthStr.padStart(2, "0")}-${dayStr.padStart(2, "0")}`);
 
-  if (userEnteredDate.startOf('day') > madeUpToDate.startOf('day')) {
-    const message = ErrorMessages.DATE_AFTER_MADE_UP_TO_DATE.replace('%s', `${madeUpToDate.day.toString().padStart(2, "0")} ${madeUpToDate.month.toString().padStart(2, "0")} ${madeUpToDate.year}`);
+  if (userEnteredDate.startOf('day') > nextMadeUpToDate.startOf('day')) {
+    const message = ErrorMessages.DATE_AFTER_MADE_UP_TO_DATE.replace('%s', nextMadeUpToDate.toFormat('dd LL yyyy'));
     throw new Error(message);
   }
   return true;

--- a/src/validation/error.messages.ts
+++ b/src/validation/error.messages.ts
@@ -178,7 +178,7 @@ export enum ErrorMessages {
   START_DATE_BEFORE_FILING_DATE = "Start date must be before or on the date of the update statement",
   CEASED_DATE_BEFORE_FILING_DATE = "Ceased date must be before or on the date of the update statement",
   RESIGNED_ON_BEFORE_FILING_DATE = "Resigned on date must be before or on the date of the update statement",
-  STATEMENT_DATE_AFTER_MADE_UP_TO_DATE = "The date you provide must be on or before %s",
+  DATE_AFTER_MADE_UP_TO_DATE = "The date you provide must be on or before %s",
 
   // No radio selected
   SELECT_IF_ENTITY_HAS_SOLD_LAND = "Select yes if the entity has disposed of UK property or land since 28 February 2022",

--- a/src/validation/error.messages.ts
+++ b/src/validation/error.messages.ts
@@ -35,6 +35,8 @@ export enum ErrorMessages {
   LEGAL_ENTITY_BO_NAME = "Enter its name",
   ENTITY_CORRESPONDENCE_ADDRESS = "Enter their correspondence address",
   START_DATE_MUST_BE_AFTER_DOB = "Start date must be on or after date of birth",
+  UNABLE_TO_RETRIEVE_ENTITY_NUMBER = "Unable to retrieve entity number",
+  UNABLE_TO_RETRIEVE_EXPECTED_DATE = "Unable to retrieve expected date",
 
   // Public Register
   PUBLIC_REGISTER_NAME = "Enter the name of the register",
@@ -176,6 +178,7 @@ export enum ErrorMessages {
   START_DATE_BEFORE_FILING_DATE = "Start date must be before or on the date of the update statement",
   CEASED_DATE_BEFORE_FILING_DATE = "Ceased date must be before or on the date of the update statement",
   RESIGNED_ON_BEFORE_FILING_DATE = "Resigned on date must be before or on the date of the update statement",
+  STATEMENT_DATE_AFTER_MADE_UP_TO_DATE = "The date you provide must be on or before %s",
 
   // No radio selected
   SELECT_IF_ENTITY_HAS_SOLD_LAND = "Select yes if the entity has disposed of UK property or land since 28 February 2022",

--- a/src/validation/error.messages.ts
+++ b/src/validation/error.messages.ts
@@ -36,7 +36,7 @@ export enum ErrorMessages {
   ENTITY_CORRESPONDENCE_ADDRESS = "Enter their correspondence address",
   START_DATE_MUST_BE_AFTER_DOB = "Start date must be on or after date of birth",
   UNABLE_TO_RETRIEVE_ENTITY_NUMBER = "Unable to retrieve entity number",
-  UNABLE_TO_RETRIEVE_EXPECTED_DATE = "Unable to retrieve expected date",
+  UNABLE_TO_RETRIEVE_EXPECTED_DATE = "Unable to retrieve the entity's expected date",
 
   // Public Register
   PUBLIC_REGISTER_NAME = "Enter the name of the register",

--- a/src/validation/fields/date.validation.ts
+++ b/src/validation/fields/date.validation.ts
@@ -183,8 +183,8 @@ export const filing_date_validations = [
 
         checkDateIsBeforeOrOnOtherDate(
           req as Request,
-          req.body["filing_date-day"], req.body["filing_date-month"], req.body["filing_date-year"],
-          nextMadeUpToDate.day.toString(), nextMadeUpToDate.month.toString(), nextMadeUpToDate.year.toString(),
+          { day: req.body["filing_date-day"], month: req.body["filing_date-month"], year: req.body["filing_date-year"] },
+          { day: nextMadeUpToDate.day.toString(), month: nextMadeUpToDate.month.toString(), year: nextMadeUpToDate.year.toString() },
           errorMessage
         );
       }

--- a/src/validation/fields/date.validation.ts
+++ b/src/validation/fields/date.validation.ts
@@ -153,7 +153,7 @@ export const filing_date_validations = [
   body("filing_date-day")
     .custom((value, { req }) => checkDate(req.body["filing_date-day"], req.body["filing_date-month"], req.body["filing_date-year"])),
   body("filing_date-day")
-    .custom(async (value, { req }) => await checkDateIsBeforeOrOnNextMadeUpToDate(req, req.body["filing_date-day"], req.body["filing_date-month"], req.body["filing_date-year"])),
+    .custom((value, { req }) => checkDateIsBeforeOrOnNextMadeUpToDate(req, req.body["filing_date-day"], req.body["filing_date-month"], req.body["filing_date-year"])),
 ];
 
 const dateOfBirthValidationsContext: dateContext = {

--- a/src/validation/fields/date.validation.ts
+++ b/src/validation/fields/date.validation.ts
@@ -155,12 +155,12 @@ export const identity_check_date_validations = [
 export const addNextMadeUpToDateToRequest = async (req: Request, res: Response, next: NextFunction) => {
   const appData: ApplicationData = getApplicationData(req.session);
   if (!appData.entity_number) {
-    logger.errorRequest(req, "filing date validation - Unable to find entity number in application data.");
+    logger.errorRequest(req, "addNextMadeUpToDateToRequest - Unable to find entity number in application data.");
     return next(new Error(ErrorMessages.UNABLE_TO_RETRIEVE_ENTITY_NUMBER));
   }
   const nextMadeUpToDateIsoString = await getConfirmationStatementNextMadeUpToDateAsIsoString(req, appData.entity_number);
   if (!nextMadeUpToDateIsoString) {
-    logger.errorRequest(req, `filing date validation - Unable to find next made up to date for entity ${appData.entity_number}`);
+    logger.errorRequest(req, `addNextMadeUpToDateToRequest - Unable to find next made up to date for entity ${appData.entity_number}`);
     return next(new Error(ErrorMessages.UNABLE_TO_RETRIEVE_EXPECTED_DATE));
   }
   req[NEXT_MADE_UP_TO_ISO_DATE] = nextMadeUpToDateIsoString;

--- a/src/validation/fields/date.validation.ts
+++ b/src/validation/fields/date.validation.ts
@@ -22,7 +22,7 @@ import {
   checkFirstDateOnOrAfterSecondDate,
   checkDatePreviousToFilingDate,
   checkTrustCeasedDate,
-  checkDateIsBeforeNextMadeUpToDate
+  checkDateIsBeforeOrOnNextMadeUpToDate
 } from "../custom.validation";
 import { ErrorMessages } from "../error.messages";
 import { conditionalDateValidations, conditionalHistoricalBODateValidations, dateContext, dateContextWithCondition, dateValidations } from "./helper/date.validation.helper";
@@ -153,7 +153,7 @@ export const filing_date_validations = [
   body("filing_date-day")
     .custom((value, { req }) => checkDate(req.body["filing_date-day"], req.body["filing_date-month"], req.body["filing_date-year"])),
   body("filing_date-day")
-    .custom(async (value, { req }) => await checkDateIsBeforeNextMadeUpToDate(req, req.body["filing_date-day"], req.body["filing_date-month"], req.body["filing_date-year"])),
+    .custom(async (value, { req }) => await checkDateIsBeforeOrOnNextMadeUpToDate(req, req.body["filing_date-day"], req.body["filing_date-month"], req.body["filing_date-year"])),
 ];
 
 const dateOfBirthValidationsContext: dateContext = {

--- a/src/validation/fields/date.validation.ts
+++ b/src/validation/fields/date.validation.ts
@@ -21,7 +21,8 @@ import {
   checkStartDateBeforeDOB,
   checkFirstDateOnOrAfterSecondDate,
   checkDatePreviousToFilingDate,
-  checkTrustCeasedDate
+  checkTrustCeasedDate,
+  checkDateIsBeforeNextMadeUpToDate
 } from "../custom.validation";
 import { ErrorMessages } from "../error.messages";
 import { conditionalDateValidations, conditionalHistoricalBODateValidations, dateContext, dateContextWithCondition, dateValidations } from "./helper/date.validation.helper";
@@ -151,6 +152,8 @@ export const filing_date_validations = [
     .custom((value, { req }) => checkDateFieldYear(ErrorMessages.YEAR, ErrorMessages.YEAR_LENGTH, req.body["filing_date-day"], req.body["filing_date-month"], req.body["filing_date-year"])),
   body("filing_date-day")
     .custom((value, { req }) => checkDate(req.body["filing_date-day"], req.body["filing_date-month"], req.body["filing_date-year"])),
+  body("filing_date-day")
+    .custom(async (value, { req }) => await checkDateIsBeforeNextMadeUpToDate(req, req.body["filing_date-day"], req.body["filing_date-month"], req.body["filing_date-year"])),
 ];
 
 const dateOfBirthValidationsContext: dateContext = {

--- a/src/validation/fields/date.validation.ts
+++ b/src/validation/fields/date.validation.ts
@@ -23,7 +23,7 @@ import {
   checkDatePreviousToFilingDate,
   checkTrustCeasedDate,
   checkDateIsBeforeOrOnOtherDate,
-  checkDateForFilingDate,
+  checkFilingDate,
 } from "../custom.validation";
 import { ErrorMessages } from "../error.messages";
 import { conditionalDateValidations, conditionalHistoricalBODateValidations, dateContext, dateContextWithCondition, dateValidations } from "./helper/date.validation.helper";
@@ -177,7 +177,7 @@ export const filing_date_validations = [
     .custom((value, { req }) => checkDateFieldYear(ErrorMessages.YEAR, ErrorMessages.YEAR_LENGTH, req.body["filing_date-day"], req.body["filing_date-month"], req.body["filing_date-year"])),
   body("filing_date-day")
     .custom((value, { req }) => {
-      if (checkDateForFilingDate(req.body["filing_date-day"], req.body["filing_date-month"], req.body["filing_date-year"])) {
+      if (checkFilingDate(req.body["filing_date-day"], req.body["filing_date-month"], req.body["filing_date-year"])) {
         const nextMadeUpToDate = DateTime.fromISO(req[NEXT_MADE_UP_TO_ISO_DATE]);
         const errorMessage = ErrorMessages.DATE_AFTER_MADE_UP_TO_DATE.replace('%s', nextMadeUpToDate.toFormat('dd LL yyyy'));
 

--- a/test/__mocks__/session.mock.ts
+++ b/test/__mocks__/session.mock.ts
@@ -1586,6 +1586,16 @@ export const OVER_SEAS_ENTITY_MOCK_DATA: CompanyProfile = {
   links: {} as Links
 };
 
+export const COMPANY_PROFILE_WITH_CONFIRMATION_STATEMENT_MOCK_DATA: CompanyProfile = {
+  ...OVER_SEAS_ENTITY_MOCK_DATA,
+  confirmationStatement: {
+    nextDue: "2024-08-12",
+    nextMadeUpTo: "2024-08-26",
+    overdue: false,
+    lastMadeUpTo: "2023-08-12"
+  }
+};
+
 export const MANAGING_OFFICER_MOCK_MAP_DATA: CompanyOfficer = {
   address: {
     premises: "1 Acme Road",

--- a/test/controllers/update/update.filing.date.controller.spec.ts
+++ b/test/controllers/update/update.filing.date.controller.spec.ts
@@ -90,6 +90,12 @@ mockServiceAvailabilityMiddleware.mockImplementation((req: Request, res: Respons
 const mockIsActiveFeature = isActiveFeature as jest.Mock;
 mockIsActiveFeature.mockReturnValue(true);
 
+const FILING_DATE_FORM_DATA = {
+  "filing_date-day": "1",
+  "filing_date-month": "4",
+  "filing_date-year": "2024"
+};
+
 describe("Update Filing Date controller", () => {
 
   beforeEach(() => {
@@ -261,11 +267,7 @@ describe("Update Filing Date controller", () => {
 
       const resp = await request(app)
         .post(config.UPDATE_FILING_DATE_URL)
-        .send({
-          "filing_date-day": "1",
-          "filing_date-month": "4",
-          "filing_date-year": "2024"
-        });
+        .send(FILING_DATE_FORM_DATA);
 
       expect(resp.status).toEqual(200);
       expect(resp.text).toContain(ErrorMessages.DATE_AFTER_MADE_UP_TO_DATE.replace("%s", "19 03 2024"));
@@ -279,11 +281,7 @@ describe("Update Filing Date controller", () => {
 
       const resp = await request(app)
         .post(config.UPDATE_FILING_DATE_URL)
-        .send({
-          "filing_date-day": "1",
-          "filing_date-month": "4",
-          "filing_date-year": "2024"
-        });
+        .send(FILING_DATE_FORM_DATA);
 
       expect(resp.status).toEqual(200);
       expect(resp.text).toContain(ErrorMessages.UNABLE_TO_RETRIEVE_EXPECTED_DATE);
@@ -296,11 +294,7 @@ describe("Update Filing Date controller", () => {
 
       const resp = await request(app)
         .post(config.UPDATE_FILING_DATE_URL)
-        .send({
-          "filing_date-day": "1",
-          "filing_date-month": "4",
-          "filing_date-year": "2024"
-        });
+        .send(FILING_DATE_FORM_DATA);
 
       expect(resp.status).toEqual(200);
       expect(resp.text).toContain(ErrorMessages.UNABLE_TO_RETRIEVE_ENTITY_NUMBER);

--- a/test/controllers/update/update.filing.date.controller.spec.ts
+++ b/test/controllers/update/update.filing.date.controller.spec.ts
@@ -288,7 +288,7 @@ describe("Update Filing Date controller", () => {
       expect(resp.text).toContain(ERROR_LIST);
     });
 
-    test(`renders the ${config.UPDATE_FILING_DATE_PAGE} page with error when unable to get next made up to date`, async () => {
+    test(`renders the service unavailable page when unable to get next made up to date`, async () => {
       const mockData = { ...APPLICATION_DATA_MOCK };
       mockGetApplicationData.mockReturnValue(mockData);
       mockGetConfirmationStatementNextMadeUpToDateAsIsoString.mockResolvedValueOnce(undefined);
@@ -297,12 +297,11 @@ describe("Update Filing Date controller", () => {
         .post(config.UPDATE_FILING_DATE_URL)
         .send(FILING_DATE_FORM_DATA);
 
-      expect(resp.status).toEqual(200);
-      expect(resp.text).toContain(ErrorMessages.UNABLE_TO_RETRIEVE_EXPECTED_DATE);
-      expect(resp.text).toContain(ERROR_LIST);
+      expect(resp.status).toEqual(500);
+      expect(resp.text).toContain(SERVICE_UNAVAILABLE);
     });
 
-    test(`renders the ${config.UPDATE_FILING_DATE_PAGE} page with error when unable to get the entity number`, async () => {
+    test(`renders the service unavailable page when unable to get the entity number`, async () => {
       const mockData = { };
       mockGetApplicationData.mockReturnValue(mockData);
 
@@ -310,9 +309,8 @@ describe("Update Filing Date controller", () => {
         .post(config.UPDATE_FILING_DATE_URL)
         .send(FILING_DATE_FORM_DATA);
 
-      expect(resp.status).toEqual(200);
-      expect(resp.text).toContain(ErrorMessages.UNABLE_TO_RETRIEVE_ENTITY_NUMBER);
-      expect(resp.text).toContain(ERROR_LIST);
+      expect(resp.status).toEqual(500);
+      expect(resp.text).toContain(SERVICE_UNAVAILABLE);
     });
 
     test(`catch error on POST action for ${config.UPDATE_FILING_DATE_URL} page`, async () => {

--- a/test/controllers/update/update.filing.date.controller.spec.ts
+++ b/test/controllers/update/update.filing.date.controller.spec.ts
@@ -268,7 +268,7 @@ describe("Update Filing Date controller", () => {
         });
 
       expect(resp.status).toEqual(200);
-      expect(resp.text).toContain(ErrorMessages.STATEMENT_DATE_AFTER_MADE_UP_TO_DATE.replace("%s", "19 03 2024"));
+      expect(resp.text).toContain(ErrorMessages.DATE_AFTER_MADE_UP_TO_DATE.replace("%s", "19 03 2024"));
       expect(resp.text).toContain(ERROR_LIST);
     });
 

--- a/test/controllers/update/update.filing.date.controller.spec.ts
+++ b/test/controllers/update/update.filing.date.controller.spec.ts
@@ -49,7 +49,7 @@ import { saveAndContinueButtonText } from '../../__mocks__/save.and.continue.moc
 
 import { NextFunction } from "express";
 import { ErrorMessages } from "../../../src/validation/error.messages";
-import { getConfirmationStatementNextMadeUpToDate } from "../../../src/service/company.profile.service";
+import { getConfirmationStatementNextMadeUpToDateAsISoString } from "../../../src/service/company.profile.service";
 
 const NEXT_MADE_UP_TO_DATE = "2024-03-19";
 
@@ -73,7 +73,7 @@ const mockUpdateOverseasEntity = updateOverseasEntity as jest.Mock;
 const mockGetApplicationData = getApplicationData as jest.Mock;
 mockGetApplicationData.mockReturnValue( APPLICATION_DATA_MOCK );
 
-const mockGetConfirmationStatementNextMadeUpToDate = getConfirmationStatementNextMadeUpToDate as jest.Mock;
+const mockGetConfirmationStatementNextMadeUpToDate = getConfirmationStatementNextMadeUpToDateAsISoString as jest.Mock;
 mockGetConfirmationStatementNextMadeUpToDate.mockReturnValue(NEXT_MADE_UP_TO_DATE);
 
 const mockMapDataObjectToFields = mapDataObjectToFields as jest.Mock;

--- a/test/controllers/update/update.filing.date.controller.spec.ts
+++ b/test/controllers/update/update.filing.date.controller.spec.ts
@@ -193,6 +193,20 @@ describe("Update Filing Date controller", () => {
       expect(resp.status).toEqual(500);
     });
 
+    test('throws error if no entity number is found', async () => {
+      const mockData = { ...APPLICATION_DATA_MOCK };
+      mockData.entity_number = undefined;
+
+      mockGetApplicationData.mockReturnValueOnce(mockData);
+      mockCreateAndLogErrorRequest.mockReturnValueOnce(new Error("message"));
+
+      const resp = await request(app).get(config.UPDATE_FILING_DATE_URL);
+
+      expect(mockGetConfirmationStatementNextMadeUpToDateAsIsoString).not.toHaveBeenCalled();
+      expect(mockCreateAndLogErrorRequest).toHaveBeenCalled();
+      expect(resp.status).toEqual(500);
+    });
+
     test('catch error when rendering the page', async () => {
       mockLoggerDebugRequest.mockImplementationOnce( () => { throw new Error(ANY_MESSAGE_ERROR); });
       const resp = await request(app).get(config.UPDATE_FILING_DATE_URL);

--- a/test/service/company.profile.service.spec.ts
+++ b/test/service/company.profile.service.spec.ts
@@ -14,8 +14,10 @@ import {
   ERROR,
   fnGetCompanyNameGetOE,
   getSessionRequestWithExtraData,
+  COMPANY_PROFILE_WITH_CONFIRMATION_STATEMENT_MOCK_DATA,
+  OVER_SEAS_ENTITY_MOCK_DATA,
 } from "../__mocks__/session.mock";
-import { getCompanyProfile } from "../../src/service/company.profile.service";
+import { getCompanyProfile, getConfirmationStatementNextMadeUpToDate } from "../../src/service/company.profile.service";
 
 const mockCreateAndLogErrorRequest = createAndLogErrorRequest as jest.Mock;
 mockCreateAndLogErrorRequest.mockReturnValue(ERROR);
@@ -24,6 +26,7 @@ const mockMakeApiCallWithRetry = makeApiCallWithRetry as jest.Mock;
 
 const session = getSessionRequestWithExtraData();
 const req: Request = { session } as Request;
+
 describe(`Get overseas entity profile details service suite`, () => {
   beforeEach (() => {
     jest.clearAllMocks();
@@ -57,5 +60,21 @@ describe(`Get overseas entity profile details service suite`, () => {
 
     await expect(getCompanyProfile(req, COMPANY_NUMBER)).rejects.toThrow(ERROR);
     expect(mockCreateAndLogErrorRequest).toHaveBeenCalled();
+  });
+
+  test('getConfirmationStatementNextMadeUpToDate should return the next made up to date', async () => {
+    const mockResponse = { httpStatusCode: 200, resource: COMPANY_PROFILE_WITH_CONFIRMATION_STATEMENT_MOCK_DATA };
+    mockMakeApiCallWithRetry.mockResolvedValueOnce(mockResponse);
+
+    const response = await getConfirmationStatementNextMadeUpToDate(req, COMPANY_NUMBER);
+    expect(response).toEqual("2024-08-26");
+  });
+
+  test('getConfirmationStatementNextMadeUpToDate should return undefined if the next made up to date is not present', async () => {
+    const mockResponse = { httpStatusCode: 200, resource: OVER_SEAS_ENTITY_MOCK_DATA };
+    mockMakeApiCallWithRetry.mockResolvedValueOnce(mockResponse);
+
+    const response = await getConfirmationStatementNextMadeUpToDate(req, COMPANY_NUMBER);
+    expect(response).toEqual(undefined);
   });
 });

--- a/test/service/company.profile.service.spec.ts
+++ b/test/service/company.profile.service.spec.ts
@@ -17,7 +17,7 @@ import {
   COMPANY_PROFILE_WITH_CONFIRMATION_STATEMENT_MOCK_DATA,
   OVER_SEAS_ENTITY_MOCK_DATA,
 } from "../__mocks__/session.mock";
-import { getCompanyProfile, getConfirmationStatementNextMadeUpToDate } from "../../src/service/company.profile.service";
+import { getCompanyProfile, getConfirmationStatementNextMadeUpToDateAsIsoString } from "../../src/service/company.profile.service";
 
 const mockCreateAndLogErrorRequest = createAndLogErrorRequest as jest.Mock;
 mockCreateAndLogErrorRequest.mockReturnValue(ERROR);
@@ -66,7 +66,7 @@ describe(`Get overseas entity profile details service suite`, () => {
     const mockResponse = { httpStatusCode: 200, resource: COMPANY_PROFILE_WITH_CONFIRMATION_STATEMENT_MOCK_DATA };
     mockMakeApiCallWithRetry.mockResolvedValueOnce(mockResponse);
 
-    const response = await getConfirmationStatementNextMadeUpToDate(req, COMPANY_NUMBER);
+    const response = await getConfirmationStatementNextMadeUpToDateAsIsoString(req, COMPANY_NUMBER);
     expect(response).toEqual("2024-08-26");
   });
 
@@ -74,7 +74,7 @@ describe(`Get overseas entity profile details service suite`, () => {
     const mockResponse = { httpStatusCode: 200, resource: OVER_SEAS_ENTITY_MOCK_DATA };
     mockMakeApiCallWithRetry.mockResolvedValueOnce(mockResponse);
 
-    const response = await getConfirmationStatementNextMadeUpToDate(req, COMPANY_NUMBER);
+    const response = await getConfirmationStatementNextMadeUpToDateAsIsoString(req, COMPANY_NUMBER);
     expect(response).toEqual(undefined);
   });
 });

--- a/test/utils/date.spec.ts
+++ b/test/utils/date.spec.ts
@@ -1,5 +1,5 @@
 import { DateTime } from "luxon";
-import { getTodaysDate } from "../../src/utils/date";
+import { convertIsoDateToInputDate, getTodaysDate } from "../../src/utils/date";
 import { InputDate } from "../../src/model/data.types.model";
 
 describe("date utils tests", () => {
@@ -15,5 +15,45 @@ describe("date utils tests", () => {
     expect("" + todayDateTime.day).toEqual(todaysDate.day);
     expect("" + todayDateTime.month).toEqual(todaysDate.month);
     expect("" + todayDateTime.year).toEqual(todaysDate.year);
+  });
+
+  test("convertIsoDateToInputDate should convert ISO date to an InputDate with leading zeros", () => {
+    const convertedDate: InputDate = convertIsoDateToInputDate("2024-02-06");
+
+    expect(convertedDate.day).toEqual("06");
+    expect(convertedDate.month).toEqual("02");
+    expect(convertedDate.year).toEqual("2024");
+  });
+
+  test("convertIsoDateToInputDate should convert ISO date to an InputDate without leading zeros", () => {
+    const convertedDate: InputDate = convertIsoDateToInputDate("2024-12-26");
+
+    expect(convertedDate.day).toEqual("26");
+    expect(convertedDate.month).toEqual("12");
+    expect(convertedDate.year).toEqual("2024");
+  });
+
+  test("convertIsoDateToInputDate should return NaN values if input date not in ISO format", () => {
+    const convertedDate: InputDate = convertIsoDateToInputDate("26-12-2024");
+
+    expect(convertedDate.day).toEqual("NaN");
+    expect(convertedDate.month).toEqual("NaN");
+    expect(convertedDate.year).toEqual("NaN");
+  });
+
+  test("convertIsoDateToInputDate should return NaN values if input date is empty", () => {
+    const convertedDate: InputDate = convertIsoDateToInputDate("");
+
+    expect(convertedDate.day).toEqual("NaN");
+    expect(convertedDate.month).toEqual("NaN");
+    expect(convertedDate.year).toEqual("NaN");
+  });
+
+  test("convertIsoDateToInputDate should return NaN values if input date is undefined", () => {
+    const convertedDate: InputDate = convertIsoDateToInputDate(undefined as unknown as string);
+
+    expect(convertedDate.day).toEqual("NaN");
+    expect(convertedDate.month).toEqual("NaN");
+    expect(convertedDate.year).toEqual("NaN");
   });
 });

--- a/test/utils/date.spec.ts
+++ b/test/utils/date.spec.ts
@@ -36,24 +36,24 @@ describe("date utils tests", () => {
   test("convertIsoDateToInputDate should return NaN values if input date not in ISO format", () => {
     const convertedDate: InputDate = convertIsoDateToInputDate("26-12-2024");
 
-    expect(convertedDate.day).toEqual("NaN");
-    expect(convertedDate.month).toEqual("NaN");
-    expect(convertedDate.year).toEqual("NaN");
+    expect(convertedDate.day).toEqual("Invalid DateTime");
+    expect(convertedDate.month).toEqual("Invalid DateTime");
+    expect(convertedDate.year).toEqual("Invalid DateTime");
   });
 
   test("convertIsoDateToInputDate should return NaN values if input date is empty", () => {
     const convertedDate: InputDate = convertIsoDateToInputDate("");
 
-    expect(convertedDate.day).toEqual("NaN");
-    expect(convertedDate.month).toEqual("NaN");
-    expect(convertedDate.year).toEqual("NaN");
+    expect(convertedDate.day).toEqual("Invalid DateTime");
+    expect(convertedDate.month).toEqual("Invalid DateTime");
+    expect(convertedDate.year).toEqual("Invalid DateTime");
   });
 
   test("convertIsoDateToInputDate should return NaN values if input date is undefined", () => {
     const convertedDate: InputDate = convertIsoDateToInputDate(undefined as unknown as string);
 
-    expect(convertedDate.day).toEqual("NaN");
-    expect(convertedDate.month).toEqual("NaN");
-    expect(convertedDate.year).toEqual("NaN");
+    expect(convertedDate.day).toEqual("Invalid DateTime");
+    expect(convertedDate.month).toEqual("Invalid DateTime");
+    expect(convertedDate.year).toEqual("Invalid DateTime");
   });
 });

--- a/test/validation/custom.validation.spec.ts
+++ b/test/validation/custom.validation.spec.ts
@@ -12,7 +12,7 @@ import { Session } from '@companieshouse/node-session-handler';
 import { Trust } from "../../src/model/trust.model";
 import { ROUTE_PARAM_TRUST_ID } from "../../src/config/index";
 import { DefaultErrorsSecondNationality } from "../../src/validation/models/second.nationality.error.model";
-import { getConfirmationStatementNextMadeUpToDateAsISoString } from "../../src/service/company.profile.service";
+import { getConfirmationStatementNextMadeUpToDateAsIsoString } from "../../src/service/company.profile.service";
 
 const public_register_name = MAX_80 + "1";
 const public_register_jurisdiction = MAX_80;
@@ -242,7 +242,7 @@ describe('tests for checkDatePreviousToFilingDate ', () => {
   describe("tests for checkDateIsBeforeNextMadeUpToDate", () => {
     test("should return true if date is before made up to date", async () => {
       (getApplicationData as jest.Mock).mockReturnValueOnce({ entity_number: "OE123456" });
-      (getConfirmationStatementNextMadeUpToDateAsISoString as jest.Mock).mockReturnValueOnce("2024-05-19");
+      (getConfirmationStatementNextMadeUpToDateAsIsoString as jest.Mock).mockReturnValueOnce("2024-05-19");
 
       const result = await custom.checkDateIsBeforeNextMadeUpToDate({}, "18", "5", "2024");
 
@@ -251,7 +251,7 @@ describe('tests for checkDatePreviousToFilingDate ', () => {
 
     test("should return true if date is on made up to date", async () => {
       (getApplicationData as jest.Mock).mockReturnValueOnce({ entity_number: "OE123456" });
-      (getConfirmationStatementNextMadeUpToDateAsISoString as jest.Mock).mockReturnValueOnce("2024-05-19");
+      (getConfirmationStatementNextMadeUpToDateAsIsoString as jest.Mock).mockReturnValueOnce("2024-05-19");
 
       const result = await custom.checkDateIsBeforeNextMadeUpToDate({}, "19", "5", "2024");
 
@@ -260,7 +260,7 @@ describe('tests for checkDatePreviousToFilingDate ', () => {
 
     test("should throw error if date is after made up to date", async () => {
       (getApplicationData as jest.Mock).mockReturnValueOnce({ entity_number: "OE123456" });
-      (getConfirmationStatementNextMadeUpToDateAsISoString as jest.Mock).mockReturnValueOnce("2024-05-19");
+      (getConfirmationStatementNextMadeUpToDateAsIsoString as jest.Mock).mockReturnValueOnce("2024-05-19");
 
       await expect(custom.checkDateIsBeforeNextMadeUpToDate({}, "20", "5", "2024")).rejects.toThrowError("The date you provide must be on or before 19 05 2024");
     });
@@ -273,7 +273,7 @@ describe('tests for checkDatePreviousToFilingDate ', () => {
 
     test("should throw error if next made up to date not found", async () => {
       (getApplicationData as jest.Mock).mockReturnValueOnce({ entity_number: "OE123456" });
-      (getConfirmationStatementNextMadeUpToDateAsISoString as jest.Mock).mockReturnValueOnce("");
+      (getConfirmationStatementNextMadeUpToDateAsIsoString as jest.Mock).mockReturnValueOnce("");
 
       await expect(custom.checkDateIsBeforeNextMadeUpToDate({}, "18", "5", "2024")).rejects.toThrowError(ErrorMessages.UNABLE_TO_RETRIEVE_EXPECTED_DATE);
     });

--- a/test/validation/custom.validation.spec.ts
+++ b/test/validation/custom.validation.spec.ts
@@ -239,12 +239,12 @@ describe('tests for checkDatePreviousToFilingDate ', () => {
       .toThrowError(ErrorMessages.START_DATE_BEFORE_FILING_DATE);
   });
 
-  describe("tests for checkDateIsBeforeNextMadeUpToDate", () => {
+  describe("tests for checkDateIsBeforeOrOnNextMadeUpToDate", () => {
     test("should return true if date is before made up to date", async () => {
       (getApplicationData as jest.Mock).mockReturnValueOnce({ entity_number: "OE123456" });
       (getConfirmationStatementNextMadeUpToDateAsIsoString as jest.Mock).mockReturnValueOnce("2024-05-19");
 
-      const result = await custom.checkDateIsBeforeNextMadeUpToDate({}, "18", "5", "2024");
+      const result = await custom.checkDateIsBeforeOrOnNextMadeUpToDate({}, "18", "5", "2024");
 
       expect(result).toEqual(true);
     });
@@ -253,7 +253,7 @@ describe('tests for checkDatePreviousToFilingDate ', () => {
       (getApplicationData as jest.Mock).mockReturnValueOnce({ entity_number: "OE123456" });
       (getConfirmationStatementNextMadeUpToDateAsIsoString as jest.Mock).mockReturnValueOnce("2024-05-19");
 
-      const result = await custom.checkDateIsBeforeNextMadeUpToDate({}, "19", "5", "2024");
+      const result = await custom.checkDateIsBeforeOrOnNextMadeUpToDate({}, "19", "5", "2024");
 
       expect(result).toEqual(true);
     });
@@ -262,20 +262,20 @@ describe('tests for checkDatePreviousToFilingDate ', () => {
       (getApplicationData as jest.Mock).mockReturnValueOnce({ entity_number: "OE123456" });
       (getConfirmationStatementNextMadeUpToDateAsIsoString as jest.Mock).mockReturnValueOnce("2024-05-19");
 
-      await expect(custom.checkDateIsBeforeNextMadeUpToDate({}, "20", "5", "2024")).rejects.toThrowError("The date you provide must be on or before 19 05 2024");
+      await expect(custom.checkDateIsBeforeOrOnNextMadeUpToDate({}, "20", "5", "2024")).rejects.toThrowError("The date you provide must be on or before 19 05 2024");
     });
 
     test("should throw error if entity number not found", async () => {
       (getApplicationData as jest.Mock).mockReturnValueOnce({ });
 
-      await expect(custom.checkDateIsBeforeNextMadeUpToDate({}, "18", "5", "2024")).rejects.toThrowError(ErrorMessages.UNABLE_TO_RETRIEVE_ENTITY_NUMBER);
+      await expect(custom.checkDateIsBeforeOrOnNextMadeUpToDate({}, "18", "5", "2024")).rejects.toThrowError(ErrorMessages.UNABLE_TO_RETRIEVE_ENTITY_NUMBER);
     });
 
     test("should throw error if next made up to date not found", async () => {
       (getApplicationData as jest.Mock).mockReturnValueOnce({ entity_number: "OE123456" });
       (getConfirmationStatementNextMadeUpToDateAsIsoString as jest.Mock).mockReturnValueOnce("");
 
-      await expect(custom.checkDateIsBeforeNextMadeUpToDate({}, "18", "5", "2024")).rejects.toThrowError(ErrorMessages.UNABLE_TO_RETRIEVE_EXPECTED_DATE);
+      await expect(custom.checkDateIsBeforeOrOnNextMadeUpToDate({}, "18", "5", "2024")).rejects.toThrowError(ErrorMessages.UNABLE_TO_RETRIEVE_EXPECTED_DATE);
     });
   });
 });

--- a/test/validation/custom.validation.spec.ts
+++ b/test/validation/custom.validation.spec.ts
@@ -12,7 +12,6 @@ import { Session } from '@companieshouse/node-session-handler';
 import { Trust } from "../../src/model/trust.model";
 import { ROUTE_PARAM_TRUST_ID } from "../../src/config/index";
 import { DefaultErrorsSecondNationality } from "../../src/validation/models/second.nationality.error.model";
-import { getConfirmationStatementNextMadeUpToDateAsIsoString } from "../../src/service/company.profile.service";
 
 const public_register_name = MAX_80 + "1";
 const public_register_jurisdiction = MAX_80;
@@ -239,43 +238,31 @@ describe('tests for checkDatePreviousToFilingDate ', () => {
       .toThrowError(ErrorMessages.START_DATE_BEFORE_FILING_DATE);
   });
 
-  describe("tests for checkDateIsBeforeOrOnNextMadeUpToDate", () => {
-    test("should return true if date is before made up to date", async () => {
-      (getApplicationData as jest.Mock).mockReturnValueOnce({ entity_number: "OE123456" });
-      (getConfirmationStatementNextMadeUpToDateAsIsoString as jest.Mock).mockReturnValueOnce("2024-05-19");
-
-      const result = await custom.checkDateIsBeforeOrOnNextMadeUpToDate({}, "18", "5", "2024");
-
+  describe("tests for checkDateIsBeforeOrOnOtherDate", () => {
+    test("should return true if date is before other date", () => {
+      const result = custom.checkDateIsBeforeOrOnOtherDate(mockReq, "17", "05", "2024", "18", "5", "2024", "error");
       expect(result).toEqual(true);
     });
 
-    test("should return true if date is on made up to date", async () => {
-      (getApplicationData as jest.Mock).mockReturnValueOnce({ entity_number: "OE123456" });
-      (getConfirmationStatementNextMadeUpToDateAsIsoString as jest.Mock).mockReturnValueOnce("2024-05-19");
-
-      const result = await custom.checkDateIsBeforeOrOnNextMadeUpToDate({}, "19", "5", "2024");
-
+    test("should return true if date is on other date", () => {
+      const result = custom.checkDateIsBeforeOrOnOtherDate(mockReq, "18", "05", "2024", "18", "5", "2024", "error");
       expect(result).toEqual(true);
     });
 
-    test("should throw error if date is after made up to date", async () => {
-      (getApplicationData as jest.Mock).mockReturnValueOnce({ entity_number: "OE123456" });
-      (getConfirmationStatementNextMadeUpToDateAsIsoString as jest.Mock).mockReturnValueOnce("2024-05-19");
-
-      await expect(custom.checkDateIsBeforeOrOnNextMadeUpToDate({}, "20", "5", "2024")).rejects.toThrowError("The date you provide must be on or before 19 05 2024");
+    test("should throw error if date is after made up to date", () => {
+      expect(() => custom.checkDateIsBeforeOrOnOtherDate(mockReq, "19", "05", "2024", "18", "5", "2024", "error"))
+        .toThrowError("error");
     });
 
-    test("should throw error if entity number not found", async () => {
-      (getApplicationData as jest.Mock).mockReturnValueOnce({ });
-
-      await expect(custom.checkDateIsBeforeOrOnNextMadeUpToDate({}, "18", "5", "2024")).rejects.toThrowError(ErrorMessages.UNABLE_TO_RETRIEVE_ENTITY_NUMBER);
+    test("should throw error if date is invalid", () => {
+      expect(() => custom.checkDateIsBeforeOrOnOtherDate(mockReq, "", "05", "2024", "18", "5", "2024", "error"))
+        .toThrowError("error");
     });
 
-    test("should throw error if next made up to date not found", async () => {
-      (getApplicationData as jest.Mock).mockReturnValueOnce({ entity_number: "OE123456" });
-      (getConfirmationStatementNextMadeUpToDateAsIsoString as jest.Mock).mockReturnValueOnce("");
-
-      await expect(custom.checkDateIsBeforeOrOnNextMadeUpToDate({}, "18", "5", "2024")).rejects.toThrowError(ErrorMessages.UNABLE_TO_RETRIEVE_EXPECTED_DATE);
+    test("should throw error if other date is invalid", () => {
+      expect(() => custom.checkDateIsBeforeOrOnOtherDate(mockReq, "17", "05", "2024", "18", "", "2024", "error"))
+        .toThrowError("error");
     });
+
   });
 });

--- a/test/validation/custom.validation.spec.ts
+++ b/test/validation/custom.validation.spec.ts
@@ -265,4 +265,53 @@ describe('tests for checkDatePreviousToFilingDate ', () => {
     });
 
   });
+
+  describe("tests for checkDateForFilingDate", () => {
+    test("should return true if date is not in the future", () => {
+      const result = custom.checkDateForFilingDate("17", "05", "2024");
+      expect(result).toEqual(true);
+    });
+
+    test("should return true if date is today", () => {
+      const today = DateTime.now();
+      const result = custom.checkDateForFilingDate(today.day.toString(), today.month.toString(), today.year.toString());
+      expect(result).toEqual(true);
+    });
+
+    test("should throw error if date is in future", () => {
+      const today = DateTime.now();
+      const future = today.plus({ days: 1 }); // Add one day
+      expect(() => custom.checkDateForFilingDate(future.day.toString(), future.month.toString(), future.year.toString())).toThrowError();
+    });
+
+    test("should return false if more than one date part is missing", () => {
+      expect(custom.checkDateForFilingDate("", "5", "")).toEqual(false);
+    });
+
+    test("should return false if year is incorrect length", () => {
+      expect(custom.checkDateForFilingDate("3", "5", "202")).toEqual(false);
+    });
+
+    test("should return false if year is missing", () => {
+      expect(custom.checkDateForFilingDate("3", "5", "")).toEqual(false);
+    });
+
+    test("should return false if date is empty", () => {
+      expect(custom.checkDateForFilingDate("", "", "")).toEqual(false);
+    });
+
+    test("should return false if day is empty", () => {
+      expect(custom.checkDateForFilingDate("", "5", "2024")).toEqual(false);
+    });
+
+    test("should return false if month is empty", () => {
+      expect(custom.checkDateForFilingDate("2", "", "2024")).toEqual(false);
+    });
+
+    test("should throw error if date is invalid", () => {
+      expect(() => custom.checkDateForFilingDate("200", "5", "2024")).toThrowError();
+      expect(() => custom.checkDateForFilingDate("2", "55", "2024")).toThrowError();
+      expect(() => custom.checkDateForFilingDate("31", "02", "2024")).toThrowError();
+    });
+  });
 });

--- a/test/validation/custom.validation.spec.ts
+++ b/test/validation/custom.validation.spec.ts
@@ -266,52 +266,52 @@ describe('tests for checkDatePreviousToFilingDate ', () => {
 
   });
 
-  describe("tests for checkDateForFilingDate", () => {
+  describe("tests for checkFilingDate", () => {
     test("should return true if date is not in the future", () => {
-      const result = custom.checkDateForFilingDate("17", "05", "2024");
+      const result = custom.checkFilingDate("17", "05", "2024");
       expect(result).toEqual(true);
     });
 
     test("should return true if date is today", () => {
       const today = DateTime.now();
-      const result = custom.checkDateForFilingDate(today.day.toString(), today.month.toString(), today.year.toString());
+      const result = custom.checkFilingDate(today.day.toString(), today.month.toString(), today.year.toString());
       expect(result).toEqual(true);
     });
 
     test("should throw error if date is in future", () => {
       const today = DateTime.now();
       const future = today.plus({ days: 1 }); // Add one day
-      expect(() => custom.checkDateForFilingDate(future.day.toString(), future.month.toString(), future.year.toString())).toThrowError();
+      expect(() => custom.checkFilingDate(future.day.toString(), future.month.toString(), future.year.toString())).toThrowError();
     });
 
     test("should return false if more than one date part is missing", () => {
-      expect(custom.checkDateForFilingDate("", "5", "")).toEqual(false);
+      expect(custom.checkFilingDate("", "5", "")).toEqual(false);
     });
 
     test("should return false if year is incorrect length", () => {
-      expect(custom.checkDateForFilingDate("3", "5", "202")).toEqual(false);
+      expect(custom.checkFilingDate("3", "5", "202")).toEqual(false);
     });
 
     test("should return false if year is missing", () => {
-      expect(custom.checkDateForFilingDate("3", "5", "")).toEqual(false);
+      expect(custom.checkFilingDate("3", "5", "")).toEqual(false);
     });
 
     test("should return false if date is empty", () => {
-      expect(custom.checkDateForFilingDate("", "", "")).toEqual(false);
+      expect(custom.checkFilingDate("", "", "")).toEqual(false);
     });
 
     test("should return false if day is empty", () => {
-      expect(custom.checkDateForFilingDate("", "5", "2024")).toEqual(false);
+      expect(custom.checkFilingDate("", "5", "2024")).toEqual(false);
     });
 
     test("should return false if month is empty", () => {
-      expect(custom.checkDateForFilingDate("2", "", "2024")).toEqual(false);
+      expect(custom.checkFilingDate("2", "", "2024")).toEqual(false);
     });
 
     test("should throw error if date is invalid", () => {
-      expect(() => custom.checkDateForFilingDate("200", "5", "2024")).toThrowError();
-      expect(() => custom.checkDateForFilingDate("2", "55", "2024")).toThrowError();
-      expect(() => custom.checkDateForFilingDate("31", "02", "2024")).toThrowError();
+      expect(() => custom.checkFilingDate("200", "5", "2024")).toThrowError();
+      expect(() => custom.checkFilingDate("2", "55", "2024")).toThrowError();
+      expect(() => custom.checkFilingDate("31", "02", "2024")).toThrowError();
     });
   });
 });

--- a/test/validation/custom.validation.spec.ts
+++ b/test/validation/custom.validation.spec.ts
@@ -240,27 +240,27 @@ describe('tests for checkDatePreviousToFilingDate ', () => {
 
   describe("tests for checkDateIsBeforeOrOnOtherDate", () => {
     test("should return true if date is before other date", () => {
-      const result = custom.checkDateIsBeforeOrOnOtherDate(mockReq, "17", "05", "2024", "18", "5", "2024", "error");
+      const result = custom.checkDateIsBeforeOrOnOtherDate(mockReq, { day: "17", month: "05", year: "2024" }, { day: "18", month: "5", year: "2024" }, "error");
       expect(result).toEqual(true);
     });
 
     test("should return true if date is on other date", () => {
-      const result = custom.checkDateIsBeforeOrOnOtherDate(mockReq, "18", "05", "2024", "18", "5", "2024", "error");
+      const result = custom.checkDateIsBeforeOrOnOtherDate(mockReq, { day: "18", month: "05", year: "2024" }, { day: "18", month: "5", year: "2024" }, "error");
       expect(result).toEqual(true);
     });
 
     test("should throw error if date is after made up to date", () => {
-      expect(() => custom.checkDateIsBeforeOrOnOtherDate(mockReq, "19", "05", "2024", "18", "5", "2024", "error"))
+      expect(() => custom.checkDateIsBeforeOrOnOtherDate(mockReq, { day: "19", month: "05", year: "2024" }, { day: "18", month: "5", year: "2024" }, "error"))
         .toThrowError("error");
     });
 
     test("should throw error if date is invalid", () => {
-      expect(() => custom.checkDateIsBeforeOrOnOtherDate(mockReq, "", "05", "2024", "18", "5", "2024", "error"))
+      expect(() => custom.checkDateIsBeforeOrOnOtherDate(mockReq, { day: "", month: "05", year: "2024" }, { day: "18", month: "5", year: "2024" }, "error"))
         .toThrowError("error");
     });
 
     test("should throw error if other date is invalid", () => {
-      expect(() => custom.checkDateIsBeforeOrOnOtherDate(mockReq, "17", "05", "2024", "18", "", "2024", "error"))
+      expect(() => custom.checkDateIsBeforeOrOnOtherDate(mockReq, { day: "17", month: "05", year: "2024" }, { day: "18", month: "", year: "2024" }, "error"))
         .toThrowError("error");
     });
 

--- a/test/validation/date.validation.spec.ts
+++ b/test/validation/date.validation.spec.ts
@@ -642,7 +642,7 @@ describe("addNextMadeUpToDateToRequest tests", () => {
   test("test addNextMadeUpToDateToRequest sends error to next function when entity number missing", async () => {
     mockGetApplicationData.mockReturnValueOnce({ });
     await addNextMadeUpToDateToRequest(mockReq, mockRes, mockNext);
-    expect(mockErrorLogger.mock.calls[0][1]).toContain("filing date validation - Unable to find entity number in application data.");
+    expect(mockErrorLogger.mock.calls[0][1]).toContain("addNextMadeUpToDateToRequest - Unable to find entity number in application data.");
     expect(mockNext).toBeCalledWith(expect.objectContaining({ 'message': ErrorMessages.UNABLE_TO_RETRIEVE_ENTITY_NUMBER }));
   });
 
@@ -652,7 +652,7 @@ describe("addNextMadeUpToDateToRequest tests", () => {
     });
     mockGetConfirmationStatementNextMadeUpToDateAsIsoString.mockReturnValueOnce(undefined);
     await addNextMadeUpToDateToRequest(mockReq, mockRes, mockNext);
-    expect(mockErrorLogger.mock.calls[0][1]).toContain("filing date validation - Unable to find next made up to date for entity 123456");
+    expect(mockErrorLogger.mock.calls[0][1]).toContain("addNextMadeUpToDateToRequest - Unable to find next made up to date for entity 123456");
     expect(mockNext).toBeCalledWith(expect.objectContaining({ 'message': ErrorMessages.UNABLE_TO_RETRIEVE_EXPECTED_DATE }));
   });
 });

--- a/test/validation/date.validation.spec.ts
+++ b/test/validation/date.validation.spec.ts
@@ -1,3 +1,20 @@
+const mockIf = jest.fn();
+const mockCustom = jest.fn();
+const mockEquals = jest.fn();
+const mockNotEmpty = jest.fn();
+
+jest.mock('express-validator', () => ({
+  body: jest.fn().mockImplementation(() => ({
+    custom: mockCustom.mockReturnThis(),
+    equals: mockEquals.mockReturnThis(),
+    if: mockIf.mockReturnThis(),
+    notEmpty: mockNotEmpty.mockReturnThis(),
+  })),
+}));
+jest.mock('../../src/utils/application.data');
+jest.mock('../../src/service/company.profile.service');
+jest.mock("../../src/utils/logger");
+
 import { DateTime } from 'luxon';
 import { RoleWithinTrustType } from '../../src/model/role.within.trust.type.model';
 import { checkBirthDate,
@@ -16,20 +33,19 @@ import { checkBirthDate,
   isYearEitherMissingOrCorrectLength } from '../../src/validation/custom.validation';
 import { ErrorMessages } from '../../src/validation/error.messages';
 import { dateValidations, dateContext, conditionalDateValidations, dateContextWithCondition } from '../../src/validation/fields/helper/date.validation.helper';
+import { getApplicationData } from '../../src/utils/application.data';
+import { getConfirmationStatementNextMadeUpToDateAsIsoString } from "../../src/service/company.profile.service";
+import { Request, Response } from 'express';
+import { NEXT_MADE_UP_TO_ISO_DATE, addNextMadeUpToDateToRequest } from "../../src/validation/fields/date.validation";
+import { logger } from '../../src/utils/logger';
 
-const mockIf = jest.fn();
-const mockCustom = jest.fn();
-const mockEquals = jest.fn();
-const mockNotEmpty = jest.fn();
+let mockReq = {} as Request;
+const mockRes = {} as Response;
+const mockNext = jest.fn();
 
-jest.mock('express-validator', () => ({
-  body: jest.fn().mockImplementation(() => ({
-    custom: mockCustom.mockReturnThis(),
-    equals: mockEquals.mockReturnThis(),
-    if: mockIf.mockReturnThis(),
-    notEmpty: mockNotEmpty.mockReturnThis(),
-  })),
-}));
+const mockGetApplicationData = getApplicationData as jest.Mock;
+const mockGetConfirmationStatementNextMadeUpToDateAsIsoString = getConfirmationStatementNextMadeUpToDateAsIsoString as jest.Mock;
+const mockErrorLogger = logger.errorRequest as jest.Mock;
 
 describe('Test to validate date validator', () => {
 
@@ -441,7 +457,7 @@ describe("test day,month and year error checkers", () => {
   });
 });
 
-describe("should chek date functions for custom validation", () => {
+describe("should check date functions for custom validation", () => {
   const today = DateTime.local();
   const tomorrow = today.plus({ days: 1 });
   const yesterday = today.minus({ days: 1 });
@@ -602,5 +618,41 @@ describe("should chek date functions for custom validation", () => {
   // TODO: Needs some rework
   test("should test checkIdentityDate returns true for no param", () => {
     expect(checkIdentityDate()).toBe(true);
+  });
+});
+
+describe("addNextMadeUpToDateToRequest tests", () => {
+  beforeEach(() => {
+    mockReq = {} as Request;
+    mockNext.mockClear();
+    mockErrorLogger.mockClear();
+    mockGetApplicationData.mockReset();
+  });
+
+  test("test addNextMadeUpToDateToRequest adds made up to date to request object", async () => {
+    mockGetApplicationData.mockReturnValueOnce({
+      entity_number: "123456"
+    });
+    mockGetConfirmationStatementNextMadeUpToDateAsIsoString.mockReturnValueOnce("2024-03-01");
+
+    await addNextMadeUpToDateToRequest(mockReq, mockRes, mockNext);
+    expect(mockReq[NEXT_MADE_UP_TO_ISO_DATE]).toEqual("2024-03-01");
+  });
+
+  test("test addNextMadeUpToDateToRequest sends error to next function when entity number missing", async () => {
+    mockGetApplicationData.mockReturnValueOnce({ });
+    await addNextMadeUpToDateToRequest(mockReq, mockRes, mockNext);
+    expect(mockErrorLogger.mock.calls[0][1]).toContain("filing date validation - Unable to find entity number in application data.");
+    expect(mockNext).toBeCalledWith(expect.objectContaining({ 'message': ErrorMessages.UNABLE_TO_RETRIEVE_ENTITY_NUMBER }));
+  });
+
+  test("test addNextMadeUpToDateToRequest sends error to next function when next made up to date is missing", async () => {
+    mockGetApplicationData.mockReturnValueOnce({
+      entity_number: "123456"
+    });
+    mockGetConfirmationStatementNextMadeUpToDateAsIsoString.mockReturnValueOnce(undefined);
+    await addNextMadeUpToDateToRequest(mockReq, mockRes, mockNext);
+    expect(mockErrorLogger.mock.calls[0][1]).toContain("filing date validation - Unable to find next made up to date for entity 123456");
+    expect(mockNext).toBeCalledWith(expect.objectContaining({ 'message': ErrorMessages.UNABLE_TO_RETRIEVE_EXPECTED_DATE }));
   });
 });


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/UAR-1505


### Change description
- Pre-populate the update statement date with the next made up to date obtained from the confirmation statement details
- Add validation to ensure user can only enter a date before or on the the next made up to date.

### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
