### PR TITLE
Uar 1469 fix agent code changelink on cya page

### DIFF
--- a/test/controllers/update/check.your.answers.controller.spec.ts
+++ b/test/controllers/update/check.your.answers.controller.spec.ts
@@ -28,6 +28,7 @@ import {
   SECURE_UPDATE_FILTER_URL,
   REMOVE_SERVICE_NAME,
   REMOVE_CONFIRM_STATEMENT_URL,
+  UPDATE_DUE_DILIGENCE_CHANGE_AGENT_CODE,
 } from "../../../src/config";
 import app from "../../../src/app";
 import {
@@ -342,6 +343,7 @@ describe("CHECK YOUR ANSWERS controller", () => {
       expect(resp.text).toContain(UPDATE_DUE_DILIGENCE_CHANGE_SUPERVISORY_NAME);
       expect(resp.text).toContain(UPDATE_DUE_DILIGENCE_CHANGE_AML_NUMBER);
       expect(resp.text).toContain(UPDATE_DUE_DILIGENCE_CHANGE_PARTNER_NAME);
+      expect(resp.text).toContain(UPDATE_DUE_DILIGENCE_CHANGE_AGENT_CODE);
     });
 
     test.each([

--- a/views/includes/check-your-answers/verification-checks.html
+++ b/views/includes/check-your-answers/verification-checks.html
@@ -29,7 +29,7 @@
   {% set whoIsCompletingText = "Who is completing this update" %}
   {% if appData.who_is_registering == "agent" %}
     {% set whoIsCompleting = ukAgent %}
-    {% set agentChangeLink = UPDATE_DUE_DILIGENCE_CHANGE_AGENT_CODE %}
+    {% set agentChangeLink = OE_CONFIGS.UPDATE_DUE_DILIGENCE_CHANGE_AGENT_CODE %}
     {% set dateChangeLink = OE_CONFIGS.UPDATE_DUE_DILIGENCE_CHANGE_IDENTITY_DATE %}
     {% set nameChangeLink = OE_CONFIGS.UPDATE_DUE_DILIGENCE_CHANGE_NAME%}
     {% set addressChangeLink = OE_CONFIGS.UPDATE_DUE_DILIGENCE_CHANGE_IDENTITY_ADDRESS%}


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/UAR-1469

### Change description

Agent assurance code change link on cya page wasn't going anywhere.
Correctly set value by passing in OE_CONFIGS
Tested Update and Remove journeys locally, seems to work ok. 
Added a test to check for UPDATE_DUE_DILIGENCE_CHANGE_AGENT_CODE
