### PR TITLE
UAR-1543 Fix ceased date validation for new trust screen

### DIFF
--- a/src/validation/trust.details.validation.ts
+++ b/src/validation/trust.details.validation.ts
@@ -44,6 +44,9 @@ export const checkTrustStillInvolved = (req: Request): boolean => {
 };
 
 export const trustDetails = [
+  // Need to set this flag so it can be checked in the other validators
+  setIsTrustToBeCeasedFlagOnBody(),
+
   body("name")
     .not().isEmpty({ ignore_whitespace: true }).withMessage(ErrorMessages.TRUST_NAME_2)
     .matches(VALID_CHARACTERS).withMessage(ErrorMessages.NAME_INVALID_CHARACTERS_TRUST)
@@ -57,6 +60,9 @@ export const trustDetails = [
 
   body("beneficialOwnersIds")
     .not().isEmpty().withMessage(ErrorMessages.TRUST_INVOLVED_BOS),
+
+  // trustCeasedDateValidations are conditional and will only run if the trust is being ceased
+  ...trustCeasedDateValidations,
 
   body("hasAllInfo")
     .not().isEmpty().withMessage(ErrorMessages.TRUST_HAS_ALL_INFO)

--- a/test/__mocks__/text.mock.ts
+++ b/test/__mocks__/text.mock.ts
@@ -153,6 +153,7 @@ export const TRUST_SUMMARY_HEADING = "Trusts associated with the overseas entity
 export const TRUST_NOT_ASSOCIATED_WITH_BENEFICIAL_OWNER_TEXT = "This trust is no longer associated with a beneficial owner";
 export const TRUST_CEASED_DATE_TEXT = "When did this trust stop being associated with the overseas entity";
 export const TRUST_SELECT_TRUSTEES_TEXT = "Which of the overseas entity’s beneficial owners are trustees of this trust";
+export const TRUST_ENTER_CEASED_DATE = "Enter the date the trust stopped being associated with this overseas entity";
 
 export const CHANGE_LINK_INDIVIDUAL_BO_LABEL = "Individual beneficial owner ";
 export const CHANGE_LINK_INDIVIDUAL_BO_FIRST_NAME = CHANGE_LINK_INDIVIDUAL_BO_LABEL + "Ivan Drago - first name";

--- a/test/controllers/update/update.trusts.tell.us.about.it.controller.spec.ts
+++ b/test/controllers/update/update.trusts.tell.us.about.it.controller.spec.ts
@@ -119,6 +119,8 @@ describe('Update - Trusts - Tell us about the trust', () => {
       const resp = await request(app).post(UPDATE_TRUSTS_TELL_US_ABOUT_IT_URL).send({ stillInvolved: '0' });
 
       expect(resp.status).toEqual(200);
+      expect(resp.text).toContain(ERROR_LIST);
+      expect(resp.text).toContain(UPDATE_TELL_US_ABOUT_TRUST_HEADING);
       expect(resp.text).toContain(TRUST_ENTER_CEASED_DATE);
     });
 

--- a/test/controllers/update/update.trusts.tell.us.about.it.controller.spec.ts
+++ b/test/controllers/update/update.trusts.tell.us.about.it.controller.spec.ts
@@ -26,7 +26,7 @@ import { getApplicationData } from '../../../src/utils/application.data';
 import { isActiveFeature } from '../../../src/utils/feature.flag';
 
 import { APPLICATION_DATA_UPDATE_NO_TRUSTS_MOCK, APPLICATION_DATA_MOCK, APPLICATION_DATA_UPDATE_NO_BO_TRUSTEES_MOCK } from '../../__mocks__/session.mock';
-import { PAGE_TITLE_ERROR, PAGE_NOT_FOUND_TEXT, UPDATE_TELL_US_ABOUT_TRUST_HEADING, UPDATE_TELL_US_ABOUT_TRUST_QUESTION, ERROR_LIST, TRUST_CEASED_DATE_TEXT, TRUST_NOT_ASSOCIATED_WITH_BENEFICIAL_OWNER_TEXT } from '../../__mocks__/text.mock';
+import { PAGE_TITLE_ERROR, PAGE_NOT_FOUND_TEXT, UPDATE_TELL_US_ABOUT_TRUST_HEADING, UPDATE_TELL_US_ABOUT_TRUST_QUESTION, ERROR_LIST, TRUST_CEASED_DATE_TEXT, TRUST_NOT_ASSOCIATED_WITH_BENEFICIAL_OWNER_TEXT, TRUST_ENTER_CEASED_DATE } from '../../__mocks__/text.mock';
 import { saveAndContinueButtonText } from '../../__mocks__/save.and.continue.mock';
 import { saveAndContinue } from '../../../src/utils/save.and.continue';
 
@@ -111,6 +111,15 @@ describe('Update - Trusts - Tell us about the trust', () => {
       expect(resp.text).toContain(ERROR_LIST);
       expect(resp.text).toContain(UPDATE_TELL_US_ABOUT_TRUST_HEADING);
       expect(resp.text).toContain(UPDATE_TELL_US_ABOUT_TRUST_QUESTION);
+    });
+
+    test('when feature flag is on and new trust no longer involved in the OE, re-render page with ceased date validation error', async () => {
+      mockIsActiveFeature.mockReturnValueOnce(true);
+      mockGetApplicationData.mockReturnValue( { ...APPLICATION_DATA_MOCK } );
+      const resp = await request(app).post(UPDATE_TRUSTS_TELL_US_ABOUT_IT_URL).send({ stillInvolved: '0' });
+
+      expect(resp.status).toEqual(200);
+      expect(resp.text).toContain(TRUST_ENTER_CEASED_DATE);
     });
 
     test('when feature flag is on and posting valid data, redirect to update-trusts-individuals-or-entities-involved page', async () => {


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/UAR-1543

### Change description

* Validation wasn't firing as page field wasn't set to indicate trust was being ceased
* Fix implemented and unit test added

### Work checklist

- [X] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
