### PR TITLE
ROECCT-229 : Clicking on error validation message for select beneficial owner on add trust page doesn't take user to the respective area

### DIFF
--- a/views/includes/page-templates/trust-details.html
+++ b/views/includes/page-templates/trust-details.html
@@ -1,9 +1,9 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    {% include "includes/list/errors.html" %}
     {% if formData.relevant_period %}
       {% include "includes/page-templates/important-banner.html" %}
     {% endif %}
-    {% include "includes/list/errors.html" %}
 
     {# Check if there are any beneficial owners. If the length of the 'beneficialOwners' array is 0, then 'isTrustToBeCeased' will be true #}
     {# and can be used to show the ceased date - only for 'review' mode (review mode is only in update journey) #}
@@ -110,7 +110,7 @@
       {% for bo in pageData.beneficialOwners %}
         {% set boItems = (
           boItems.push({
-            id: "trustBeneficialOwners",
+            id: "beneficialOwnersIds",
             value: bo.id,
             text: bo.name,
             checked: true if bo.id in beneficialOwnersIds


### PR DESCRIPTION


### JIRA link

https://companieshouse.atlassian.net/browse/ROECCT-229

### Change description
Clicking on error validation message for select beneficial owner on add trust page doesn't take user to the respective area

