### PR TITLE
ROECCT-225-change-section-heading

### DIFF
--- a/views/update/review-update-statement.html
+++ b/views/update/review-update-statement.html
@@ -68,7 +68,7 @@ update.filing_date["year"]) %}
 
 {% set beneficialOwerSectionHeading %}
   {% if not pageParams.noChangeFlag %}
-    Beneficial owners you have added
+    Beneficial owners in the Update period
   {% else %}
     Beneficial owners
   {% endif %}

--- a/views/update/update-check-your-answers.html
+++ b/views/update/update-check-your-answers.html
@@ -154,7 +154,7 @@
       {% if newBOIs | length or newBOCs | length or newBOGs | length %}
         {% set hideChangeLinksForNonEditableFields = false %}
         <br>
-        <h2 class="govuk-heading-l">Beneficial owners you have added</h2>
+        <h2 class="govuk-heading-l">Beneficial owners in the Update period</h2>
         {% for boi in newBOIs %}
           {% include "includes/check-your-answers/beneficial-owner-individual.html" %}
         {% endfor %}


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/ROECCT-225

### Change description

Bloc 8.5: Change section heading for RBOs added in the Update period

### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
