### PR TITLE
Adding an argument to jest command to speed up test run time

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "sonarqube-base-branch": "sonar-scanner",
     "sonarqube-pull-request": "sonar-scanner -D sonar.pullrequest.base=main",
     "sonarqube": "branch=$(git rev-parse --symbolic-full-name --abbrev-ref HEAD); if [[ $branch == \"HEAD\" ]]; then echo $branch && npm run sonarqube-base-branch; else echo $branch && npm run sonarqube-pull-request; fi;",
-    "test": "jest",
+    "test": "jest --maxWorkers=50%",
     "coverage": "jest --coverage --forceExit --passWithNoTests",
     "prepare": "husky install"
   },


### PR DESCRIPTION
### JIRA link
None


### Change description
Adding --maxWorkers=50% to speed up test run time - suggested in an article I found, seems to work - https://dev.to/vantanev/make-your-jest-tests-up-to-20-faster-by-changing-a-single-setting-i36


### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
