### PR TITLE
Feature/ROE-2434: Update backLinkUrls for mo/bo personal info page

### DIFF
--- a/src/controllers/interrupt.card.controller.ts
+++ b/src/controllers/interrupt.card.controller.ts
@@ -11,7 +11,7 @@ export const get = (req: Request, res: Response) => {
   let nextPageUrl = config.OVERSEAS_NAME_URL;
   let backLinkUrl = config.SECURE_REGISTER_FILTER_URL;
 
-  if (isActiveFeature(config.FEATURE_FLAG_ENABLE_REDIS_REMOVAL)){
+  if (isActiveFeature(config.FEATURE_FLAG_ENABLE_REDIS_REMOVAL)) {
     nextPageUrl = getUrlWithParamsToPath(config.OVERSEAS_NAME_WITH_PARAMS_URL, req);
     backLinkUrl = getUrlWithParamsToPath(config.SECURE_REGISTER_FILTER_WITH_PARAMS_URL, req);
   }

--- a/src/controllers/secure.register.filter.controller.ts
+++ b/src/controllers/secure.register.filter.controller.ts
@@ -6,13 +6,13 @@ import { getUrlWithParamsToPath } from "../utils/url";
 import { isActiveFeature } from "../utils/feature.flag";
 
 export const get = (req: Request, res: Response, next: NextFunction) => {
-  const backLinkUrl = isActiveFeature(config.FEATURE_FLAG_ENABLE_REDIS_REMOVAL)
+  const backLinkUrl: string = isActiveFeature(config.FEATURE_FLAG_ENABLE_REDIS_REMOVAL)
     ? getUrlWithParamsToPath(config.SOLD_LAND_FILTER_WITH_PARAMS_URL, req)
     : config.SOLD_LAND_FILTER_URL;
   getFilterPage(req, res, next, config.SECURE_REGISTER_FILTER_PAGE, backLinkUrl);
 };
 
-// @todo: remember to remove url parameters after update journey is updated for REDIS removal
+// @todo: remember to remove url parameters after update journey is refactored for REDIS removal
 export const post = async (req: Request, res: Response, next: NextFunction) => {
   const nextPageUrl = isActiveFeature(config.FEATURE_FLAG_ENABLE_REDIS_REMOVAL)
     ? config.INTERRUPT_CARD_WITH_PARAMS_URL

--- a/test/controllers/interrupt.card.controller.spec.ts
+++ b/test/controllers/interrupt.card.controller.spec.ts
@@ -63,8 +63,8 @@ describe("INTERRUPT CARD controller", () => {
     });
 
     test(`renders the ${INTERRUPT_CARD_PAGE} page with trust feature flag false and REDIS_removal flag is set to OFF`, async () => {
-      (isActiveFeature as jest.Mock).mockReturnValueOnce(false);
-      (isActiveFeature as jest.Mock).mockReturnValueOnce(false);
+      mockIsActiveFeature.mockReturnValueOnce(false);
+      mockIsActiveFeature.mockReturnValueOnce(false);
 
       const resp = await request(app).get(INTERRUPT_CARD_URL);
 
@@ -77,8 +77,8 @@ describe("INTERRUPT CARD controller", () => {
     });
 
     test(`renders the ${INTERRUPT_CARD_PAGE} page with trust feature flag false and REDIS_removal flag is set to ON`, async () => {
-      (isActiveFeature as jest.Mock).mockReturnValueOnce(true);
-      (isActiveFeature as jest.Mock).mockReturnValueOnce(false);
+      mockIsActiveFeature.mockReturnValueOnce(true);
+      mockIsActiveFeature.mockReturnValueOnce(false);
 
       const resp = await request(app).get(INTERRUPT_CARD_WITH_PARAMS_URL);
 

--- a/test/controllers/secure.register.filter.controller.spec.ts
+++ b/test/controllers/secure.register.filter.controller.spec.ts
@@ -34,6 +34,7 @@ import {
   SERVICE_UNAVAILABLE,
   BACK_BUTTON_CLASS
 } from "../__mocks__/text.mock";
+
 import {
   SECURE_REGISTER_FILTER_URL,
   SECURE_REGISTER_FILTER_WITH_PARAMS_URL,
@@ -48,6 +49,7 @@ import { serviceAvailabilityMiddleware } from "../../src/middleware/service.avai
 import { isActiveFeature } from "../../src/utils/feature.flag";
 import { isRemoveJourney, getUrlWithTransactionIdAndSubmissionId } from "./../../src/utils/url";
 import { updateOverseasEntity } from "../../src/service/overseas.entities.service";
+import { getUrlWithParamsToPath } from "../../src/utils/url";
 
 mockCsrfProtectionMiddleware.mockClear();
 const mockAuthenticationMiddleware = authentication as jest.Mock;
@@ -69,6 +71,7 @@ mockRemoveJourneyMiddleware.mockClear();
 const mockIsActiveFeature = isActiveFeature as jest.Mock;
 const mockIsRemoveJourney = isRemoveJourney as jest.Mock;
 const mockGetUrlWithTransactionIdAndSubmissionId = getUrlWithTransactionIdAndSubmissionId as jest.Mock;
+const mockGetUrlWithParamsToPath = getUrlWithParamsToPath as jest.Mock;
 
 describe( "SECURE REGISTER FILTER controller", () => {
 
@@ -76,10 +79,12 @@ describe( "SECURE REGISTER FILTER controller", () => {
     jest.clearAllMocks();
     mockIsActiveFeature.mockReset();
     mockIsRemoveJourney.mockReset();
+    mockGetUrlWithParamsToPath.mockReset();
   });
 
   describe("GET tests", () => {
-    test(`renders the ${config.SECURE_REGISTER_FILTER_PAGE} page`, async () => {
+
+    test(`renders the the ${config.SECURE_REGISTER_FILTER_PAGE} page`, async () => {
       mockGetApplicationData.mockReturnValueOnce({});
       const resp = await request(app).get(SECURE_REGISTER_FILTER_URL);
 
@@ -96,6 +101,7 @@ describe( "SECURE REGISTER FILTER controller", () => {
 
     test(`renders the ${config.SECURE_REGISTER_FILTER_PAGE} page and REDIS_removal flag is set to OFF`, async () => {
       mockIsActiveFeature.mockReturnValueOnce(false);
+      mockGetUrlWithParamsToPath.mockReturnValueOnce('/some-url');
       mockGetApplicationData.mockReturnValueOnce({});
       mockIsRemoveJourney.mockReturnValue(false);
       const resp = await request(app).get(SECURE_REGISTER_FILTER_URL);
@@ -109,10 +115,15 @@ describe( "SECURE REGISTER FILTER controller", () => {
       expect(resp.text).not.toContain(PAGE_TITLE_ERROR);
       expect(resp.text).toContain(INFORMATION_SHOWN_ON_THE_PUBLIC_REGISTER);
       expect(resp.text).toContain(NOT_SHOW_INFORMATION_ON_PUBLIC_REGISTER);
+      expect(mockIsActiveFeature).toHaveBeenCalledTimes(1);
+      expect(mockGetUrlWithParamsToPath).not.toHaveBeenCalled();
+      expect(mockGetApplicationData).toHaveBeenCalledTimes(1);
+      expect(mockIsRemoveJourney).toHaveBeenCalledTimes(1);
     });
 
     test(`renders the ${config.SECURE_REGISTER_FILTER_PAGE} page and REDIS_removal flag is set to ON`, async () => {
       mockIsActiveFeature.mockReturnValueOnce(true);
+      mockGetUrlWithParamsToPath.mockReturnValueOnce('/some-url');
       mockGetApplicationData.mockReturnValueOnce({});
       mockIsRemoveJourney.mockReturnValue(false);
       const resp = await request(app).get(SECURE_REGISTER_FILTER_WITH_PARAMS_URL);
@@ -127,6 +138,10 @@ describe( "SECURE REGISTER FILTER controller", () => {
       expect(resp.text).toContain(INFORMATION_SHOWN_ON_THE_PUBLIC_REGISTER);
       expect(resp.text).toContain(NOT_SHOW_INFORMATION_ON_PUBLIC_REGISTER);
       expect(resp.text).toContain(BACK_BUTTON_CLASS);
+      expect(mockIsActiveFeature).toHaveBeenCalledTimes(1);
+      expect(mockGetUrlWithParamsToPath).toHaveBeenCalledTimes(1);
+      expect(mockGetApplicationData).toHaveBeenCalledTimes(1);
+      expect(mockIsRemoveJourney).toHaveBeenCalledTimes(1);
     });
 
     test(`renders the ${config.SECURE_REGISTER_FILTER_PAGE} page with radios selected to no`, async () => {

--- a/test/controllers/secure.register.filter.controller.spec.ts
+++ b/test/controllers/secure.register.filter.controller.spec.ts
@@ -84,7 +84,7 @@ describe( "SECURE REGISTER FILTER controller", () => {
 
   describe("GET tests", () => {
 
-    test(`renders the the ${config.SECURE_REGISTER_FILTER_PAGE} page`, async () => {
+    test(`renders the ${config.SECURE_REGISTER_FILTER_PAGE} page`, async () => {
       mockGetApplicationData.mockReturnValueOnce({});
       const resp = await request(app).get(SECURE_REGISTER_FILTER_URL);
 


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/ROE-2434

### Change description

Update backLinkUrls for managing officer/beneficial owner personal info page and interrupt page when REDIS_removal flag is set to ON

### Work checklist

- [x] Tests added where applicable
- [x] UI changes meet accessibility criteria
