### PR TITLE
UAR-1356 Fixing accessibility issues when using phone sized screens, …

### DIFF
--- a/views/includes/page-templates/who-is-filing.html
+++ b/views/includes/page-templates/who-is-filing.html
@@ -3,6 +3,8 @@
 
     {% include "includes/list/errors.html" %}
 
+    <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">{{ title }}</h1>
+
     <form method="post">
       {% include "includes/csrf_token.html" %}
       
@@ -10,8 +12,7 @@
         name: 'who_is_registering',
         error: errors.who_is_registering if errors,
         legend: {
-          text: title,
-          isPageHeading: true,
+          isPageHeading: false,
           classes: "govuk-fieldset__legend--xl"
         },
         items: [

--- a/views/includes/page-templates/who-is-filing.html
+++ b/views/includes/page-templates/who-is-filing.html
@@ -4,7 +4,6 @@
     {% include "includes/list/errors.html" %}
 
     <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">{{ title }}</h1>
-
     <form method="post">
       {% include "includes/csrf_token.html" %}
       

--- a/views/includes/secure-filter.html
+++ b/views/includes/secure-filter.html
@@ -3,6 +3,8 @@
 
     {% include "includes/list/errors.html" %}
 
+    <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">{{ title }}</h1>
+
     <form method="post">
       {% include "includes/csrf_token.html" %}    
       {{ govukRadios({
@@ -12,8 +14,7 @@
         name: "is_secure_register",
         fieldset: {
           legend: {
-            text: title,
-            isPageHeading: true,
+            isPageHeading: false,
             classes: "govuk-fieldset__legend--xl"
           }
         },

--- a/views/includes/sign-out-user-banner.html
+++ b/views/includes/sign-out-user-banner.html
@@ -18,5 +18,4 @@
       <a class="govuk-link" href="{{ url }}{{ signOutPath }}" data-event-id="signout">Sign out</a>
     </li>
   </ul>
-  <hr class="govuk-section-break govuk-section-break--visible">
 {% endif %}

--- a/views/layout.html
+++ b/views/layout.html
@@ -46,11 +46,13 @@
 
 {% block beforeContent %}
   {% include "includes/phase_banner.html" %}
-  {% block backLink %}
-  {% endblock %}
-  {% block signOutBanner %}
-    {% include "includes/sign-out-user-banner.html" %}
-  {% endblock %}
+  <div style="margin-bottom: 25px; border-bottom: 1px solid #b1b4b6;">
+    {% block backLink %}
+    {% endblock %}
+    {% block signOutBanner %}
+      {% include "includes/sign-out-user-banner.html" %}
+    {% endblock %}
+  </div>
 {% endblock %}
 
 {% block header %}

--- a/views/sold-land-filter.html
+++ b/views/sold-land-filter.html
@@ -5,7 +5,6 @@
 {% block pageTitle %}
   {% include "includes/page-title.html" %}
 {% endblock %}
-
 {% block backLink %}
   {% include "includes/back-link.html" %}
 {% endblock %}
@@ -14,7 +13,6 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       {% include "includes/list/errors.html" %}
-
       <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">{{ title }}</h1>
       <form method="post">
         {% include "includes/csrf_token.html" %}

--- a/views/sold-land-filter.html
+++ b/views/sold-land-filter.html
@@ -11,10 +11,8 @@
 {% endblock %}
 
 {% block content %}
-
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-
       {% include "includes/list/errors.html" %}
 
       <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">{{ title }}</h1>

--- a/views/sold-land-filter.html
+++ b/views/sold-land-filter.html
@@ -13,6 +13,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       {% include "includes/list/errors.html" %}
+
       <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">{{ title }}</h1>
       <form method="post">
         {% include "includes/csrf_token.html" %}

--- a/views/sold-land-filter.html
+++ b/views/sold-land-filter.html
@@ -18,7 +18,6 @@
       {% include "includes/list/errors.html" %}
 
       <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">{{ title }}</h1>
-
       <form method="post">
         {% include "includes/csrf_token.html" %}
         {{ govukRadios({

--- a/views/sold-land-filter.html
+++ b/views/sold-land-filter.html
@@ -17,6 +17,8 @@
 
       {% include "includes/list/errors.html" %}
 
+      <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">{{ title }}</h1>
+
       <form method="post">
         {% include "includes/csrf_token.html" %}
         {{ govukRadios({
@@ -26,8 +28,7 @@
           name: "has_sold_land",
           fieldset: {
             legend: {
-              text: "Has the entity disposed of any property or land in England, Wales or Scotland since 28 February 2022?",
-              isPageHeading: true,
+              isPageHeading: false,
               classes: "govuk-fieldset__legend--xl"
             }
           },

--- a/views/starting-new.html
+++ b/views/starting-new.html
@@ -17,7 +17,6 @@
       {% include "includes/list/errors.html" %}
 
       <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">{{ title }}</h1>
-
       <form method="post">
         {% include "includes/csrf_token.html" %}
         {{ govukRadios({

--- a/views/starting-new.html
+++ b/views/starting-new.html
@@ -19,6 +19,9 @@
       <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">{{ title }}</h1>
       <form method="post">
         {% include "includes/csrf_token.html" %}
+
+
+        
         {{ govukRadios({
           errorMessage: errors.continue_saved_application if errors,
           classes: "govuk-radios",

--- a/views/starting-new.html
+++ b/views/starting-new.html
@@ -16,7 +16,7 @@
 
       {% include "includes/list/errors.html" %}
 
-      <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">{{ title }}</h1>
+      <h1 class="govuk-!-margin-bottom-3 govuk-heading-xl">{{ title }}</h1>
       <form method="post">
         {% include "includes/csrf_token.html" %}
         {{ govukRadios({

--- a/views/starting-new.html
+++ b/views/starting-new.html
@@ -19,7 +19,6 @@
       <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">{{ title }}</h1>
       <form method="post">
         {% include "includes/csrf_token.html" %}
-        
         {{ govukRadios({
           errorMessage: errors.continue_saved_application if errors,
           classes: "govuk-radios",

--- a/views/starting-new.html
+++ b/views/starting-new.html
@@ -16,6 +16,8 @@
 
       {% include "includes/list/errors.html" %}
 
+      <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">{{ title }}</h1>
+
       <form method="post">
         {% include "includes/csrf_token.html" %}
         {{ govukRadios({
@@ -25,8 +27,7 @@
           name: "continue_saved_application",
           fieldset: {
             legend: {
-              text: title,
-              isPageHeading: true,
+              isPageHeading: false,
               classes: "govuk-fieldset__legend--xl"
             }  
           },

--- a/views/starting-new.html
+++ b/views/starting-new.html
@@ -19,8 +19,6 @@
       <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">{{ title }}</h1>
       <form method="post">
         {% include "includes/csrf_token.html" %}
-
-
         
         {{ govukRadios({
           errorMessage: errors.continue_saved_application if errors,

--- a/views/update/continue-with-saved-filing.html
+++ b/views/update/continue-with-saved-filing.html
@@ -18,8 +18,11 @@
 
       {% include "includes/list/errors.html" %}
 
+      <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">{{ title }}</h1>
+
       <form method="post">
         {% include "includes/csrf_token.html" %}
+
         {{ govukRadios({
           errorMessage: errors.continue_saved_filing if errors,
           classes: "govuk-radios",
@@ -27,8 +30,7 @@
           name: "continue_saved_filing",
           fieldset: {
             legend: {
-              text: title,
-              isPageHeading: true,
+              isPageHeading: false,
               classes: "govuk-fieldset__legend--xl"
             }
           },

--- a/views/update/remove/remove-sold-all-land-filter.html
+++ b/views/update/remove/remove-sold-all-land-filter.html
@@ -16,8 +16,11 @@
 
       {% include "includes/list/errors.html" %}
 
+      <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">{{ title }}</h1>
+
       <form method="post">
         {% include "includes/csrf_token.html" %}
+
         {{ govukRadios({
           errorMessage: errors.has_sold_all_land if errors,
           classes: "govuk-radios",
@@ -25,8 +28,7 @@
           name: "has_sold_all_land",
           fieldset: {
             legend: {
-              text: title,
-              isPageHeading: true,
+              isPageHeading: false,
               classes: "govuk-fieldset__legend--xl"
             }
           },

--- a/views/update/remove/remove-sold-all-land-filter.html
+++ b/views/update/remove/remove-sold-all-land-filter.html
@@ -17,7 +17,6 @@
       {% include "includes/list/errors.html" %}
 
       <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">{{ title }}</h1>
-
       <form method="post">
         {% include "includes/csrf_token.html" %}
 

--- a/views/update/update-layout.html
+++ b/views/update/update-layout.html
@@ -46,11 +46,13 @@
 
 {% block beforeContent %}
   {% include "includes/update_phase_banner.html" %}
-  {% block backLink %}
-  {% endblock %}
-  {% block signOutBanner %}
-    {% include "includes/sign-out-user-banner.html" %}
-  {% endblock %}
+  <div style="margin-bottom: 25px; border-bottom: 1px solid #b1b4b6;">
+    {% block backLink %}
+    {% endblock %}
+    {% block signOutBanner %}
+      {% include "includes/sign-out-user-banner.html" %}
+    {% endblock %}
+  </div>
 {% endblock %}
 
 {% if (journey == "remove") %}


### PR DESCRIPTION
…radio button text and sign-out link position

### JIRA link
https://companieshouse.atlassian.net/browse/UAR-1356


### Change description
Changes to the template styling to try and fix some formatting problems when viewing pages on older phones
* Some radio button text was aligning to the left hand side of screen - caused by the setting isPageHeading: true, these have now been changed to false and a new H1 heading added in its place
* signout link was overlaying some parts of the screen (blue interrupt page) - I've added spacing to the layout templates so there is now more space under the signout link, so when it wraps around on smaller screens there is less chance of it appearing on top of other screen elements.
* the separator line under signout was shortened on smaller screens - replaced the `<hr>` element in signout template with a div wrapper in the layout file and added a line to the bottom of that div. This is how the Beta banner at top of the page draws its line also (copied from there).


### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
