### PR TITLE
Feat/ROE-2375: Resume journey with `transactionId` and `submissionId` in URL

### DIFF
--- a/src/controllers/resume.submission.controller.ts
+++ b/src/controllers/resume.submission.controller.ts
@@ -1,7 +1,13 @@
 import { NextFunction, Request, Response } from "express";
 import * as config from "../config";
+import { isActiveFeature } from "../utils/feature.flag";
 import { getResumePage } from "./shared/common.resume.submission.controller";
+import { getUrlWithTransactionIdAndSubmissionId } from "../utils/url";
 
-export const get = (req: Request, res: Response, next: NextFunction) => {
-  getResumePage(req, res, next, config.SOLD_LAND_FILTER_URL);
+export const get = async (req: Request, res: Response, next: NextFunction) => {
+  const { transactionId, overseaEntityId } = req.params;
+  const resumeUrl: string = isActiveFeature(config.FEATURE_FLAG_ENABLE_REDIS_REMOVAL)
+    ? getUrlWithTransactionIdAndSubmissionId(config.SOLD_LAND_FILTER_WITH_PARAMS_URL, transactionId, overseaEntityId)
+    : config.SOLD_LAND_FILTER_URL;
+  await getResumePage(req, res, next, resumeUrl);
 };

--- a/test/controllers/resume.submission.controller.spec.ts
+++ b/test/controllers/resume.submission.controller.spec.ts
@@ -8,6 +8,7 @@ jest.mock('../../src/utils/application.data');
 jest.mock("../../src/utils/feature.flag" );
 jest.mock("../../src/utils/logger");
 jest.mock("../../src/utils/trusts");
+jest.mock("../../src/utils/url");
 
 import { describe, expect, test, jest, beforeEach } from '@jest/globals';
 import { NextFunction, Request, Response } from "express";
@@ -47,6 +48,7 @@ import { OverseasEntityDueDiligenceKey } from '../../src/model/overseas.entity.d
 import { OVERSEAS_ENTITY_DUE_DILIGENCE_OBJECT_MOCK } from '../__mocks__/overseas.entity.due.diligence.mock';
 import { MOCK_GET_TRANSACTION_RESPONSE } from '../__mocks__/transaction.mock';
 import { mapTrustApiReturnModelToWebModel } from '../../src/utils/trusts';
+import { getUrlWithTransactionIdAndSubmissionId } from "../../src/utils/url";
 
 const mockServiceAvailabilityMiddleware = serviceAvailabilityMiddleware as jest.Mock;
 mockServiceAvailabilityMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => next() );
@@ -71,6 +73,8 @@ const mockAuthenticationMiddleware = authentication as jest.Mock;
 mockAuthenticationMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => next() );
 
 const mockMapTrustApiReturnModelToWebModel = mapTrustApiReturnModelToWebModel as jest.Mock;
+
+const mockGetUrlWithTransactionIdAndSubmissionId = getUrlWithTransactionIdAndSubmissionId as jest.Mock;
 
 const baseURL = `${config.CHS_URL}${config.REGISTER_AN_OVERSEAS_ENTITY_URL}`;
 
@@ -187,6 +191,7 @@ describe("Resume submission controller", () => {
     expect(mockCreateAndLogErrorRequest).not.toHaveBeenCalled();
     expect(mockMapTrustApiReturnModelToWebModel).toHaveBeenCalledTimes(1);
     expect(mockIsActiveFeature).toHaveBeenCalledTimes(2);
+    expect(mockGetUrlWithTransactionIdAndSubmissionId).not.toHaveBeenCalled();
   });
 
   test(`Redirect to starting payment page after resuming the OverseasEntity object and trusts feature flag on and REDIS_flag set to ON`, async () => {
@@ -218,6 +223,7 @@ describe("Resume submission controller", () => {
     expect(mockCreateAndLogErrorRequest).not.toHaveBeenCalled();
     expect(mockMapTrustApiReturnModelToWebModel).toHaveBeenCalledTimes(1);
     expect(mockIsActiveFeature).toHaveBeenCalledTimes(2);
+    expect(mockGetUrlWithTransactionIdAndSubmissionId).toHaveBeenCalledTimes(1);
   });
 
   test(`Should throw an error on Resuming the OverseasEntity`, async () => {


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/ROE-2375

### Change description

Adds `transactionId` and `submissionId` in URL for the resume journey

### Work checklist

- [x] Tests added where applicable
- [x] UI changes meet accessibility criteria