### PR TITLE
UAR-1415 Fix for 'null' trust ids

### DIFF
--- a/src/utils/update/trust.model.fetch.ts
+++ b/src/utils/update/trust.model.fetch.ts
@@ -327,7 +327,7 @@ export const mapTrustLink = (trustLink: TrustLinkData, appData: ApplicationData)
 
 const linkBoToTrust = (beneficialOwner: BeneficialOwnerIndividual | BeneficialOwnerOther, trust: Trust, boType: string) => {
   logger.debug(`Linking ${boType} ${beneficialOwner.ch_reference} to trust ${trust.ch_reference}`);
-  if (beneficialOwner.trust_ids === undefined) {
+  if (!beneficialOwner.trust_ids) {
     beneficialOwner.trust_ids = [];
   }
   beneficialOwner.trust_ids.push(trust.trust_id);

--- a/test/utils/update/trust.model.fetch.spec.ts
+++ b/test/utils/update/trust.model.fetch.spec.ts
@@ -655,12 +655,42 @@ describe("Test fetching and mapping of Trust data", () => {
     expect(appData.beneficial_owners_individual[0].trust_ids).toEqual(undefined);
   });
 
-  test("should fetch and map trust links when trusts to review in update match", () => {
+  test("should fetch and map trust links when trusts to review in update match and trust_ids is 'undefined'", () => {
     const appData = {
       beneficial_owners_individual: [{
         id: "bo1",
         ch_reference: "bolink100",
         trust_ids: undefined
+      }],
+      update: {
+        review_trusts:
+        [
+          {
+            trust_id: "1",
+            ch_reference: "abcd1234",
+            trust_name: "Test Trust",
+            creation_date_day: "1",
+            creation_date_month: "1",
+            creation_date_year: "2020",
+            trust_still_involved_in_overseas_entity: "Yes",
+            unable_to_obtain_all_trust_info: "No"
+          }
+        ]
+      }
+    };
+    mapTrustLink({
+      hashedTrustId: "abcd1234",
+      hashedCorporateBodyAppointmentId: "bolink100",
+    }, appData);
+    expect(appData.beneficial_owners_individual[0].trust_ids).toEqual(["1"]);
+  });
+
+  test("should fetch and map trust links when trusts to review in update match and trust_ids is 'null'", () => {
+    const appData = {
+      beneficial_owners_individual: [{
+        id: "bo1",
+        ch_reference: "bolink100",
+        trust_ids: null as unknown as string[]
       }],
       update: {
         review_trusts:


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/UAR-1415

### Change description

* In a 'Save & Resume' scenario with update and remove, the trust ids can be set to null and not undefined. This causes an issue
* Relaxed the logic check so that both are handled correctly
* New unit test added

### Work checklist

- [X] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
