### PR TITLE
Fix/ROE-2558: Patch in correct back links for change/remove of individual BOs and all MOs

### DIFF
--- a/src/controllers/beneficial.owner.individual.controller.ts
+++ b/src/controllers/beneficial.owner.individual.controller.ts
@@ -21,7 +21,10 @@ export const get = (req: Request, res: Response) => {
 };
 
 export const getById = (req: Request, res: Response, next: NextFunction) => {
-  getBeneficialOwnerIndividualById(req, res, next, config.BENEFICIAL_OWNER_INDIVIDUAL_PAGE, config.BENEFICIAL_OWNER_TYPE_URL);
+  const backLinkUrl = isActiveFeature(config.FEATURE_FLAG_ENABLE_REDIS_REMOVAL)
+    ? getUrlWithParamsToPath(config.BENEFICIAL_OWNER_TYPE_WITH_PARAMS_URL, req)
+    : config.BENEFICIAL_OWNER_TYPE_URL;
+  getBeneficialOwnerIndividualById(req, res, next, config.BENEFICIAL_OWNER_INDIVIDUAL_PAGE, backLinkUrl);
 };
 
 export const post = (req: Request, res: Response, next: NextFunction) => {

--- a/src/controllers/managing.officer.controller.ts
+++ b/src/controllers/managing.officer.controller.ts
@@ -17,7 +17,11 @@ export const get = (req: Request, res: Response) => {
 };
 
 export const getById = (req: Request, res: Response, next: NextFunction) => {
-  getManagingOfficerById(req, res, next, config.BENEFICIAL_OWNER_TYPE_URL, config.MANAGING_OFFICER_PAGE);
+  let backLinkUrl: string = config.BENEFICIAL_OWNER_TYPE_URL;
+  if (isActiveFeature(config.FEATURE_FLAG_ENABLE_REDIS_REMOVAL)) {
+    backLinkUrl = getUrlWithParamsToPath(config.BENEFICIAL_OWNER_TYPE_WITH_PARAMS_URL, req);
+  }
+  getManagingOfficerById(req, res, next, backLinkUrl, config.MANAGING_OFFICER_PAGE);
 };
 
 export const post = (req: Request, res: Response, next: NextFunction) => {

--- a/src/controllers/managing.officer.controller.ts
+++ b/src/controllers/managing.officer.controller.ts
@@ -17,10 +17,9 @@ export const get = (req: Request, res: Response) => {
 };
 
 export const getById = (req: Request, res: Response, next: NextFunction) => {
-  let backLinkUrl: string = config.BENEFICIAL_OWNER_TYPE_URL;
-  if (isActiveFeature(config.FEATURE_FLAG_ENABLE_REDIS_REMOVAL)) {
-    backLinkUrl = getUrlWithParamsToPath(config.BENEFICIAL_OWNER_TYPE_WITH_PARAMS_URL, req);
-  }
+  const backLinkUrl = isActiveFeature(config.FEATURE_FLAG_ENABLE_REDIS_REMOVAL)
+    ? getUrlWithParamsToPath(config.BENEFICIAL_OWNER_TYPE_WITH_PARAMS_URL, req)
+    : config.BENEFICIAL_OWNER_TYPE_URL;
   getManagingOfficerById(req, res, next, backLinkUrl, config.MANAGING_OFFICER_PAGE);
 };
 

--- a/src/controllers/managing.officer.corporate.controller.ts
+++ b/src/controllers/managing.officer.corporate.controller.ts
@@ -19,7 +19,10 @@ export const get = (req: Request, res: Response) => {
 };
 
 export const getById = (req: Request, res: Response, next: NextFunction) => {
-  getManagingOfficerCorporateById(req, res, next, config.BENEFICIAL_OWNER_TYPE_URL, config.MANAGING_OFFICER_CORPORATE_PAGE);
+  const backLinkUrl = isActiveFeature(config.FEATURE_FLAG_ENABLE_REDIS_REMOVAL)
+    ? getUrlWithParamsToPath(config.BENEFICIAL_OWNER_TYPE_WITH_PARAMS_URL, req)
+    : config.BENEFICIAL_OWNER_TYPE_URL;
+  getManagingOfficerCorporateById(req, res, next, backLinkUrl, config.MANAGING_OFFICER_CORPORATE_PAGE);
 };
 
 export const post = (req: Request, res: Response, next: NextFunction) => {

--- a/test/controllers/beneficial.owner.individual.controller.spec.ts
+++ b/test/controllers/beneficial.owner.individual.controller.spec.ts
@@ -231,7 +231,7 @@ describe("BENEFICIAL OWNER INDIVIDUAL controller", () => {
       expect(resp.text).toContain(SECOND_NATIONALITY_HINT);
     });
 
-    test(`renders the ${BENEFICIAL_OWNER_INDIVIDUAL_PAGE} page when the REDIS_removal flag is on`, async () => {
+    test(`renders the ${BENEFICIAL_OWNER_INDIVIDUAL_PAGE} page when the REDIS_removal flag is ON`, async () => {
       mockGetFromApplicationData.mockReturnValueOnce(BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK);
       const applicationDataMock = { ...APPLICATION_DATA_MOCK };
       delete applicationDataMock[EntityNumberKey];
@@ -253,7 +253,7 @@ describe("BENEFICIAL OWNER INDIVIDUAL controller", () => {
       expect(mockIsActiveFeature).toHaveBeenCalledTimes(2);
     });
 
-    test(`renders the ${BENEFICIAL_OWNER_INDIVIDUAL_PAGE} page when the REDIS_removal flag is off`, async () => {
+    test(`renders the ${BENEFICIAL_OWNER_INDIVIDUAL_PAGE} page when the REDIS_removal flag is OFF`, async () => {
       mockGetFromApplicationData.mockReturnValueOnce(BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK);
       const applicationDataMock = { ...APPLICATION_DATA_MOCK };
       delete applicationDataMock[EntityNumberKey];

--- a/test/controllers/beneficial.owner.individual.controller.spec.ts
+++ b/test/controllers/beneficial.owner.individual.controller.spec.ts
@@ -231,6 +231,50 @@ describe("BENEFICIAL OWNER INDIVIDUAL controller", () => {
       expect(resp.text).toContain(SECOND_NATIONALITY_HINT);
     });
 
+    test(`renders the ${BENEFICIAL_OWNER_INDIVIDUAL_PAGE} page when the REDIS_removal flag is on`, async () => {
+      mockGetFromApplicationData.mockReturnValueOnce(BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK);
+      const applicationDataMock = { ...APPLICATION_DATA_MOCK };
+      delete applicationDataMock[EntityNumberKey];
+      mockGetApplicationData.mockReturnValueOnce(applicationDataMock);
+      mockIsActiveFeature.mockReturnValue(true);
+
+      const resp = await request(app).get(BENEFICIAL_OWNER_INDIVIDUAL_WITH_PARAMS_URL + BO_IND_ID_URL);
+
+      expect(resp.status).toEqual(200);
+      expect(resp.text).toContain(BENEFICIAL_OWNER_INDIVIDUAL_PAGE_HEADING);
+      expect(resp.text).toContain(SAVE_AND_CONTINUE_BUTTON_TEXT);
+      expect(resp.text).toContain("Ivan");
+      expect(resp.text).toContain("Drago");
+      expect(resp.text).toContain("Russian");
+      expect(resp.text).toContain(SECOND_NATIONALITY);
+      expect(resp.text).toContain(SECOND_NATIONALITY_HINT);
+      expect(resp.text).toContain(BACK_BUTTON_CLASS);
+      expect(mockGetUrlWithParamsToPath).toHaveBeenCalledTimes(2);
+      expect(mockIsActiveFeature).toHaveBeenCalledTimes(2);
+    });
+
+    test(`renders the ${BENEFICIAL_OWNER_INDIVIDUAL_PAGE} page when the REDIS_removal flag is off`, async () => {
+      mockGetFromApplicationData.mockReturnValueOnce(BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK);
+      const applicationDataMock = { ...APPLICATION_DATA_MOCK };
+      delete applicationDataMock[EntityNumberKey];
+      mockGetApplicationData.mockReturnValueOnce(applicationDataMock);
+      mockIsActiveFeature.mockReturnValue(false);
+
+      const resp = await request(app).get(BENEFICIAL_OWNER_INDIVIDUAL_WITH_PARAMS_URL + BO_IND_ID_URL);
+
+      expect(resp.status).toEqual(200);
+      expect(resp.text).toContain(BENEFICIAL_OWNER_INDIVIDUAL_PAGE_HEADING);
+      expect(resp.text).toContain(SAVE_AND_CONTINUE_BUTTON_TEXT);
+      expect(resp.text).toContain("Ivan");
+      expect(resp.text).toContain("Drago");
+      expect(resp.text).toContain("Russian");
+      expect(resp.text).toContain(SECOND_NATIONALITY);
+      expect(resp.text).toContain(SECOND_NATIONALITY_HINT);
+      expect(resp.text).toContain(BACK_BUTTON_CLASS);
+      expect(mockGetUrlWithParamsToPath).toHaveBeenCalledTimes(0);
+      expect(mockIsActiveFeature).toHaveBeenCalledTimes(2);
+    });
+
     test("catch error when rendering the page", async () => {
       mockGetFromApplicationData.mockImplementationOnce( () => { throw new Error(ANY_MESSAGE_ERROR); });
       const resp = await request(app).get(BENEFICIAL_OWNER_INDIVIDUAL_URL + BO_IND_ID_URL);

--- a/test/controllers/managing.officer.controller.spec.ts
+++ b/test/controllers/managing.officer.controller.spec.ts
@@ -139,6 +139,44 @@ describe("MANAGING_OFFICER controller", () => {
       expect(resp.text).toContain(ALL_THE_OTHER_INFORMATION_ON_PUBLIC_REGISTER);
       expect(resp.text).toContain(NOT_SHOW_MANAGING_OFFICER_INFORMATION_ON_PUBLIC_REGISTER);
     });
+
+    test(`renders the ${MANAGING_OFFICER_PAGE} page when REDIS_removal flag is ON`, async () => {
+      mockGetApplicationData.mockReturnValueOnce(APPLICATION_DATA_MOCK);
+      mockIsActiveFeature.mockReturnValue(true);
+      const resp = await request(app).get(MANAGING_OFFICER_WITH_PARAMS_URL);
+
+      expect(resp.status).toEqual(200);
+      expect(resp.text).toContain(LANDING_PAGE_URL);
+      expect(resp.text).toContain(MANAGING_OFFICER_PAGE_HEADING);
+      expect(resp.text).not.toContain(PAGE_TITLE_ERROR);
+      expect(resp.text).toContain(SAVE_AND_CONTINUE_BUTTON_TEXT);
+      expect(resp.text).toContain(SECOND_NATIONALITY);
+      expect(resp.text).toContain(SECOND_NATIONALITY_HINT);
+      expect(resp.text).toContain(INFORMATION_SHOWN_ON_THE_PUBLIC_REGISTER);
+      expect(resp.text).toContain(ALL_THE_OTHER_INFORMATION_ON_PUBLIC_REGISTER);
+      expect(resp.text).toContain(NOT_SHOW_MANAGING_OFFICER_INFORMATION_ON_PUBLIC_REGISTER);
+      expect(mockIsActiveFeature).toHaveBeenCalledTimes(1);
+      expect(mockGetUrlWithParamsToPath).toHaveBeenCalledTimes(1);
+    });
+
+    test(`renders the ${MANAGING_OFFICER_PAGE} page when REDIS_removal flag is OFF`, async () => {
+      mockGetApplicationData.mockReturnValueOnce(APPLICATION_DATA_MOCK);
+      mockIsActiveFeature.mockReturnValue(false);
+      const resp = await request(app).get(MANAGING_OFFICER_WITH_PARAMS_URL);
+
+      expect(resp.status).toEqual(200);
+      expect(resp.text).toContain(LANDING_PAGE_URL);
+      expect(resp.text).toContain(MANAGING_OFFICER_PAGE_HEADING);
+      expect(resp.text).not.toContain(PAGE_TITLE_ERROR);
+      expect(resp.text).toContain(SAVE_AND_CONTINUE_BUTTON_TEXT);
+      expect(resp.text).toContain(SECOND_NATIONALITY);
+      expect(resp.text).toContain(SECOND_NATIONALITY_HINT);
+      expect(resp.text).toContain(INFORMATION_SHOWN_ON_THE_PUBLIC_REGISTER);
+      expect(resp.text).toContain(ALL_THE_OTHER_INFORMATION_ON_PUBLIC_REGISTER);
+      expect(resp.text).toContain(NOT_SHOW_MANAGING_OFFICER_INFORMATION_ON_PUBLIC_REGISTER);
+      expect(mockIsActiveFeature).toHaveBeenCalledTimes(1);
+      expect(mockGetUrlWithParamsToPath).toHaveBeenCalledTimes(0);
+    });
   });
 
   describe("GET with url params tests", () => {
@@ -181,6 +219,54 @@ describe("MANAGING_OFFICER controller", () => {
       expect(resp.text).toContain(SECOND_NATIONALITY);
       expect(resp.text).toContain(SECOND_NATIONALITY_HINT);
       expect(resp.text).toContain(MANAGING_OFFICER_URL);
+    });
+
+    test("renders the managing officer page when REDIS_removal flag is set to ON", async () => {
+      const moMock = { ...MANAGING_OFFICER_OBJECT_MOCK };
+      const appData = {
+        ...APPLICATION_DATA_MOCK,
+        [ManagingOfficerKey]: [moMock],
+        [EntityNumberKey]: undefined,
+      };
+      mockGetApplicationData.mockReturnValueOnce(appData);
+      mockGetFromApplicationData.mockReturnValueOnce(moMock);
+      mockIsActiveFeature.mockReturnValue(true);
+      const resp = await request(app).get(MANAGING_OFFICER_WITH_PARAMS_URL + MO_IND_ID_URL);
+
+      expect(resp.status).toEqual(200);
+      expect(resp.text).toContain(MANAGING_OFFICER_PAGE_HEADING);
+      expect(resp.text).toContain(MANAGING_OFFICER);
+      expect(resp.text).toContain("Malawian");
+      expect(resp.text).toContain(SAVE_AND_CONTINUE_BUTTON_TEXT);
+      expect(resp.text).toContain(SECOND_NATIONALITY);
+      expect(resp.text).toContain(SECOND_NATIONALITY_HINT);
+      expect(resp.text).toContain(BACK_BUTTON_CLASS);
+      expect(mockIsActiveFeature).toHaveBeenCalledTimes(2);
+      expect(mockGetUrlWithParamsToPath).toHaveBeenCalledTimes(2);
+    });
+
+    test("renders the managing officer page when REDIS_removal flag is set to OFF", async () => {
+      const moMock = { ...MANAGING_OFFICER_OBJECT_MOCK };
+      const appData = {
+        ...APPLICATION_DATA_MOCK,
+        [ManagingOfficerKey]: [moMock],
+        [EntityNumberKey]: undefined,
+      };
+      mockGetApplicationData.mockReturnValueOnce(appData);
+      mockGetFromApplicationData.mockReturnValueOnce(moMock);
+      mockIsActiveFeature.mockReturnValue(false);
+      const resp = await request(app).get(MANAGING_OFFICER_URL + MO_IND_ID_URL);
+
+      expect(resp.status).toEqual(200);
+      expect(resp.text).toContain(MANAGING_OFFICER_PAGE_HEADING);
+      expect(resp.text).toContain(MANAGING_OFFICER);
+      expect(resp.text).toContain("Malawian");
+      expect(resp.text).toContain(SAVE_AND_CONTINUE_BUTTON_TEXT);
+      expect(resp.text).toContain(SECOND_NATIONALITY);
+      expect(resp.text).toContain(SECOND_NATIONALITY_HINT);
+      expect(resp.text).toContain(BACK_BUTTON_CLASS);
+      expect(mockIsActiveFeature).toHaveBeenCalledTimes(2);
+      expect(mockGetUrlWithParamsToPath).toHaveBeenCalledTimes(0);
     });
 
     test("catch error when rendering the page", async () => {

--- a/test/controllers/managing.officer.corporate.controller.spec.ts
+++ b/test/controllers/managing.officer.corporate.controller.spec.ts
@@ -135,7 +135,7 @@ describe("MANAGING_OFFICER CORPORATE controller", () => {
       expect(resp.text).toContain(SHOW_INFORMATION_ON_PUBLIC_REGISTER);
     });
 
-    test(`renders the ${MANAGING_OFFICER_CORPORATE_PAGE} page with correct backlink url when REDIS_removal feature flag is on`, async () => {
+    test(`renders the ${MANAGING_OFFICER_CORPORATE_PAGE} page with correct backlink url when REDIS_removal feature flag is ON`, async () => {
       mockIsActiveFeature.mockReturnValue(true);
       mockGetApplicationData.mockReturnValueOnce(APPLICATION_DATA_MOCK);
       const resp = await request(app).get(MANAGING_OFFICER_CORPORATE_URL);
@@ -150,7 +150,7 @@ describe("MANAGING_OFFICER CORPORATE controller", () => {
       expect(mockIsActiveFeature).toHaveBeenCalledTimes(1);
     });
 
-    test(`renders the ${MANAGING_OFFICER_CORPORATE_PAGE} page with correct backlink url when REDIS_removal feature flag is off`, async () => {
+    test(`renders the ${MANAGING_OFFICER_CORPORATE_PAGE} page with correct backlink url when REDIS_removal feature flag is OFF`, async () => {
       mockIsActiveFeature.mockReturnValue(false);
       mockIsActiveFeature.mockReturnValue(false);
       mockGetApplicationData.mockReturnValueOnce(APPLICATION_DATA_MOCK);


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/ROE-2558

### Change description

Patches in correct back links for "change or remove" screens for individual BOs and all MOs when accessed via the "beneficial owner or managing officer" screen 

### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes meet accessibility criteria
