### PR TITLE
UAR-1561 Correct display of trustees for ceased trust

### DIFF
--- a/test/controllers/update/check.your.answers.controller.spec.ts
+++ b/test/controllers/update/check.your.answers.controller.spec.ts
@@ -884,7 +884,7 @@ describe("CHECK YOUR ANSWERS controller", () => {
       expect(resp.text).toContain("2023");
 
       expect(resp.text).toContain(`${TRUSTEE_LEGAL_ENTITY_TITLE} Flying Cats`);
-      expect(resp.text).toContain(TRUSTEE_INDIVIDUAL_INVOLVED);
+      expect(resp.text).toContain(TRUSTEE_LEGAL_ENTITY_INVOLVED);
       expect(resp.text).toContain(TRUSTEE_LEGAL_ENTITY_CEASED_DATE);
       expect(resp.text).toContain("10");
       expect(resp.text).toContain("May");
@@ -929,7 +929,7 @@ describe("CHECK YOUR ANSWERS controller", () => {
       expect(resp.text).toContain("2024");
 
       expect(resp.text).toContain(`${TRUSTEE_LEGAL_ENTITY_TITLE} Flying Cats`);
-      expect(resp.text).toContain(TRUSTEE_INDIVIDUAL_INVOLVED);
+      expect(resp.text).toContain(TRUSTEE_LEGAL_ENTITY_INVOLVED);
       expect(resp.text).not.toContain(TRUSTEE_LEGAL_ENTITY_CEASED_DATE);
     });
 
@@ -968,7 +968,89 @@ describe("CHECK YOUR ANSWERS controller", () => {
       expect(resp.text).not.toContain(TRUSTEE_INDIVIDUAL_CEASED_DATE);
 
       expect(resp.text).toContain(`${TRUSTEE_LEGAL_ENTITY_TITLE} Flying Cats`);
+      expect(resp.text).toContain(TRUSTEE_LEGAL_ENTITY_INVOLVED);
+      expect(resp.text).toContain(TRUSTEE_LEGAL_ENTITY_CEASED_DATE);
+      expect(resp.text).toContain("10");
+      expect(resp.text).toContain("May");
+      expect(resp.text).toContain("2024");
+    });
+
+    test(`renders the ${UPDATE_CHECK_YOUR_ANSWERS_PAGE} page when a reviewed trust is not still involved in the overseas entity trustee still involved fields are excluded`, async () => {
+
+      const trustee = {
+        ...INDIVIUAL_TRUSTEE,
+        still_involved: "Yes"
+      };
+
+      const coprorateTrustee = {
+        ...CORPORATE_TRUSTEE,
+        still_involved: "Yes"
+      };
+
+      const appData = {
+        ...APPLICATION_DATA_UPDATE_BO_MOCK,
+        ["trusts"]: [{
+          ...TRUST_WITH_ID,
+          trust_still_involved_in_overseas_entity: "No",
+          ceased_date_day: "10",
+          ceased_date_month: "05",
+          ceased_date_year: "2024",
+          INDIVIDUALS: [trustee],
+          CORPORATES: [coprorateTrustee]
+        }]
+      };
+
+      mockGetApplicationData.mockReturnValue(appData);
+      mockIsActiveFeature.mockReturnValueOnce(true).mockReturnValueOnce(true).mockReturnValueOnce(true).mockReturnValueOnce(true);
+      const resp = await request(app).get(UPDATE_CHECK_YOUR_ANSWERS_URL);
+
+      expect(resp.text).not.toContain(TRUSTEE_INDIVIDUAL_INVOLVED);
+      expect(resp.text).not.toContain(TRUSTEE_INDIVIDUAL_CEASED_DATE);
+      expect(resp.text).not.toContain(TRUSTEE_LEGAL_ENTITY_INVOLVED);
+      expect(resp.text).not.toContain(TRUSTEE_LEGAL_ENTITY_CEASED_DATE);
+    });
+
+    test(`renders the ${UPDATE_CHECK_YOUR_ANSWERS_PAGE} page when a reviewed trust is not still involved in the overseas entity trustee still involved fields are excluded`, async () => {
+
+      const trustee = {
+        ...INDIVIUAL_TRUSTEE,
+        still_involved: "No",
+        ceased_date_day: "10",
+        ceased_date_month: "05",
+        ceased_date_year: "2024",
+      };
+
+      const coprorateTrustee = {
+        ...CORPORATE_TRUSTEE,
+        still_involved: "No",
+        ceased_date_day: "10",
+        ceased_date_month: "05",
+        ceased_date_year: "2024",
+      };
+
+      const appData = {
+        ...APPLICATION_DATA_UPDATE_BO_MOCK,
+        ["trusts"]: [{
+          ...TRUST_WITH_ID,
+          trust_still_involved_in_overseas_entity: "No",
+          ceased_date_day: "01",
+          ceased_date_month: "05",
+          ceased_date_year: "2024",
+          INDIVIDUALS: [trustee],
+          CORPORATES: [coprorateTrustee]
+        }]
+      };
+
+      mockGetApplicationData.mockReturnValue(appData);
+      mockIsActiveFeature.mockReturnValueOnce(true).mockReturnValueOnce(true).mockReturnValueOnce(true).mockReturnValueOnce(true);
+      const resp = await request(app).get(UPDATE_CHECK_YOUR_ANSWERS_URL);
+
       expect(resp.text).toContain(TRUSTEE_INDIVIDUAL_INVOLVED);
+      expect(resp.text).toContain(TRUSTEE_INDIVIDUAL_CEASED_DATE);
+      expect(resp.text).toContain("10");
+      expect(resp.text).toContain("May");
+      expect(resp.text).toContain("2024");
+      expect(resp.text).toContain(TRUSTEE_LEGAL_ENTITY_INVOLVED);
       expect(resp.text).toContain(TRUSTEE_LEGAL_ENTITY_CEASED_DATE);
       expect(resp.text).toContain("10");
       expect(resp.text).toContain("May");

--- a/test/controllers/update/check.your.answers.controller.spec.ts
+++ b/test/controllers/update/check.your.answers.controller.spec.ts
@@ -1010,7 +1010,7 @@ describe("CHECK YOUR ANSWERS controller", () => {
       expect(resp.text).not.toContain(TRUSTEE_LEGAL_ENTITY_CEASED_DATE);
     });
 
-    test(`renders the ${UPDATE_CHECK_YOUR_ANSWERS_PAGE} page when a reviewed trust is not still involved in the overseas entity trustee still involved fields are excluded`, async () => {
+    test(`renders the ${UPDATE_CHECK_YOUR_ANSWERS_PAGE} page when a reviewed trust and reviewed trustees are all specified as not still involved`, async () => {
 
       const trustee = {
         ...INDIVIUAL_TRUSTEE,

--- a/views/includes/check-your-answers/individual-trustee.html
+++ b/views/includes/check-your-answers/individual-trustee.html
@@ -209,7 +209,7 @@
   }), rows) %}
 {% endif %}
 
-{% if not pageParams.isRegistration %}
+{% if not pageParams.isRegistration and (trustStillInvolved === "Yes" or isNotStillInvolved) %}
   {% set rows = (rows.push({
     key: {
     text: "Are they still involved in the trust?"

--- a/views/includes/check-your-answers/individual-trustee.html
+++ b/views/includes/check-your-answers/individual-trustee.html
@@ -209,7 +209,7 @@
   }), rows) %}
 {% endif %}
 
-{% if not pageParams.isRegistration and (trustStillInvolved === "Yes" or isNotStillInvolved) %}
+{% if not pageParams.isRegistration and (isTrustStillInvolved or isNotStillInvolved) %}
   {% set rows = (rows.push({
     key: {
     text: "Are they still involved in the trust?"

--- a/views/includes/check-your-answers/legal-entity-trustee.html
+++ b/views/includes/check-your-answers/legal-entity-trustee.html
@@ -217,7 +217,7 @@
   } if not inNoChangeJourney
 }), rows) %}
 
-{% if not pageParams.isRegistration %}
+{% if not pageParams.isRegistration and (trustStillInvolved === "Yes" or isNotStillInvolved) %}
   {% set rows = (rows.push({
     key: {
     text: "Is it still involved in the trust?"

--- a/views/includes/check-your-answers/legal-entity-trustee.html
+++ b/views/includes/check-your-answers/legal-entity-trustee.html
@@ -217,7 +217,7 @@
   } if not inNoChangeJourney
 }), rows) %}
 
-{% if not pageParams.isRegistration and (trustStillInvolved === "Yes" or isNotStillInvolved) %}
+{% if not pageParams.isRegistration and (isTrustStillInvolved or isNotStillInvolved) %}
   {% set rows = (rows.push({
     key: {
     text: "Is it still involved in the trust?"

--- a/views/includes/check-your-answers/trusts.html
+++ b/views/includes/check-your-answers/trusts.html
@@ -18,8 +18,8 @@
   {% if isRegistration  %}
     {% set changeLinkUrl = OE_CONFIGS.TRUST_DETAILS_URL %}
   {% else %}
-    {% set stillInvolved = trust.trust_still_involved_in_overseas_entity %}
-    {% set isNotStillInvolved = stillInvolved === "No" %}    
+    {% set trustStillInvolved = trust.trust_still_involved_in_overseas_entity %}
+    {% set isNottrustStillInvolved = trustStillInvolved === "No" %}    
     {% set trustCeasedDate = dateMacros.formatDate(trust.ceased_date_day, trust.ceased_date_month, trust.ceased_date_year) %}
     {% if manageTrusts %}
       {% set changeLinkUrl = OE_CONFIGS.UPDATE_MANAGE_TRUSTS_ORCHESTRATOR_CHANGE_HANDLER_URL %}
@@ -81,7 +81,7 @@
           text: "Is the trust still involved in the overseas entity?"
         },
         value: {
-          text: stillInvolved
+          text: trustStillInvolved
         },
         actions: {
           items: [ CREATE_CHANGE_LINK(
@@ -105,7 +105,7 @@
             "change-trust-ceased-date-button"
           ) ]
         } 
-      } if not isRegistration and isNotStillInvolved
+      } if not isRegistration and isNottrustStillInvolved
     ]
 }) }}
   <br>

--- a/views/includes/check-your-answers/trusts.html
+++ b/views/includes/check-your-answers/trusts.html
@@ -19,6 +19,7 @@
     {% set changeLinkUrl = OE_CONFIGS.TRUST_DETAILS_URL %}
   {% else %}
     {% set trustStillInvolved = trust.trust_still_involved_in_overseas_entity %}
+    {% set isTrustStillInvolved = trustStillInvolved === "Yes" %}  
     {% set isTrustNotStillInvolved = trustStillInvolved === "No" %}    
     {% set trustCeasedDate = dateMacros.formatDate(trust.ceased_date_day, trust.ceased_date_month, trust.ceased_date_year) %}
     {% if manageTrusts %}

--- a/views/includes/check-your-answers/trusts.html
+++ b/views/includes/check-your-answers/trusts.html
@@ -19,7 +19,7 @@
     {% set changeLinkUrl = OE_CONFIGS.TRUST_DETAILS_URL %}
   {% else %}
     {% set trustStillInvolved = trust.trust_still_involved_in_overseas_entity %}
-    {% set isNottrustStillInvolved = trustStillInvolved === "No" %}    
+    {% set isTrustNotStillInvolved = trustStillInvolved === "No" %}    
     {% set trustCeasedDate = dateMacros.formatDate(trust.ceased_date_day, trust.ceased_date_month, trust.ceased_date_year) %}
     {% if manageTrusts %}
       {% set changeLinkUrl = OE_CONFIGS.UPDATE_MANAGE_TRUSTS_ORCHESTRATOR_CHANGE_HANDLER_URL %}
@@ -105,7 +105,7 @@
             "change-trust-ceased-date-button"
           ) ]
         } 
-      } if not isRegistration and isNottrustStillInvolved
+      } if not isRegistration and isTrustNotStillInvolved
     ]
 }) }}
   <br>


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/UAR-1561

### Change description

Updated the templates with more detailed conditions for displaying trustee "still involved" fields.

### Work checklist

- [x] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
