### PR TITLE
Fix/ROE-2560: Ensure `is_secure_register` option is only saved for registration journey

### DIFF
--- a/src/controllers/secure.register.filter.controller.ts
+++ b/src/controllers/secure.register.filter.controller.ts
@@ -13,5 +13,5 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
   const nextPageUrl = isActiveFeature(config.FEATURE_FLAG_ENABLE_REDIS_REMOVAL)
     ? config.INTERRUPT_CARD_WITH_PARAMS_URL
     : config.INTERRUPT_CARD_URL;
-  await postFilterPage(req, res, next, config.USE_PAPER_URL, nextPageUrl);
+  await postFilterPage(req, res, next, config.USE_PAPER_URL, nextPageUrl, true);
 };

--- a/src/utils/secure.filter.ts
+++ b/src/utils/secure.filter.ts
@@ -33,7 +33,7 @@ export const getFilterPage = (req: Request, res: Response, next: NextFunction, t
   }
 };
 
-export const postFilterPage = async (req: Request, res: Response, next: NextFunction, isSecureRegisterYesUrl: string, isSecureRegisterNoUrl: string): Promise<void> => {
+export const postFilterPage = async (req: Request, res: Response, next: NextFunction, isSecureRegisterYesUrl: string, isSecureRegisterNoUrl: string, isRegistrationJourney: boolean = false): Promise<void> => {
   try {
 
     logger.debugRequest(req, `${req.method} ${req.route.path}`);
@@ -50,7 +50,7 @@ export const postFilterPage = async (req: Request, res: Response, next: NextFunc
     }
     if (isSecureRegister === "0") {
       nextPageUrl = isSecureRegisterNoUrl;
-      if (isActiveFeature(config.FEATURE_FLAG_ENABLE_REDIS_REMOVAL)) {
+      if (isActiveFeature(config.FEATURE_FLAG_ENABLE_REDIS_REMOVAL) && isRegistrationJourney) {
         if (appData[Transactionkey] && appData[OverseasEntityKey]) {
           await updateOverseasEntity(req, session, appData);
         } else {

--- a/src/utils/secure.filter.ts
+++ b/src/utils/secure.filter.ts
@@ -33,7 +33,14 @@ export const getFilterPage = (req: Request, res: Response, next: NextFunction, t
   }
 };
 
-export const postFilterPage = async (req: Request, res: Response, next: NextFunction, isSecureRegisterYesUrl: string, isSecureRegisterNoUrl: string, isRegistrationJourney: boolean = false): Promise<void> => {
+export const postFilterPage = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+  isSecureRegisterYesUrl: string,
+  isSecureRegisterNoUrl: string,
+  isRegistrationJourney: boolean = false
+): Promise<void> => {
   try {
 
     logger.debugRequest(req, `${req.method} ${req.route.path}`);


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/ROE-2560

### Change description

Ensures `is_secure_register` option is only saved to the DB for the registration journey (for now).

### Work checklist

- [x] Tests added where applicable
- [x] UI changes meet accessibility criteria
