### PR TITLE
UAR-1549 Set status on individual review page based on still active

### DIFF
--- a/test/controllers/update/update.manage.trusts.review.individuals.controller.spec.ts
+++ b/test/controllers/update/update.manage.trusts.review.individuals.controller.spec.ts
@@ -146,6 +146,70 @@ describe('Update - Manage Trusts - Review individuals', () => {
       expect(resp.text).toContain('Beneficiary');
     });
 
+    test('Page displays status as active when entity is still involved in the trust', async () => {
+      mockIsActiveFeature.mockReturnValueOnce(true);
+
+      const individualTrustee = [{
+        ...individuals[0],
+        still_involved: "Yes"
+      }];
+
+      const trusts = [{
+        trust_id: 'test-trust-1',
+        INDIVIDUALS: individualTrustee,
+        review_status: {
+          in_review: true,
+          reviewed_individuals: false,
+        }
+      }];
+
+      const appData = { update: { review_trusts: trusts } };
+
+      const trustInReview = {
+        ...trusts[0],
+      };
+
+      mockGetApplicationData.mockReturnValueOnce(appData);
+      mockGetTrustInReview.mockReturnValueOnce(trustInReview);
+
+      const response = await request(app).get(UPDATE_MANAGE_TRUSTS_REVIEW_INDIVIDUALS_URL);
+      expect(response.text).toContain('Add an individual');
+      expect(response.text).toContain('Status');
+      expect(response.text).toContain('Active');
+    });
+
+    test('Page displays status as removed when entity is not still involved in the trust', async () => {
+      mockIsActiveFeature.mockReturnValueOnce(true);
+
+      const individualTrustee = [{
+        ...individuals[0],
+        still_involved: "No"
+      }];
+
+      const trusts = [{
+        trust_id: 'test-trust-1',
+        INDIVIDUALS: individualTrustee,
+        review_status: {
+          in_review: true,
+          reviewed_individuals: false,
+        }
+      }];
+
+      const appData = { update: { review_trusts: trusts } };
+
+      const trustInReview = {
+        ...trusts[0],
+      };
+
+      mockGetApplicationData.mockReturnValueOnce(appData);
+      mockGetTrustInReview.mockReturnValueOnce(trustInReview);
+
+      const response = await request(app).get(UPDATE_MANAGE_TRUSTS_REVIEW_INDIVIDUALS_URL);
+      expect(response.text).toContain('Add an individual');
+      expect(response.text).toContain('Status');
+      expect(response.text).toContain('Removed');
+    });
+
     test('when feature flag is off, 404 is returned', async () => {
       mockIsActiveFeature.mockReturnValueOnce(false);
 

--- a/test/controllers/update/update.manage.trusts.review.individuals.controller.spec.ts
+++ b/test/controllers/update/update.manage.trusts.review.individuals.controller.spec.ts
@@ -146,7 +146,7 @@ describe('Update - Manage Trusts - Review individuals', () => {
       expect(resp.text).toContain('Beneficiary');
     });
 
-    test('Page displays status as active when entity is still involved in the trust', async () => {
+    test('Page displays status as active when the individual trustee is still involved in the trust', async () => {
       mockIsActiveFeature.mockReturnValueOnce(true);
 
       const individualTrustee = [{
@@ -178,7 +178,7 @@ describe('Update - Manage Trusts - Review individuals', () => {
       expect(response.text).toContain('Active');
     });
 
-    test('Page displays status as removed when entity is not still involved in the trust', async () => {
+    test('Page displays status as removed when the individual trustee is not still involved in the trust', async () => {
       mockIsActiveFeature.mockReturnValueOnce(true);
 
       const individualTrustee = [{

--- a/views/update/update-manage-trusts-review-individuals.html
+++ b/views/update/update-manage-trusts-review-individuals.html
@@ -10,7 +10,7 @@
 
 {% for trustee in pageData.individuals %}
   {% set trusteeName = trustee.forename + ' ' + trustee.surname %}
-  {% set trusteeStatus = 'Removed' if (trustee.still_involved === "0") else 'Active' %}
+  {% set trusteeStatus = 'Removed' if (trustee.still_involved === "No") else 'Active' %}
   {% set trusteeRole = trusteeMacros.readableTrusteeRole(trustee.type | upper) %}
   {% set changeLink = OE_CONFIGS.UPDATE_MANAGE_TRUSTS_TELL_US_ABOUT_THE_INDIVIDUAL_URL + '/' + trustee.id %}
 


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/UAR-1549


### Change description

Changed query value in template to reflect the "still involved" value supplied.

### Work checklist

- [x] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
