### PR TITLE
UAR-1515 Suppress output of ceased trustees

### DIFF
--- a/src/utils/update/trust.model.fetch.ts
+++ b/src/utils/update/trust.model.fetch.ts
@@ -121,6 +121,13 @@ export const mapIndividualTrusteeData = (trustee: IndividualTrusteeData, trust: 
     mapHistoricalIndividualTrusteeData(trustee, trust);
     return;
   }
+
+  // This needs to be done after checking (and mapping) an historical individual trustee, as they will have ceased dates. It's
+  // enough to simply check for the presence of a ceased date, since future dates cannot be entered in this field
+  if (trustee.ceasedDate) {
+    return;
+  }
+
   const dateOfBirth = mapInputDate(trustee.dateOfBirth);
   const nationalities = splitNationalities(trustee.nationality);
 
@@ -208,6 +215,13 @@ export const mapCorporateTrusteeData = (trustee: CorporateTrusteeData, trust: Tr
     mapHistoricalCorporateTrusteeData(trustee, trust);
     return;
   }
+
+  // This needs to be done after checking (and mapping) an historical corporate trustee, as they will have ceased dates. It's
+  // enough to simply check for the presence of a ceased date, since future dates cannot be entered in this field
+  if (trustee.ceasedDate) {
+    return;
+  }
+
   const appointmentDate = mapInputDate(trustee.appointmentDate);
 
   const corporateTrustee: TrustCorporate = {

--- a/test/utils/update/trust.model.fetch.spec.ts
+++ b/test/utils/update/trust.model.fetch.spec.ts
@@ -791,6 +791,71 @@ describe("Test fetching and mapping of Trust data", () => {
     expect(trustMock.HISTORICAL_BO).toHaveLength(2);
   });
 
+  test("should not map trustees into trust when trustees are ceased", () => {
+    trustMock.INDIVIDUALS = [];
+    trustMock.CORPORATES = [];
+    trustMock.HISTORICAL_BO = [];
+
+    const ceasedIndividualTrusteeData = {
+      hashedTrusteeId: "1",
+      trusteeForename1: "",
+      trusteeSurname: "",
+      corporateIndicator: "",
+      trusteeTypeId: "5002",
+      ceasedDate: "2021-11-17"
+    } as unknown as IndividualTrusteeData;
+    mapIndividualTrusteeData(ceasedIndividualTrusteeData, trustMock);
+
+    const individualTrusteeData = {
+      hashedTrusteeId: "1",
+      trusteeForename1: "",
+      trusteeSurname: "",
+      corporateIndicator: "",
+      trusteeTypeId: "5002"
+    } as unknown as IndividualTrusteeData;
+    mapIndividualTrusteeData(individualTrusteeData, trustMock);
+
+    const historicalIndividualTrusteeData = {
+      hashedTrusteeId: "2",
+      trusteeForename1: "",
+      trusteeSurname: "",
+      corporateIndicator: "",
+      trusteeTypeId: "5001",
+      ceasedDate: "2023-03-03"
+    } as unknown as IndividualTrusteeData;
+    mapIndividualTrusteeData(historicalIndividualTrusteeData, trustMock);
+
+    const ceasedCorporateTrusteeData = {
+      hashedTrusteeId: "3",
+      trusteeName: "",
+      corporateIndicator: "",
+      trusteeTypeId: "5005",
+      ceasedDate: "2022-06-25"
+    } as unknown as CorporateTrusteeData;
+    mapCorporateTrusteeData(ceasedCorporateTrusteeData, trustMock);
+
+    const corporateTrusteeData = {
+      hashedTrusteeId: "3",
+      trusteeName: "",
+      corporateIndicator: "",
+      trusteeTypeId: "5005"
+    } as unknown as CorporateTrusteeData;
+    mapCorporateTrusteeData(corporateTrusteeData, trustMock);
+
+    const historicalCorporateTrusteeData: CorporateTrusteeData = {
+      hashedTrusteeId: "3",
+      trusteeName: "",
+      corporateIndicator: "",
+      trusteeTypeId: "5001",
+      ceasedDate: "2022-02-02"
+    } as unknown as CorporateTrusteeData;
+    mapCorporateTrusteeData(historicalCorporateTrusteeData, trustMock);
+
+    expect(trustMock.INDIVIDUALS).toHaveLength(1);
+    expect(trustMock.CORPORATES).toHaveLength(1);
+    expect(trustMock.HISTORICAL_BO).toHaveLength(2);
+  });
+
   test("should map interested person trustees into trust", () => {
     const trusteeData = {
       hashedTrusteeId: "1",

--- a/test/utils/update/trust.model.fetch.spec.ts
+++ b/test/utils/update/trust.model.fetch.spec.ts
@@ -797,7 +797,7 @@ describe("Test fetching and mapping of Trust data", () => {
     trustMock.HISTORICAL_BO = [];
 
     const ceasedIndividualTrusteeData = {
-      hashedTrusteeId: "1",
+      hashedTrusteeId: "17",
       trusteeForename1: "",
       trusteeSurname: "",
       corporateIndicator: "",
@@ -826,7 +826,7 @@ describe("Test fetching and mapping of Trust data", () => {
     mapIndividualTrusteeData(historicalIndividualTrusteeData, trustMock);
 
     const ceasedCorporateTrusteeData = {
-      hashedTrusteeId: "3",
+      hashedTrusteeId: "19",
       trusteeName: "",
       corporateIndicator: "",
       trusteeTypeId: "5005",
@@ -843,7 +843,7 @@ describe("Test fetching and mapping of Trust data", () => {
     mapCorporateTrusteeData(corporateTrusteeData, trustMock);
 
     const historicalCorporateTrusteeData: CorporateTrusteeData = {
-      hashedTrusteeId: "3",
+      hashedTrusteeId: "14",
       trusteeName: "",
       corporateIndicator: "",
       trusteeTypeId: "5001",

--- a/test/utils/update/trust.model.fetch.spec.ts
+++ b/test/utils/update/trust.model.fetch.spec.ts
@@ -802,7 +802,7 @@ describe("Test fetching and mapping of Trust data", () => {
       trusteeSurname: "",
       corporateIndicator: "",
       trusteeTypeId: "5002",
-      ceasedDate: "2021-11-17"
+      ceasedDate: "2021-11-18"
     } as unknown as IndividualTrusteeData;
     mapIndividualTrusteeData(ceasedIndividualTrusteeData, trustMock);
 


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/UAR-1515

### Change description

* Individual and corporate trustees with 'ceased dates' no longer appear if filing an Update or Remove submission
* Test added to verify behaviour

### Work checklist

- [X] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
