### PR TITLE
UAR-1508 Ensure BOs don't lose their trust associations when updated

### DIFF
--- a/src/controllers/update/update.review.beneficial.owner.individual.ts
+++ b/src/controllers/update/update.review.beneficial.owner.individual.ts
@@ -61,10 +61,7 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
       const dob = boData.date_of_birth as InputDate;
       const haveDayOfBirth = boData.have_day_of_birth;
 
-      let trustIds: string[] = [];
-      if (boData.trust_ids) {
-        trustIds = boData.trust_ids;
-      }
+      const trustIds: string[] = boData?.trust_ids?.length ? [...boData.trust_ids] : [];
 
       removeFromApplicationData(req, BeneficialOwnerIndividualKey, boId);
 
@@ -78,7 +75,7 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
       }
 
       if (trustIds.length > 0) {
-        (data as BeneficialOwnerIndividual).trust_ids = trustIds;
+        (data as BeneficialOwnerIndividual).trust_ids = [...trustIds];
       }
 
       setApplicationData(req.session, data, BeneficialOwnerIndividualKey);

--- a/src/controllers/update/update.review.beneficial.owner.individual.ts
+++ b/src/controllers/update/update.review.beneficial.owner.individual.ts
@@ -6,7 +6,7 @@ import {
 import { NextFunction, Request, Response } from "express";
 import { getApplicationData, mapDataObjectToFields, removeFromApplicationData, setApplicationData } from "../../utils/application.data";
 import { logger } from "../../utils/logger";
-import { BeneficialOwnerIndividualKey } from "../../model/beneficial.owner.individual.model";
+import { BeneficialOwnerIndividual, BeneficialOwnerIndividualKey } from "../../model/beneficial.owner.individual.model";
 import { ApplicationDataType } from "../../model";
 import { setBeneficialOwnerData } from "../../utils/beneficial.owner.individual";
 import { v4 as uuidv4 } from "uuid";
@@ -55,19 +55,30 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
     const boiIndex = req.query.index;
     const appData = getApplicationData(req.session);
 
-    if (boiIndex !== undefined && appData.beneficial_owners_individual && appData.beneficial_owners_individual[Number(boiIndex)].id === req.body["id"]){
-      const boId = appData.beneficial_owners_individual[Number(boiIndex)].id;
-      const dob = appData.beneficial_owners_individual[Number(boiIndex)].date_of_birth as InputDate;
-      const haveDayOfBirth = appData.beneficial_owners_individual[Number(boiIndex)].have_day_of_birth;
+    if (boiIndex !== undefined && appData.beneficial_owners_individual && appData.beneficial_owners_individual[Number(boiIndex)].id === req.body["id"]) {
+      const boData: BeneficialOwnerIndividual = appData.beneficial_owners_individual[Number(boiIndex)];
+      const boId = boData.id;
+      const dob = boData.date_of_birth as InputDate;
+      const haveDayOfBirth = boData.have_day_of_birth;
+
+      let trustIds: string[] = [];
+      if (boData.trust_ids) {
+        trustIds = boData.trust_ids;
+      }
 
       removeFromApplicationData(req, BeneficialOwnerIndividualKey, boId);
 
       setReviewedDateOfBirth(req, dob);
+
       const session = req.session as Session;
 
       const data: ApplicationDataType = setBeneficialOwnerData(req.body, uuidv4());
       if (haveDayOfBirth) {
         data[HaveDayOfBirthKey] = haveDayOfBirth;
+      }
+
+      if (trustIds.length > 0) {
+        (data as BeneficialOwnerIndividual).trust_ids = trustIds;
       }
 
       setApplicationData(req.session, data, BeneficialOwnerIndividualKey);

--- a/src/controllers/update/update.review.beneficial.owner.other.ts
+++ b/src/controllers/update/update.review.beneficial.owner.other.ts
@@ -67,10 +67,7 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
       const boData: BeneficialOwnerOther = appData.beneficial_owners_corporate[Number(booIndex)];
       const boId = boData.id;
 
-      let trustIds: string[] = [];
-      if (boData.trust_ids) {
-        trustIds = boData.trust_ids;
-      }
+      const trustIds: string[] = boData?.trust_ids?.length ? [...boData.trust_ids] : [];
 
       removeFromApplicationData(req, BeneficialOwnerOtherKey, boId);
 
@@ -79,7 +76,7 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
       const data: ApplicationDataType = setBeneficialOwnerData(req.body, uuidv4());
 
       if (trustIds.length > 0) {
-        (data as BeneficialOwnerOther).trust_ids = trustIds;
+        (data as BeneficialOwnerOther).trust_ids = [...trustIds];
       }
 
       setApplicationData(req.session, data, BeneficialOwnerOtherKey);

--- a/src/controllers/update/update.review.beneficial.owner.other.ts
+++ b/src/controllers/update/update.review.beneficial.owner.other.ts
@@ -8,7 +8,7 @@ import { getApplicationData, mapDataObjectToFields, removeFromApplicationData, s
 import { logger } from "../../utils/logger";
 import { CeasedDateKey } from "../../model/date.model";
 import { addCeasedDateToTemplateOptions } from "../../utils/update/ceased_date_util";
-import { BeneficialOwnerOtherKey } from "../../model/beneficial.owner.other.model";
+import { BeneficialOwnerOther, BeneficialOwnerOtherKey } from "../../model/beneficial.owner.other.model";
 import { Session } from "@companieshouse/node-session-handler";
 import { ApplicationDataType } from "../../model";
 import { setBeneficialOwnerData } from "../../utils/beneficial.owner.other";
@@ -63,13 +63,24 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
     const booIndex = req.query.index;
     const appData = getApplicationData(req.session);
 
-    if (booIndex !== undefined && appData.beneficial_owners_corporate && appData.beneficial_owners_corporate[Number(booIndex)].id === req.body["id"]){
-      const boId = appData.beneficial_owners_corporate[Number(booIndex)].id;
+    if (booIndex !== undefined && appData.beneficial_owners_corporate && appData.beneficial_owners_corporate[Number(booIndex)].id === req.body["id"]) {
+      const boData: BeneficialOwnerOther = appData.beneficial_owners_corporate[Number(booIndex)];
+      const boId = boData.id;
+
+      let trustIds: string[] = [];
+      if (boData.trust_ids) {
+        trustIds = boData.trust_ids;
+      }
+
       removeFromApplicationData(req, BeneficialOwnerOtherKey, boId);
 
       const session = req.session as Session;
 
       const data: ApplicationDataType = setBeneficialOwnerData(req.body, uuidv4());
+
+      if (trustIds.length > 0) {
+        (data as BeneficialOwnerOther).trust_ids = trustIds;
+      }
 
       setApplicationData(req.session, data, BeneficialOwnerOtherKey);
 

--- a/src/utils/beneficial.owner.individual.ts
+++ b/src/utils/beneficial.owner.individual.ts
@@ -123,10 +123,7 @@ export const updateBeneficialOwnerIndividual = async (req: Request, res: Respons
     const id = req.params[ID];
     const boData: BeneficialOwnerIndividual = getFromApplicationData(req, BeneficialOwnerIndividualKey, id, true);
 
-    let trustIds: string[] = [];
-    if (boData.trust_ids) {
-      trustIds = boData.trust_ids;
-    }
+    const trustIds: string[] = boData?.trust_ids?.length ? [...boData.trust_ids] : [];
 
     // Remove old Beneficial Owner
     removeFromApplicationData(req, BeneficialOwnerIndividualKey, id);
@@ -135,7 +132,7 @@ export const updateBeneficialOwnerIndividual = async (req: Request, res: Respons
     const data: ApplicationDataType = setBeneficialOwnerData(req.body, id);
 
     if (trustIds.length > 0) {
-      (data as BeneficialOwnerIndividual).trust_ids = trustIds;
+      (data as BeneficialOwnerIndividual).trust_ids = [...trustIds];
     }
 
     const session = req.session as Session;

--- a/src/utils/beneficial.owner.individual.ts
+++ b/src/utils/beneficial.owner.individual.ts
@@ -7,6 +7,7 @@ import { saveAndContinue } from "../utils/save.and.continue";
 import { ApplicationDataType, ApplicationData } from "../model";
 import { logger } from "../utils/logger";
 import {
+  BeneficialOwnerIndividual,
   BeneficialOwnerIndividualKey,
   BeneficialOwnerIndividualKeys
 } from "../model/beneficial.owner.individual.model";
@@ -119,11 +120,24 @@ export const updateBeneficialOwnerIndividual = async (req: Request, res: Respons
   try {
     logger.debugRequest(req, `UPDATE ${req.route.path}`);
 
+    const id = req.params[ID];
+    const boData: BeneficialOwnerIndividual = getFromApplicationData(req, BeneficialOwnerIndividualKey, id, true);
+
+    let trustIds: string[] = [];
+    if (boData.trust_ids) {
+      trustIds = boData.trust_ids;
+    }
+
     // Remove old Beneficial Owner
-    removeFromApplicationData(req, BeneficialOwnerIndividualKey, req.params[ID]);
+    removeFromApplicationData(req, BeneficialOwnerIndividualKey, id);
 
     // Set Beneficial Owner data
-    const data: ApplicationDataType = setBeneficialOwnerData(req.body, req.params[ID]);
+    const data: ApplicationDataType = setBeneficialOwnerData(req.body, id);
+
+    if (trustIds.length > 0) {
+      (data as BeneficialOwnerIndividual).trust_ids = trustIds;
+    }
+
     const session = req.session as Session;
 
     // Save new Beneficial Owner

--- a/src/utils/beneficial.owner.other.ts
+++ b/src/utils/beneficial.owner.other.ts
@@ -107,10 +107,7 @@ export const updateBeneficialOwnerOther = async (req: Request, res: Response, ne
     const id = req.params[ID];
     const boData: BeneficialOwnerOther = getFromApplicationData(req, BeneficialOwnerOtherKey, id, true);
 
-    let trustIds: string[] = [];
-    if (boData.trust_ids) {
-      trustIds = boData.trust_ids;
-    }
+    const trustIds: string[] = boData?.trust_ids?.length ? [...boData.trust_ids] : [];
 
     // Remove old Beneficial Owner
     removeFromApplicationData(req, BeneficialOwnerOtherKey, id);
@@ -119,7 +116,7 @@ export const updateBeneficialOwnerOther = async (req: Request, res: Response, ne
     const data: ApplicationDataType = setBeneficialOwnerData(req.body, id);
 
     if (trustIds.length > 0) {
-      (data as BeneficialOwnerOther).trust_ids = trustIds;
+      (data as BeneficialOwnerOther).trust_ids = [...trustIds];
     }
 
     // Save new Beneficial Owner

--- a/src/utils/beneficial.owner.other.ts
+++ b/src/utils/beneficial.owner.other.ts
@@ -5,7 +5,7 @@ import { saveAndContinue } from "./save.and.continue";
 import { ApplicationData, ApplicationDataType } from "../model";
 import { getApplicationData, getFromApplicationData, mapDataObjectToFields, mapFieldsToDataObject, prepareData, removeFromApplicationData, setApplicationData } from "./application.data";
 import { addCeasedDateToTemplateOptions } from "../utils/update/ceased_date_util";
-import { BeneficialOwnerOtherKey, BeneficialOwnerOtherKeys } from "../model/beneficial.owner.other.model";
+import { BeneficialOwnerOther, BeneficialOwnerOtherKey, BeneficialOwnerOtherKeys } from "../model/beneficial.owner.other.model";
 import {
   AddressKeys,
   BeneficialOwnerNoc,
@@ -104,11 +104,23 @@ export const updateBeneficialOwnerOther = async (req: Request, res: Response, ne
   try {
     logger.debugRequest(req, `UPDATE ${req.route.path}`);
 
+    const id = req.params[ID];
+    const boData: BeneficialOwnerOther = getFromApplicationData(req, BeneficialOwnerOtherKey, id, true);
+
+    let trustIds: string[] = [];
+    if (boData.trust_ids) {
+      trustIds = boData.trust_ids;
+    }
+
     // Remove old Beneficial Owner
-    removeFromApplicationData(req, BeneficialOwnerOtherKey, req.params[ID]);
+    removeFromApplicationData(req, BeneficialOwnerOtherKey, id);
 
     // Set Beneficial Owner data
-    const data: ApplicationDataType = setBeneficialOwnerData(req.body, req.params[ID]);
+    const data: ApplicationDataType = setBeneficialOwnerData(req.body, id);
+
+    if (trustIds.length > 0) {
+      (data as BeneficialOwnerOther).trust_ids = trustIds;
+    }
 
     // Save new Beneficial Owner
     const session = req.session as Session;

--- a/test/__mocks__/session.mock.ts
+++ b/test/__mocks__/session.mock.ts
@@ -324,7 +324,7 @@ export const BENEFICIAL_OWNER_OTHER_OBJECT_MOCK: beneficialOwnerOtherType.Benefi
   non_legal_firm_members_nature_of_control_types: [NatureOfControlType.OVER_25_PERCENT_OF_SHARES],
   is_on_sanctions_list: 0,
   ...START_DATE,
-  trust_ids: []
+  trust_ids: ["6"]
 };
 
 export const BENEFICIAL_OWNER_OTHER_NO_TRUSTEE_OBJECT_MOCK: beneficialOwnerOtherType.BeneficialOwnerOther = {
@@ -383,7 +383,7 @@ export const UPDATE_BENEFICIAL_OWNER_OTHER_OBJECT_MOCK: beneficialOwnerOtherType
   non_legal_firm_members_nature_of_control_types: [NatureOfControlType.OVER_25_PERCENT_OF_SHARES],
   is_on_sanctions_list: 0,
   ...START_DATE,
-  trust_ids: []
+  trust_ids: ["8"]
 };
 
 export const UPDATE_REVIEW_BENEFICIAL_OWNER_OTHER_REQ_MOCK = {
@@ -473,7 +473,7 @@ export const BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK: beneficialOwnerIndividualT
   trustees_nature_of_control_types: [NatureOfControlType.OVER_25_PERCENT_OF_VOTING_RIGHTS],
   non_legal_firm_members_nature_of_control_types: [NatureOfControlType.APPOINT_OR_REMOVE_MAJORITY_BOARD_DIRECTORS],
   is_on_sanctions_list: 1,
-  trust_ids: []
+  trust_ids: ["5"]
 };
 
 export const BENEFICIAL_OWNER_INDIVIDUAL_NO_TRUSTEE_OBJECT_MOCK: beneficialOwnerIndividualType.BeneficialOwnerIndividual = {

--- a/test/controllers/beneficial.owner.individual.controller.spec.ts
+++ b/test/controllers/beneficial.owner.individual.controller.spec.ts
@@ -77,7 +77,7 @@ import {
   BENEFICIAL_OWNER_INDIVIDUAL_WITH_MAX_LENGTH_FIELDS_MOCK
 } from '../__mocks__/validation.mock';
 
-import { BeneficialOwnerIndividualKey } from '../../src/model/beneficial.owner.individual.model';
+import { BeneficialOwnerIndividual, BeneficialOwnerIndividualKey } from '../../src/model/beneficial.owner.individual.model';
 import { AddressKeys, EntityNumberKey } from '../../src/model/data.types.model';
 import { saveAndContinue } from "../../src/utils/save.and.continue";
 import { ErrorMessages } from '../../src/validation/error.messages';
@@ -1665,6 +1665,8 @@ describe("BENEFICIAL OWNER INDIVIDUAL controller", () => {
 
   describe("UPDATE tests", () => {
     test(`redirects to the ${BENEFICIAL_OWNER_TYPE_PAGE} page`, async () => {
+      mockGetFromApplicationData.mockReturnValueOnce(BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK);
+
       mockPrepareData.mockReturnValueOnce(BENEFICIAL_OWNER_INDIVIDUAL_REQ_BODY_OBJECT_MOCK);
       const resp = await request(app)
         .post(BENEFICIAL_OWNER_INDIVIDUAL_URL + BO_IND_ID_URL)
@@ -1687,6 +1689,7 @@ describe("BENEFICIAL OWNER INDIVIDUAL controller", () => {
     });
 
     test(`replaces existing object on submit`, async () => {
+      mockGetFromApplicationData.mockReturnValueOnce(BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK);
       mockPrepareData.mockReturnValueOnce(BENEFICIAL_OWNER_INDIVIDUAL_REPLACE);
       const resp = await request(app)
         .post(BENEFICIAL_OWNER_INDIVIDUAL_URL + BO_IND_ID_URL)
@@ -1695,14 +1698,20 @@ describe("BENEFICIAL OWNER INDIVIDUAL controller", () => {
       expect(mockRemoveFromApplicationData.mock.calls[0][1]).toEqual(BeneficialOwnerIndividualKey);
       expect(mockRemoveFromApplicationData.mock.calls[0][2]).toEqual(BO_IND_ID);
 
+      const data = mockSetApplicationData.mock.calls[0][1];
+      expect(data.id).toEqual(BO_IND_ID);
       expect(mockSetApplicationData.mock.calls[0][1].id).toEqual(BO_IND_ID);
       expect(mockSetApplicationData.mock.calls[0][2]).toEqual(BeneficialOwnerIndividualKey);
+
+      // Ensure that trust ids on the original BO aren't lost during the update
+      expect((data as BeneficialOwnerIndividual).trust_ids).toEqual(BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK.trust_ids);
 
       expect(resp.status).toEqual(302);
       expect(resp.header.location).toEqual(BENEFICIAL_OWNER_TYPE_URL);
     });
 
     test(`Service address from the ${BENEFICIAL_OWNER_INDIVIDUAL_PAGE} is present when same address is set to no`, async () => {
+      mockGetFromApplicationData.mockReturnValueOnce(BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK);
       mockPrepareData.mockReturnValueOnce( { ...BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK_WITH_SERVICE_ADDRESS_NO } );
       await request(app)
         .post(BENEFICIAL_OWNER_INDIVIDUAL_URL + BO_IND_ID_URL)
@@ -1714,6 +1723,7 @@ describe("BENEFICIAL OWNER INDIVIDUAL controller", () => {
     });
 
     test(`Service address from the ${BENEFICIAL_OWNER_INDIVIDUAL_PAGE} is empty when same address is set to yes`, async () => {
+      mockGetFromApplicationData.mockReturnValueOnce(BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK);
       mockPrepareData.mockImplementationOnce( () => BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK_WITH_SERVICE_ADDRESS_YES);
       await request(app)
         .post(BENEFICIAL_OWNER_INDIVIDUAL_URL + BO_IND_ID_URL)

--- a/test/controllers/beneficial.owner.other.controller.spec.ts
+++ b/test/controllers/beneficial.owner.other.controller.spec.ts
@@ -69,7 +69,7 @@ import {
   NatureOfControlType, PublicRegisterNameKey, RegistrationNumberKey,
   yesNoResponse
 } from "../../src/model/data.types.model";
-import { BeneficialOwnerOtherKey } from "../../src/model/beneficial.owner.other.model";
+import { BeneficialOwnerOther, BeneficialOwnerOtherKey } from "../../src/model/beneficial.owner.other.model";
 import {
   BENEFICIAL_OWNER_OTHER_WITH_INVALID_CHARS_MOCK,
   BENEFICIAL_OWNER_OTHER_WITH_INVALID_CHARS_SERVICE_ADDRESS_MOCK,
@@ -1198,6 +1198,7 @@ describe("BENEFICIAL OWNER OTHER controller", () => {
 
   describe("UPDATE tests", () => {
     test(`Redirects to the ${BENEFICIAL_OWNER_TYPE_URL} page`, async () => {
+      mockGetFromApplicationData.mockReturnValueOnce(BENEFICIAL_OWNER_OTHER_OBJECT_MOCK);
       mockPrepareData.mockReturnValueOnce({ ...BENEFICIAL_OWNER_OTHER_BODY_OBJECT_MOCK_WITH_ADDRESS });
       const resp = await request(app).post(BENEFICIAL_OWNER_OTHER_URL + BO_OTHER_ID_URL)
         .send(BENEFICIAL_OWNER_OTHER_BODY_OBJECT_MOCK_WITH_ADDRESS);
@@ -1218,6 +1219,7 @@ describe("BENEFICIAL OWNER OTHER controller", () => {
     });
 
     test(`Replaces existing object on submit`, async () => {
+      mockGetFromApplicationData.mockReturnValueOnce(BENEFICIAL_OWNER_OTHER_OBJECT_MOCK);
       mockPrepareData.mockReturnValueOnce({ ...BENEFICIAL_OWNER_OTHER_REPLACE });
       const resp = await request(app)
         .post(BENEFICIAL_OWNER_OTHER_URL + BO_OTHER_ID_URL)
@@ -1226,8 +1228,12 @@ describe("BENEFICIAL OWNER OTHER controller", () => {
       expect(mockRemoveFromApplicationData.mock.calls[0][1]).toEqual(BeneficialOwnerOtherKey);
       expect(mockRemoveFromApplicationData.mock.calls[0][2]).toEqual(BO_OTHER_ID);
 
-      expect(mockSetApplicationData.mock.calls[0][1].id).toEqual(BO_OTHER_ID);
+      const data = mockSetApplicationData.mock.calls[0][1];
+      expect(data.id).toEqual(BO_OTHER_ID);
       expect(mockSetApplicationData.mock.calls[0][2]).toEqual(BeneficialOwnerOtherKey);
+
+      // Ensure that trust ids on the original BO aren't lost during the update
+      expect((data as BeneficialOwnerOther).trust_ids).toEqual(BENEFICIAL_OWNER_OTHER_OBJECT_MOCK.trust_ids);
 
       expect(resp.status).toEqual(302);
       expect(resp.header.location).toEqual(BENEFICIAL_OWNER_TYPE_URL);
@@ -1235,6 +1241,7 @@ describe("BENEFICIAL OWNER OTHER controller", () => {
     });
 
     test(`Service address from the ${BENEFICIAL_OWNER_OTHER_PAGE} is present when same address is set to no`, async () => {
+      mockGetFromApplicationData.mockReturnValueOnce(BENEFICIAL_OWNER_OTHER_OBJECT_MOCK);
       mockPrepareData.mockReturnValueOnce({ ...BENEFICIAL_OWNER_OTHER_OBJECT_MOCK_WITH_SERVICE_ADDRESS_NO });
       await request(app)
         .post(BENEFICIAL_OWNER_OTHER_URL + BO_OTHER_ID_URL)
@@ -1246,6 +1253,7 @@ describe("BENEFICIAL OWNER OTHER controller", () => {
     });
 
     test(`Service address from the ${BENEFICIAL_OWNER_OTHER_PAGE} is empty when same address is set to yes`, async () => {
+      mockGetFromApplicationData.mockReturnValueOnce(BENEFICIAL_OWNER_OTHER_OBJECT_MOCK);
       mockPrepareData.mockReturnValueOnce({ ...BENEFICIAL_OWNER_OTHER_OBJECT_MOCK_WITH_SERVICE_ADDRESS_YES });
       await request(app)
         .post(BENEFICIAL_OWNER_OTHER_URL + BO_OTHER_ID_URL)
@@ -1257,6 +1265,7 @@ describe("BENEFICIAL OWNER OTHER controller", () => {
     });
 
     test(`Public register data from the ${BENEFICIAL_OWNER_OTHER_PAGE} is present when is on register set to yes`, async () => {
+      mockGetFromApplicationData.mockReturnValueOnce(BENEFICIAL_OWNER_OTHER_OBJECT_MOCK);
       mockPrepareData.mockReturnValueOnce({ ...BENEFICIAL_OWNER_OTHER_OBJECT_MOCK_WITH_PUBLIC_REGISTER_DATA_YES });
       await request(app).post(BENEFICIAL_OWNER_OTHER_URL + BO_OTHER_ID_URL)
         .send(BENEFICIAL_OWNER_OTHER_OBJECT_MOCK_WITH_PUBLIC_REGISTER_DATA_YES);
@@ -1267,6 +1276,7 @@ describe("BENEFICIAL OWNER OTHER controller", () => {
     });
 
     test(`Public register data from the ${BENEFICIAL_OWNER_OTHER_PAGE} is empty when is on register set to no`, async () => {
+      mockGetFromApplicationData.mockReturnValueOnce(BENEFICIAL_OWNER_OTHER_OBJECT_MOCK);
       mockPrepareData.mockReturnValueOnce({ ...BENEFICIAL_OWNER_OTHER_OBJECT_MOCK_WITH_PUBLIC_REGISTER_DATA_NO });
       await request(app).post(BENEFICIAL_OWNER_OTHER_URL + BO_OTHER_ID_URL)
         .send(BENEFICIAL_OWNER_OTHER_OBJECT_MOCK_WITH_PUBLIC_REGISTER_DATA_NO);

--- a/test/controllers/update/update.beneficial.owner.individual.controller.spec.ts
+++ b/test/controllers/update/update.beneficial.owner.individual.controller.spec.ts
@@ -61,7 +61,8 @@ import {
   UPDATE_BENEFICIAL_OWNER_INDIVIDUAL_MOCK_FOR_CEASE_VALIDATION,
   UPDATE_BENEFICIAL_OWNER_INDIVIDUAL_REQ_BODY_OBJECT_MOCK,
 } from '../../__mocks__/session.mock';
-import { BeneficialOwnerIndividualKey } from '../../../src/model/beneficial.owner.individual.model';
+
+import { BeneficialOwnerIndividual, BeneficialOwnerIndividualKey } from '../../../src/model/beneficial.owner.individual.model';
 import { AddressKeys } from '../../../src/model/data.types.model';
 import {
   BENEFICIAL_OWNER_INDIVIDUAL_WITH_INVALID_CHARS_MOCK,
@@ -948,6 +949,7 @@ describe("UPDATE BENEFICIAL OWNER INDIVIDUAL controller", () => {
 
   describe("UPDATE tests", () => {
     test(`redirects to the ${UPDATE_BENEFICIAL_OWNER_TYPE_PAGE} page`, async () => {
+      mockGetFromApplicationData.mockReturnValueOnce(UPDATE_BENEFICIAL_OWNER_INDIVIDUAL_REQ_BODY_OBJECT_MOCK);
       mockPrepareData.mockReturnValueOnce(UPDATE_BENEFICIAL_OWNER_INDIVIDUAL_REQ_BODY_OBJECT_MOCK);
       const resp = await request(app)
         .post(UPDATE_BENEFICIAL_OWNER_INDIVIDUAL_URL + BO_IND_ID_URL)
@@ -970,6 +972,7 @@ describe("UPDATE BENEFICIAL OWNER INDIVIDUAL controller", () => {
     });
 
     test(`replaces existing object on submit`, async () => {
+      mockGetFromApplicationData.mockReturnValueOnce(UPDATE_BENEFICIAL_OWNER_INDIVIDUAL_REQ_BODY_OBJECT_MOCK);
       mockPrepareData.mockReturnValueOnce({ id: BO_IND_ID, name: "new name" });
       const resp = await request(app)
         .post(UPDATE_BENEFICIAL_OWNER_INDIVIDUAL_URL + BO_IND_ID_URL)
@@ -978,14 +981,19 @@ describe("UPDATE BENEFICIAL OWNER INDIVIDUAL controller", () => {
       expect(mockRemoveFromApplicationData.mock.calls[0][1]).toEqual(BeneficialOwnerIndividualKey);
       expect(mockRemoveFromApplicationData.mock.calls[0][2]).toEqual(BO_IND_ID);
 
-      expect(mockSetApplicationData.mock.calls[0][1].id).toEqual(BO_IND_ID);
+      const data = mockSetApplicationData.mock.calls[0][1];
+      expect(data.id).toEqual(BO_IND_ID);
       expect(mockSetApplicationData.mock.calls[0][2]).toEqual(BeneficialOwnerIndividualKey);
+
+      // Ensure that trust ids on the original BO aren't lost during the update
+      expect((data as BeneficialOwnerIndividual).trust_ids).toEqual(UPDATE_BENEFICIAL_OWNER_INDIVIDUAL_REQ_BODY_OBJECT_MOCK.trust_ids);
 
       expect(resp.status).toEqual(302);
       expect(resp.header.location).toEqual(UPDATE_BENEFICIAL_OWNER_TYPE_URL);
     });
 
     test(`Service address from the ${UPDATE_BENEFICIAL_OWNER_INDIVIDUAL_PAGE} is present when same address is set to no`, async () => {
+      mockGetFromApplicationData.mockReturnValueOnce(UPDATE_BENEFICIAL_OWNER_INDIVIDUAL_REQ_BODY_OBJECT_MOCK);
       mockPrepareData.mockImplementationOnce( () => BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK_WITH_SERVICE_ADDRESS_NO);
       await request(app)
         .post(UPDATE_BENEFICIAL_OWNER_INDIVIDUAL_URL + BO_IND_ID_URL)
@@ -997,6 +1005,7 @@ describe("UPDATE BENEFICIAL OWNER INDIVIDUAL controller", () => {
     });
 
     test(`Service address from the ${UPDATE_BENEFICIAL_OWNER_INDIVIDUAL_PAGE} is empty when same address is set to yes`, async () => {
+      mockGetFromApplicationData.mockReturnValueOnce(UPDATE_BENEFICIAL_OWNER_INDIVIDUAL_REQ_BODY_OBJECT_MOCK);
       mockPrepareData.mockImplementationOnce( () => BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK_WITH_SERVICE_ADDRESS_YES);
       await request(app)
         .post(UPDATE_BENEFICIAL_OWNER_INDIVIDUAL_URL + BO_IND_ID_URL)

--- a/test/controllers/update/update.beneficial.owner.other.controller.spec.ts
+++ b/test/controllers/update/update.beneficial.owner.other.controller.spec.ts
@@ -28,6 +28,7 @@ import {
   UPDATE_BENEFICIAL_OWNER_OTHER_OBJECT_MOCK_WITH_PUBLIC_REGISTER_DATA_NO,
   UPDATE_BENEFICIAL_OWNER_OTHER_MOCK_FOR_CEASE_VALIDATION,
   APPLICATION_DATA_UPDATE_BO_MOCK,
+  UPDATE_BENEFICIAL_OWNER_OTHER_OBJECT_MOCK,
 } from "../../__mocks__/session.mock";
 import {
   getFromApplicationData, mapFieldsToDataObject,
@@ -66,7 +67,7 @@ import {
   NatureOfControlType, PublicRegisterNameKey, RegistrationNumberKey,
   yesNoResponse
 } from "../../../src/model/data.types.model";
-import { BeneficialOwnerOtherKey } from "../../../src/model/beneficial.owner.other.model";
+import { BeneficialOwnerOther, BeneficialOwnerOtherKey } from "../../../src/model/beneficial.owner.other.model";
 import {
   BENEFICIAL_OWNER_OTHER_WITH_INVALID_CHARS_MOCK,
   BENEFICIAL_OWNER_OTHER_WITH_INVALID_CHARS_SERVICE_ADDRESS_MOCK,
@@ -740,6 +741,7 @@ describe("UPDATE BENEFICIAL OWNER OTHER controller", () => {
 
   describe("UPDATE tests", () => {
     test(`Redirects to the ${UPDATE_BENEFICIAL_OWNER_TYPE_URL} page`, async () => {
+      mockGetFromApplicationData.mockReturnValueOnce(UPDATE_BENEFICIAL_OWNER_OTHER_OBJECT_MOCK);
       mockPrepareData.mockReturnValueOnce({ ...UPDATE_BENEFICIAL_OWNER_OTHER_BODY_OBJECT_MOCK_WITH_ADDRESS });
       const resp = await request(app).post(UPDATE_BENEFICIAL_OWNER_OTHER_URL + BO_OTHER_ID_URL)
         .send(UPDATE_BENEFICIAL_OWNER_OTHER_BODY_OBJECT_MOCK_WITH_ADDRESS);
@@ -760,6 +762,7 @@ describe("UPDATE BENEFICIAL OWNER OTHER controller", () => {
     });
 
     test(`Replaces existing object on submit`, async () => {
+      mockGetFromApplicationData.mockReturnValueOnce(UPDATE_BENEFICIAL_OWNER_OTHER_OBJECT_MOCK);
       mockPrepareData.mockReturnValueOnce({ id: BO_OTHER_ID, name: "new name" });
       const resp = await request(app)
         .post(UPDATE_BENEFICIAL_OWNER_OTHER_URL + BO_OTHER_ID_URL)
@@ -768,8 +771,12 @@ describe("UPDATE BENEFICIAL OWNER OTHER controller", () => {
       expect(mockRemoveFromApplicationData.mock.calls[0][1]).toEqual(BeneficialOwnerOtherKey);
       expect(mockRemoveFromApplicationData.mock.calls[0][2]).toEqual(BO_OTHER_ID);
 
-      expect(mockSetApplicationData.mock.calls[0][1].id).toEqual(BO_OTHER_ID);
+      const data = mockSetApplicationData.mock.calls[0][1];
+      expect(data.id).toEqual(BO_OTHER_ID);
       expect(mockSetApplicationData.mock.calls[0][2]).toEqual(BeneficialOwnerOtherKey);
+
+      // Ensure that trust ids on the original BO aren't lost during the update
+      expect((data as BeneficialOwnerOther).trust_ids).toEqual(UPDATE_BENEFICIAL_OWNER_OTHER_OBJECT_MOCK.trust_ids);
 
       expect(resp.status).toEqual(302);
       expect(resp.header.location).toEqual(UPDATE_BENEFICIAL_OWNER_TYPE_URL);
@@ -777,6 +784,7 @@ describe("UPDATE BENEFICIAL OWNER OTHER controller", () => {
     });
 
     test(`Service address from the ${UPDATE_BENEFICIAL_OWNER_OTHER_PAGE} page is present when same address is set to no`, async () => {
+      mockGetFromApplicationData.mockReturnValueOnce(UPDATE_BENEFICIAL_OWNER_OTHER_OBJECT_MOCK);
       mockPrepareData.mockReturnValueOnce({ ...BENEFICIAL_OWNER_OTHER_OBJECT_MOCK_WITH_SERVICE_ADDRESS_NO });
       await request(app)
         .post(UPDATE_BENEFICIAL_OWNER_OTHER_URL + BO_OTHER_ID_URL)
@@ -788,6 +796,7 @@ describe("UPDATE BENEFICIAL OWNER OTHER controller", () => {
     });
 
     test(`Service address from the ${UPDATE_BENEFICIAL_OWNER_OTHER_PAGE} page is empty when same address is set to yes`, async () => {
+      mockGetFromApplicationData.mockReturnValueOnce(UPDATE_BENEFICIAL_OWNER_OTHER_OBJECT_MOCK);
       mockPrepareData.mockReturnValueOnce({ ...BENEFICIAL_OWNER_OTHER_OBJECT_MOCK_WITH_SERVICE_ADDRESS_YES });
       await request(app)
         .post(UPDATE_BENEFICIAL_OWNER_OTHER_URL + BO_OTHER_ID_URL)
@@ -799,6 +808,7 @@ describe("UPDATE BENEFICIAL OWNER OTHER controller", () => {
     });
 
     test(`Public register data from the ${UPDATE_BENEFICIAL_OWNER_OTHER_PAGE} page is present when is on register set to yes`, async () => {
+      mockGetFromApplicationData.mockReturnValueOnce(UPDATE_BENEFICIAL_OWNER_OTHER_OBJECT_MOCK);
       mockPrepareData.mockReturnValueOnce({ ...BENEFICIAL_OWNER_OTHER_OBJECT_MOCK_WITH_PUBLIC_REGISTER_DATA_YES });
       await request(app).post(UPDATE_BENEFICIAL_OWNER_OTHER_URL + BO_OTHER_ID_URL)
         .send({ ...BENEFICIAL_OWNER_OTHER_OBJECT_MOCK_WITH_PUBLIC_REGISTER_DATA_YES, is_still_bo: '1' });
@@ -810,6 +820,7 @@ describe("UPDATE BENEFICIAL OWNER OTHER controller", () => {
     });
 
     test(`Public register data from the ${UPDATE_BENEFICIAL_OWNER_OTHER_PAGE} page is empty when is on register set to no`, async () => {
+      mockGetFromApplicationData.mockReturnValueOnce(UPDATE_BENEFICIAL_OWNER_OTHER_OBJECT_MOCK);
       mockPrepareData.mockReturnValueOnce({ ...BENEFICIAL_OWNER_OTHER_OBJECT_MOCK_WITH_PUBLIC_REGISTER_DATA_NO });
       await request(app).post(UPDATE_BENEFICIAL_OWNER_OTHER_URL + BO_OTHER_ID_URL)
         .send({ ...BENEFICIAL_OWNER_OTHER_OBJECT_MOCK_WITH_PUBLIC_REGISTER_DATA_NO, is_still_bo: '1' });


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/UAR-1508

### Change description

* Trust ids associated with BOs now persist, even after BO details are edited
* Works also for BOs been reviewed on the Update/Remove journeys
* Unit tests updated to relect and check the change in behaviour

### Work checklist

- [X] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
