### PR TITLE
ROE-2562 Fix error messaging for trust after resuming a registration

### DIFF
--- a/src/validation/trust.details.validation.ts
+++ b/src/validation/trust.details.validation.ts
@@ -38,7 +38,7 @@ const setIsTrustToBeCeasedFlagOnBody = () => {
 export const checkTrustStillInvolved = (req: Request): boolean => {
   const appData: ApplicationData = getApplicationData(req.session);
 
-  const isUpdateOrRemove: boolean = appData.entity_number !== undefined;
+  const isUpdateOrRemove: boolean = !!appData.entity_number;
 
   return !hasNoBoAssignableToTrust(appData) && isUpdateOrRemove;
 };

--- a/test/controllers/trust.details.controller.spec.ts
+++ b/test/controllers/trust.details.controller.spec.ts
@@ -546,5 +546,41 @@ describe('Trust Details controller', () => {
       expect(resp.text).toContain(pageUrl); // TODO update when backlinks are implemented
       expect(resp.text).toContain(ErrorMessages.NAME_INVALID_CHARACTERS_TRUST);
     });
+
+    test("successful POST submission to same page with a missing (equivalent to 'undefined') entity number does not raise an error for the 'still involved' trust question", async () => {
+      mockGetApplicationData.mockReturnValue({});
+
+      (mapDetailToSession as jest.Mock).mockReturnValue({
+        trust_id: mockTrust2Data.trust_id,
+      });
+
+      const resp = await request(app)
+        .post(pageWithParamsUrl)
+        .send({
+          name: "dummyName"
+        });
+
+      expect(resp.status).toEqual(constants.HTTP_STATUS_OK);
+      expect(resp.text).toContain(pageUrl); // TODO update when backlinks are implemented
+      expect(resp.text).not.toContain(ErrorMessages.TRUST_STILL_INVOLVED);
+    });
+
+    test("successful POST submission to same page with a null entity number (simulating a resumed registration) does not raise an error for the 'still involved' trust question", async () => {
+      mockGetApplicationData.mockReturnValue({ entity_number: null });
+
+      (mapDetailToSession as jest.Mock).mockReturnValue({
+        trust_id: mockTrust2Data.trust_id,
+      });
+
+      const resp = await request(app)
+        .post(pageWithParamsUrl)
+        .send({
+          name: "dummyName"
+        });
+
+      expect(resp.status).toEqual(constants.HTTP_STATUS_OK);
+      expect(resp.text).toContain(pageUrl); // TODO update when backlinks are implemented
+      expect(resp.text).not.toContain(ErrorMessages.TRUST_STILL_INVOLVED);
+    });
   });
 });


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/ROE-2562

### Change description

* 'entity_number' in session application model was 'undefined' during a registration but 'null' when resuming a registration
* Check extended so 'Still involved' error message is no longer displayed
* Unit tests added to check the changed implementation

### Work checklist

- [X] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
