### PR TITLE
uar-1566 hide changelinks & sections on an oe02 no change journey

### DIFF
--- a/views/includes/check-your-answers/individual-trustee.html
+++ b/views/includes/check-your-answers/individual-trustee.html
@@ -224,7 +224,7 @@
           "change-individual-beneficial-owner-still-involved-button"
         ) ]
       }
-    }), rows) %}
+    }) if not inNoChangeJourney, rows) %}
     
     {% set rows = (rows.push({
       key: {

--- a/views/includes/check-your-answers/legal-entity-trustee.html
+++ b/views/includes/check-your-answers/legal-entity-trustee.html
@@ -232,7 +232,7 @@
           "change-legal-entity-still-involved-button"
         ) ]
       }
-    }), rows) %}
+    }) if not inNoChangeJourney, rows) %}
     
     {% set rows = (rows.push({
       key: {

--- a/views/includes/check-your-answers/trusts.html
+++ b/views/includes/check-your-answers/trusts.html
@@ -91,7 +91,7 @@
             "change-trust-still-involved-button"
           ) ]
         } 
-      } if not isRegistration,
+      } if not isRegistration and not inNoChangeJourney,
       {
         key: {
           text: "Date the trust stopped being associated to the overseas entity"


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/UAR-1566

### Change description

Hidden the following trust sections on review-update-statement page to not show on a no change journey

“Is the trust still involved in the overseas entity?” 
"Is it still involved in the trust?"
“Are they still involved in the trust?” 

### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
