### PR TITLE
ROECCT-207 refactor update.beneficial.owner.type.controller to handle…

### DIFF
--- a/src/controllers/update/beneficial.owner.type.controller.ts
+++ b/src/controllers/update/beneficial.owner.type.controller.ts
@@ -22,6 +22,43 @@ import { checkEntityRequiresTrusts, getTrustLandingUrl } from "../../utils/trust
 import { retrieveTrustData } from "../../utils/update/trust.model.fetch";
 import { saveAndContinue } from "../../utils/save.and.continue";
 import { Session } from "@companieshouse/node-session-handler";
+import { validationResult } from "express-validator/src/validation-result";
+import { FormattedValidationErrors, formatValidationError } from "../../middleware/validation.middleware";
+
+type BeneficialOwnerTypePageProperties = {
+  backLinkUrl: string;
+  templateName: string;
+  errors?: FormattedValidationErrors;
+  hasExistingBosMos: boolean;
+  hasNewlyAddedBosMos: boolean;
+};
+
+const getPageProperties = (
+  req: Request,
+  errors?: FormattedValidationErrors,
+): BeneficialOwnerTypePageProperties => {
+  const appData: ApplicationData = getApplicationData(req.session);
+
+  const allBosMos = [
+    ...(appData[BeneficialOwnerIndividualKey] ?? []),
+    ...(appData[BeneficialOwnerOtherKey] ?? []),
+    ...(appData[BeneficialOwnerGovKey] ?? []),
+    ...(appData[ManagingOfficerCorporateKey] ?? []),
+    ...(appData[ManagingOfficerKey] ?? [])
+  ];
+
+  const hasNewlyAddedBosMos = allBosMos.find(boMo => !boMo.ch_reference) !== undefined;
+  const hasExistingBosMos = allBosMos.find(boMo => boMo.ch_reference) !== undefined;
+
+  return {
+    backLinkUrl: config.UPDATE_BENEFICIAL_OWNER_BO_MO_REVIEW_URL,
+    templateName: config.UPDATE_BENEFICIAL_OWNER_TYPE_PAGE,
+    hasNewlyAddedBosMos,
+    hasExistingBosMos,
+    ...appData,
+    errors
+  };
+};
 
 export const get = (req: Request, res: Response, next: NextFunction) => {
   try {
@@ -38,24 +75,9 @@ export const get = (req: Request, res: Response, next: NextFunction) => {
       return res.redirect(checkMoRedirect);
     }
 
-    const allBosMos = [
-      ...(appData[BeneficialOwnerIndividualKey] ?? []),
-      ...(appData[BeneficialOwnerOtherKey] ?? []),
-      ...(appData[BeneficialOwnerGovKey] ?? []),
-      ...(appData[ManagingOfficerCorporateKey] ?? []),
-      ...(appData[ManagingOfficerKey] ?? [])
-    ];
+    const pageProps = getPageProperties(req);
 
-    const hasNewlyAddedBosMos = allBosMos.find(boMo => !boMo.ch_reference) !== undefined;
-    const hasExistingBosMos = allBosMos.find(boMo => boMo.ch_reference) !== undefined;
-
-    return res.render(config.UPDATE_BENEFICIAL_OWNER_TYPE_PAGE, {
-      backLinkUrl: config.UPDATE_BENEFICIAL_OWNER_BO_MO_REVIEW_URL,
-      templateName: config.UPDATE_BENEFICIAL_OWNER_TYPE_PAGE,
-      ...appData,
-      hasExistingBosMos,
-      hasNewlyAddedBosMos
-    });
+    return res.render(pageProps.templateName, pageProps);
   } catch (error) {
     logger.errorRequest(req, error);
     next(error);
@@ -64,6 +86,15 @@ export const get = (req: Request, res: Response, next: NextFunction) => {
 
 export const post = (req: Request, res: Response) => {
   logger.debugRequest(req, `${req.method} ${req.route.path}`);
+
+  //  check on errors
+  const errorList = validationResult(req);
+
+  if (!errorList.isEmpty()) {
+    const pageProps = getPageProperties(req, formatValidationError(errorList.array()));
+
+    return res.render(pageProps.templateName, pageProps);
+  }
   return res.redirect(getNextPage(req.body[BeneficialOwnerTypeKey]));
 };
 

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -683,7 +683,7 @@ router.route(config.UPDATE_BENEFICIAL_OWNER_TYPE_URL)
     navigation.hasUpdatePresenter
   )
   .get(updateBeneficialOwnerType.get)
-  .post(...validator.updateBeneficialOwnerAndManagingOfficerType, checkValidations, updateBeneficialOwnerType.post);
+  .post(...validator.updateBeneficialOwnerAndManagingOfficerType, updateBeneficialOwnerType.post);
 
 router.post(config.UPDATE_BENEFICIAL_OWNER_TYPE_SUBMIT_URL, authentication, navigation.hasUpdatePresenter, updateBeneficialOwnerType.postSubmit);
 

--- a/test/controllers/update/update.beneficial.owner.type.controller.spec.ts
+++ b/test/controllers/update/update.beneficial.owner.type.controller.spec.ts
@@ -148,7 +148,7 @@ describe("BENEFICIAL OWNER TYPE controller", () => {
         appData = APPLICATION_DATA_UPDATE_NO_BO_OR_MO_TO_REVIEW;
         appData[BeneficialOwnerStatementKey] = BeneficialOwnersStatementType.ALL_IDENTIFIED_ALL_DETAILS;
 
-        mockGetApplicationData.mockReturnValueOnce(appData);
+        mockGetApplicationData.mockReturnValueOnce(appData).mockReturnValueOnce(appData);
         const resp = await request(app).get(config.UPDATE_BENEFICIAL_OWNER_TYPE_URL);
 
         expect(resp.status).toEqual(200);
@@ -179,7 +179,7 @@ describe("BENEFICIAL OWNER TYPE controller", () => {
         appData = APPLICATION_DATA_UPDATE_NO_BO_OR_MO_TO_REVIEW;
         appData[key] = [objectWithRef];
 
-        mockGetApplicationData.mockReturnValueOnce(appData);
+        mockGetApplicationData.mockReturnValueOnce(appData).mockReturnValueOnce(appData);
         const resp = await request(app).get(config.UPDATE_BENEFICIAL_OWNER_TYPE_URL);
 
         expect(resp.status).toEqual(200);
@@ -197,7 +197,7 @@ describe("BENEFICIAL OWNER TYPE controller", () => {
         appData = APPLICATION_DATA_UPDATE_NO_BO_OR_MO_TO_REVIEW;
         appData[key] = [mockObject];
 
-        mockGetApplicationData.mockReturnValueOnce(appData);
+        mockGetApplicationData.mockReturnValueOnce(appData).mockReturnValueOnce(appData);
         const resp = await request(app).get(config.UPDATE_BENEFICIAL_OWNER_TYPE_URL);
 
         expect(resp.status).toEqual(200);
@@ -219,7 +219,7 @@ describe("BENEFICIAL OWNER TYPE controller", () => {
       appData = APPLICATION_DATA_UPDATE_NO_BO_OR_MO_TO_REVIEW;
       appData[UpdateKey] = UPDATE_OBJECT_MOCK_RELEVANT_PERIOD_CHANGE;
 
-      mockGetApplicationData.mockReturnValueOnce(appData);
+      mockGetApplicationData.mockReturnValueOnce(appData).mockReturnValueOnce(appData);
       const resp = await request(app).get(config.UPDATE_BENEFICIAL_OWNER_TYPE_URL);
       expect(resp.status).toEqual(200);
       expect(resp.text).toContain(RELEVANT_PERIOD_INDIVIDUAL_BENEFICIAL_OWNER);
@@ -232,7 +232,7 @@ describe("BENEFICIAL OWNER TYPE controller", () => {
       appData = APPLICATION_DATA_UPDATE_NO_BO_OR_MO_TO_REVIEW;
       appData[UpdateKey] = UPDATE_OBJECT_MOCK_RELEVANT_PERIOD_NO_CHANGE;
 
-      mockGetApplicationData.mockReturnValueOnce(appData);
+      mockGetApplicationData.mockReturnValueOnce(appData).mockReturnValueOnce(appData);
       const resp = await request(app).get(config.UPDATE_BENEFICIAL_OWNER_TYPE_URL);
       expect(resp.status).toEqual(200);
       expect(resp.text).toContain(RELEVANT_PERIOD_INDIVIDUAL_BENEFICIAL_OWNER);
@@ -440,8 +440,6 @@ describe("BENEFICIAL OWNER TYPE controller", () => {
     });
 
     test(`redirects to the ${config.UPDATE_BENEFICIAL_OWNER_TYPE_URL + "?relevant-period=true"} page when the relevant_period=true and Other leegal entity button selected`, async () => {
-      appData = APPLICATION_DATA_UPDATE_NO_BO_OR_MO_TO_REVIEW;
-      appData[UpdateKey] = UPDATE_OBJECT_MOCK_RELEVANT_PERIOD_CHANGE;
 
       const resp = await request(app)
         .post(config.UPDATE_BENEFICIAL_OWNER_TYPE_URL)
@@ -452,8 +450,6 @@ describe("BENEFICIAL OWNER TYPE controller", () => {
     });
 
     test(`redirects to the ${config.UPDATE_BENEFICIAL_OWNER_TYPE_URL + RELEVANT_PERIOD_QUERY_PARAM } page when the relevant_period=true and Other leegal entity button selected`, async () => {
-      appData = APPLICATION_DATA_UPDATE_NO_BO_OR_MO_TO_REVIEW;
-      appData[UpdateKey] = UPDATE_OBJECT_MOCK_RELEVANT_PERIOD_CHANGE;
 
       const resp = await request(app)
         .post(config.UPDATE_BENEFICIAL_OWNER_TYPE_URL)
@@ -461,6 +457,21 @@ describe("BENEFICIAL OWNER TYPE controller", () => {
 
       expect(resp.status).toEqual(302);
       expect(resp.header.location).toEqual(config.UPDATE_BENEFICIAL_OWNER_OTHER_URL + RELEVANT_PERIOD_QUERY_PARAM);
+    });
+
+    test(`renders ${config.UPDATE_BENEFICIAL_OWNER_TYPE_URL } page with validation errors when no radio button is selected`, async () => {
+      appData = APPLICATION_DATA_UPDATE_NO_BO_OR_MO_TO_REVIEW;
+      appData[UpdateKey] = UPDATE_OBJECT_MOCK_RELEVANT_PERIOD_CHANGE;
+
+      mockGetApplicationData.mockReturnValueOnce(appData).mockReturnValueOnce(appData);
+
+      const resp = await request(app)
+        .post(config.UPDATE_BENEFICIAL_OWNER_TYPE_URL);
+
+      expect(resp.status).toEqual(200);
+      expect(resp.text).toContain(BENEFICIAL_OWNER_MANAGING_OFFFICER_TYPE_PAGE_HEADING);
+      expect(resp.text).toContain(BENEFICIAL_OWNER_MANAGING_OFFICER_TYPE_LEGEND_TEXT);
+      expect(resp.text).not.toContain(REVIEWED_BENEFICIAL_OWNER_MANAGING_OFFICER_TABLE_HEADING);
     });
 
     test(`redirects to the ${config.UPDATE_BENEFICIAL_OWNER_TYPE_URL + RELEVANT_PERIOD_QUERY_PARAM } page when the relevant_period=true and government entity button selected`, async () => {

--- a/test/controllers/update/update.beneficial.owner.type.controller.spec.ts
+++ b/test/controllers/update/update.beneficial.owner.type.controller.spec.ts
@@ -40,7 +40,7 @@ import {
   REVIEWED_BENEFICIAL_OWNER_MANAGING_OFFICER_TABLE_HEADING,
   NEWLY_ADDED_BENEFICIAL_OWNERS_SUMMARY_TABLE_HEADING,
   MESSAGE_ERROR,
-  RELEVANT_PERIOD_INDIVIDUAL_BENEFICIAL_OWNER,
+  RELEVANT_PERIOD_INDIVIDUAL_BENEFICIAL_OWNER, ERROR_LIST,
 } from '../../__mocks__/text.mock';
 import {
   ERROR,
@@ -459,9 +459,9 @@ describe("BENEFICIAL OWNER TYPE controller", () => {
       expect(resp.header.location).toEqual(config.UPDATE_BENEFICIAL_OWNER_OTHER_URL + RELEVANT_PERIOD_QUERY_PARAM);
     });
 
-    test(`renders ${config.UPDATE_BENEFICIAL_OWNER_TYPE_URL } page with validation errors when no radio button is selected`, async () => {
+    test(`renders ${config.UPDATE_BENEFICIAL_OWNER_TYPE_URL } page with validation errors when no radio button is selected, including reviewed and newly added beneficial owner summaries`, async () => {
       appData = APPLICATION_DATA_UPDATE_NO_BO_OR_MO_TO_REVIEW;
-      appData[UpdateKey] = UPDATE_OBJECT_MOCK_RELEVANT_PERIOD_CHANGE;
+      appData[BeneficialOwnerIndividualKey] = [{ ...BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK, ch_reference: '12345' }, BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK];
 
       mockGetApplicationData.mockReturnValueOnce(appData).mockReturnValueOnce(appData);
 
@@ -471,7 +471,9 @@ describe("BENEFICIAL OWNER TYPE controller", () => {
       expect(resp.status).toEqual(200);
       expect(resp.text).toContain(BENEFICIAL_OWNER_MANAGING_OFFFICER_TYPE_PAGE_HEADING);
       expect(resp.text).toContain(BENEFICIAL_OWNER_MANAGING_OFFICER_TYPE_LEGEND_TEXT);
-      expect(resp.text).not.toContain(REVIEWED_BENEFICIAL_OWNER_MANAGING_OFFICER_TABLE_HEADING);
+      expect(resp.text).toContain(REVIEWED_BENEFICIAL_OWNER_MANAGING_OFFICER_TABLE_HEADING);
+      expect(resp.text).toContain(NEWLY_ADDED_BENEFICIAL_OWNERS_SUMMARY_TABLE_HEADING);
+      expect(resp.text).toContain(ERROR_LIST);
     });
 
     test(`redirects to the ${config.UPDATE_BENEFICIAL_OWNER_TYPE_URL + RELEVANT_PERIOD_QUERY_PARAM } page when the relevant_period=true and government entity button selected`, async () => {

--- a/views/update/update-beneficial-owner-type.html
+++ b/views/update/update-beneficial-owner-type.html
@@ -31,16 +31,16 @@
 {% set entity_name = entity_name %}
 {% set entity_number = entity_number %}
 
-{% if not errors %}
-  {% set hasBeneficialOwners = (beneficial_owners_individual and beneficial_owners_individual.length > 0)
-    or (beneficial_owners_corporate and beneficial_owners_corporate.length > 0)
-    or (beneficial_owners_government_or_public_authority and beneficial_owners_government_or_public_authority.length > 0)
-  %}
 
-  {% set hasManagingOfficers = (managing_officers_individual and managing_officers_individual.length > 0)
-    or (managing_officers_corporate and managing_officers_corporate.length > 0)
-  %}
-{% endif %}
+{% set hasBeneficialOwners = (beneficial_owners_individual and beneficial_owners_individual.length > 0)
+  or (beneficial_owners_corporate and beneficial_owners_corporate.length > 0)
+  or (beneficial_owners_government_or_public_authority and beneficial_owners_government_or_public_authority.length > 0)
+%}
+
+{% set hasManagingOfficers = (managing_officers_individual and managing_officers_individual.length > 0)
+  or (managing_officers_corporate and managing_officers_corporate.length > 0)
+%}
+
 
 {% block pageTitle %}
   {% include "includes/update-page-title.html" %}


### PR DESCRIPTION
This PR moves validation handling for beneficial.owner.type.controller from the checkValidations function into the controller itself. This allows us to pass dynamic data to the page to be rendered without it interacting with the validation error handling.

This fixes a bug where the summary table at the top disappears when validation is triggered and will allow us to pass inn a relevant-period variable to the page to determine if relevant-period features should be active in a later PR

### JIRA link

https://companieshouse.atlassian.net/jira/software/c/projects/ROECCT/boards/562?selectedIssue=ROECCT-207

https://companieshouse.atlassian.net/browse/UAR-1363


### Change description



### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
