### PR TITLE
UAR-1552 Make the 'are they still involved' question appear on legal …

### DIFF
--- a/src/utils/trust.legal.entity.bo.ts
+++ b/src/utils/trust.legal.entity.bo.ts
@@ -33,6 +33,7 @@ type TrustLegalEntityBeneificalOwnerPageProperties = {
   formData?: TrustLegalEntityForm,
   errors?: FormattedValidationErrors,
   url: string,
+  isUpdate: boolean
 };
 
 const getPageProperties = (
@@ -56,6 +57,7 @@ const getPageProperties = (
     formData,
     errors,
     url: getUrl(isUpdate),
+    isUpdate
   };
 };
 

--- a/test/__mocks__/text.mock.ts
+++ b/test/__mocks__/text.mock.ts
@@ -157,6 +157,7 @@ export const TRUST_NOT_ASSOCIATED_WITH_BENEFICIAL_OWNER_TEXT = "This trust is no
 export const TRUST_CEASED_DATE_TEXT = "When did this trust stop being associated with the overseas entity";
 export const TRUST_SELECT_TRUSTEES_TEXT = "Which of the overseas entity’s beneficial owners are trustees of this trust";
 export const TRUST_ENTER_CEASED_DATE = "Enter the date the trust stopped being associated with this overseas entity";
+export const TRUSTEE_STILL_INVOLVED_TEXT = "Are they still involved in the trust";
 
 export const CHANGE_LINK_INDIVIDUAL_BO_LABEL = "Individual beneficial owner ";
 export const CHANGE_LINK_INDIVIDUAL_BO_FIRST_NAME = CHANGE_LINK_INDIVIDUAL_BO_LABEL + "Ivan Drago - first name";

--- a/test/controllers/update/update.trust.individual.beneficial.owner.spec.ts
+++ b/test/controllers/update/update.trust.individual.beneficial.owner.spec.ts
@@ -22,7 +22,7 @@ import { Session } from '@companieshouse/node-session-handler';
 import request from "supertest";
 import app from "../../../src/app";
 import { get, post } from "../../../src/controllers/update/update.trusts.individual.beneficial.owner.controller";
-import { ANY_MESSAGE_ERROR, PAGE_NOT_FOUND_TEXT, PAGE_TITLE_ERROR, UPDATE_TELL_US_ABOUT_THE_INDIVIDUAL_HEADING } from '../../__mocks__/text.mock';
+import { ANY_MESSAGE_ERROR, PAGE_NOT_FOUND_TEXT, PAGE_TITLE_ERROR, TRUSTEE_STILL_INVOLVED_TEXT, UPDATE_TELL_US_ABOUT_THE_INDIVIDUAL_HEADING } from '../../__mocks__/text.mock';
 import { authentication } from '../../../src/middleware/authentication.middleware';
 import { hasTrustWithIdUpdate } from '../../../src/middleware/navigation/has.trust.middleware';
 import {
@@ -218,6 +218,7 @@ describe('Update Trust Individual Beneficial Owner Controller', () => {
       expect(resp.text).toContain(UPDATE_TELL_US_ABOUT_THE_INDIVIDUAL_HEADING);
       expect(resp.text).toContain(mockTrust.trustName);
       expect(resp.text).not.toContain(PAGE_TITLE_ERROR);
+      expect(resp.text).toContain(TRUSTEE_STILL_INVOLVED_TEXT);
 
       expect(authentication).toBeCalledTimes(1);
       expect(hasTrustWithIdUpdate).toBeCalledTimes(1);

--- a/test/controllers/update/update.trust.legal.entity.beneficial.owner.controller.spec.ts
+++ b/test/controllers/update/update.trust.legal.entity.beneficial.owner.controller.spec.ts
@@ -27,7 +27,7 @@ import {
   post,
 } from "../../../src/controllers/update/update.trusts.legal.entity.beneficial.owner.controller";
 import { LEGAL_ENTITY_BO_TEXTS } from "../../../src/utils/trust.legal.entity.bo";
-import { ANY_MESSAGE_ERROR, PAGE_NOT_FOUND_TEXT, PAGE_TITLE_ERROR } from "../../__mocks__/text.mock";
+import { ANY_MESSAGE_ERROR, PAGE_NOT_FOUND_TEXT, PAGE_TITLE_ERROR, TRUSTEE_STILL_INVOLVED_TEXT } from "../../__mocks__/text.mock";
 import { authentication } from "../../../src/middleware/authentication.middleware";
 import { hasTrustWithIdUpdate } from "../../../src/middleware/navigation/has.trust.middleware";
 import {
@@ -227,6 +227,7 @@ describe('Trust Legal Entity Beneficial Owner Controller', () => {
       expect(resp.status).toEqual(constants.HTTP_STATUS_OK);
       expect(resp.text).toContain(LEGAL_ENTITY_BO_TEXTS.title);
       expect(resp.text).not.toContain(PAGE_TITLE_ERROR);
+      expect(resp.text).toContain(TRUSTEE_STILL_INVOLVED_TEXT);
 
       expect(authentication).toBeCalledTimes(1);
       expect(hasTrustWithIdUpdate).toBeCalledTimes(1);


### PR DESCRIPTION
…trustee page when adding new trust on update journey

### JIRA link
https://companieshouse.atlassian.net/browse/UAR-1552


### Change description
Make the 'are they still involved' question appear on the legal trustee page when adding a new one on a new trust on an update/remove journey.


### Work checklist

- [x] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
