### PR TITLE
Fix some unit test warnings

### DIFF
--- a/test/controllers/trust.individual.beneficial.owner.controller.int.spec.ts
+++ b/test/controllers/trust.individual.beneficial.owner.controller.int.spec.ts
@@ -117,6 +117,9 @@ describe('Trust Individual Beneficial Owner Controller Integration Tests', () =>
         dateBecameIPDay: "11",
         dateBecameIPMonth: "11",
         dateBecameIPYear: "1987",
+        startDateDay: "",
+        startDateMonth: "",
+        startDateYear: ""
       };
 
       const resp =
@@ -244,6 +247,9 @@ describe('Trust Individual Beneficial Owner Controller Integration Tests', () =>
         dateBecameIPDay: "11",
         dateBecameIPMonth: "11",
         dateBecameIPYear: "1987",
+        startDateDay: "",
+        startDateMonth: "",
+        startDateYear: ""
       };
 
       const resp =

--- a/test/middleware/authentication.middleware.spec.ts
+++ b/test/middleware/authentication.middleware.spec.ts
@@ -41,6 +41,15 @@ const next = jest.fn();
 
 const mockIsActiveFeature = isActiveFeature as jest.Mock;
 
+function setReadOnlyProperty(req: Request, propertyName: string, propertyValue: string) {
+  Object.defineProperties(req, {
+    [propertyName]: {
+      value: propertyValue,
+      writable: true
+    }
+  });
+}
+
 describe('Authentication middleware', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -66,7 +75,7 @@ describe('Authentication middleware', () => {
   test(`should redirect to signin page with ${SOLD_LAND_FILTER_URL} page as return page`, () => {
     const signinRedirectPath = `/signin?return_to=${SOLD_LAND_FILTER_URL}`;
     req.session = undefined;
-    req.path = `${LANDING_URL}`;
+    setReadOnlyProperty(req, 'path', `${LANDING_URL}`);
 
     authentication(req, res, next);
 
@@ -84,7 +93,7 @@ describe('Authentication middleware', () => {
   test(`should redirect to signin page with ${SECURE_UPDATE_FILTER_URL} page as return page`, () => {
     const signinRedirectPath = `/signin?return_to=${SECURE_UPDATE_FILTER_URL}`;
     req.session = undefined;
-    req.path = `${UPDATE_LANDING_URL}`;
+    setReadOnlyProperty(req, 'path', `${UPDATE_LANDING_URL}`);
 
     authentication(req, res, next);
 
@@ -102,7 +111,7 @@ describe('Authentication middleware', () => {
   test(`should redirect to signin page with ${STARTING_NEW_URL} page as return page`, () => {
     const signinRedirectPath = `/signin?return_to=${STARTING_NEW_URL}`;
     req.session = undefined;
-    req.path = `${STARTING_NEW_URL}`;
+    setReadOnlyProperty(req, 'path', `${STARTING_NEW_URL}`);
 
     authentication(req, res, next);
 
@@ -120,7 +129,7 @@ describe('Authentication middleware', () => {
   test(`should redirect to signin page with ${RESUME_SUBMISSION_URL} page as return page`, () => {
     const signinRedirectPath = `/signin?return_to=${RESUME_SUBMISSION_URL}`;
     req.session = undefined;
-    req.path = `${RESUME_SUBMISSION_URL}`;
+    setReadOnlyProperty(req, 'path', `${RESUME_SUBMISSION_URL}`);
 
     authentication(req, res, next);
 
@@ -190,7 +199,7 @@ describe('Authentication middleware', () => {
 
   test(`should throw error when request path is invalid`, () => {
     req.session = undefined;
-    req.path = `/INVALID/${RESUME}`;
+    setReadOnlyProperty(req, 'path', `/INVALID/${RESUME}`);
 
     authentication(req, res, next);
 

--- a/test/middleware/authentication.middleware.spec.ts
+++ b/test/middleware/authentication.middleware.spec.ts
@@ -41,7 +41,7 @@ const next = jest.fn();
 
 const mockIsActiveFeature = isActiveFeature as jest.Mock;
 
-function setReadOnlyProperty(req: Request, propertyName: string, propertyValue: string) {
+function setReadOnlyRequestProperty(req: Request, propertyName: string, propertyValue: string) {
   Object.defineProperties(req, {
     [propertyName]: {
       value: propertyValue,
@@ -75,7 +75,7 @@ describe('Authentication middleware', () => {
   test(`should redirect to signin page with ${SOLD_LAND_FILTER_URL} page as return page`, () => {
     const signinRedirectPath = `/signin?return_to=${SOLD_LAND_FILTER_URL}`;
     req.session = undefined;
-    setReadOnlyProperty(req, 'path', `${LANDING_URL}`);
+    setReadOnlyRequestProperty(req, 'path', `${LANDING_URL}`);
 
     authentication(req, res, next);
 
@@ -93,7 +93,7 @@ describe('Authentication middleware', () => {
   test(`should redirect to signin page with ${SECURE_UPDATE_FILTER_URL} page as return page`, () => {
     const signinRedirectPath = `/signin?return_to=${SECURE_UPDATE_FILTER_URL}`;
     req.session = undefined;
-    setReadOnlyProperty(req, 'path', `${UPDATE_LANDING_URL}`);
+    setReadOnlyRequestProperty(req, 'path', `${UPDATE_LANDING_URL}`);
 
     authentication(req, res, next);
 
@@ -111,7 +111,7 @@ describe('Authentication middleware', () => {
   test(`should redirect to signin page with ${STARTING_NEW_URL} page as return page`, () => {
     const signinRedirectPath = `/signin?return_to=${STARTING_NEW_URL}`;
     req.session = undefined;
-    setReadOnlyProperty(req, 'path', `${STARTING_NEW_URL}`);
+    setReadOnlyRequestProperty(req, 'path', `${STARTING_NEW_URL}`);
 
     authentication(req, res, next);
 
@@ -129,7 +129,7 @@ describe('Authentication middleware', () => {
   test(`should redirect to signin page with ${RESUME_SUBMISSION_URL} page as return page`, () => {
     const signinRedirectPath = `/signin?return_to=${RESUME_SUBMISSION_URL}`;
     req.session = undefined;
-    setReadOnlyProperty(req, 'path', `${RESUME_SUBMISSION_URL}`);
+    setReadOnlyRequestProperty(req, 'path', `${RESUME_SUBMISSION_URL}`);
 
     authentication(req, res, next);
 
@@ -199,7 +199,7 @@ describe('Authentication middleware', () => {
 
   test(`should throw error when request path is invalid`, () => {
     req.session = undefined;
-    setReadOnlyProperty(req, 'path', `/INVALID/${RESUME}`);
+    setReadOnlyRequestProperty(req, 'path', `/INVALID/${RESUME}`);
 
     authentication(req, res, next);
 

--- a/test/utils/trust/individual.trustee.mapper.spec.ts
+++ b/test/utils/trust/individual.trustee.mapper.spec.ts
@@ -63,7 +63,10 @@ describe('Individual Beneficial Owner page Mapper Service', () => {
           stillInvolved: '0',
           ceasedDateDay: '24',
           ceasedDateMonth: '11',
-          ceasedDateYear: '2023'
+          ceasedDateYear: '2023',
+          startDateDay: '',
+          startDateMonth: '',
+          startDateYear: ''
         };
 
         expect(mapIndividualTrusteeToSession(<Page.IndividualTrusteesFormCommon>mockFormData)).toEqual({
@@ -99,7 +102,10 @@ describe('Individual Beneficial Owner page Mapper Service', () => {
           still_involved: 'No',
           ceased_date_day: '24',
           ceased_date_month: '11',
-          ceased_date_year: '2023'
+          ceased_date_year: '2023',
+          start_date_day: '',
+          start_date_month: '',
+          start_date_year: ''
         });
       });
 
@@ -112,7 +118,10 @@ describe('Individual Beneficial Owner page Mapper Service', () => {
           stillInvolved: '0',
           ceasedDateDay: '24',
           ceasedDateMonth: '11',
-          ceasedDateYear: '2023'
+          ceasedDateYear: '2023',
+          startDateDay: '10',
+          startDateMonth: '11',
+          startDateYear: '2020'
         };
 
         expect(mapIndividualTrusteeToSession(<Page.IndividualTrusteesFormCommon>mockFormData)).toEqual({
@@ -148,7 +157,10 @@ describe('Individual Beneficial Owner page Mapper Service', () => {
           still_involved: 'No',
           ceased_date_day: '24',
           ceased_date_month: '11',
-          ceased_date_year: '2023'
+          ceased_date_year: '2023',
+          start_date_day: '10',
+          start_date_month: '11',
+          start_date_year: '2020'
         });
       });
 
@@ -219,7 +231,10 @@ describe('Individual Beneficial Owner page Mapper Service', () => {
           stillInvolved: '0',
           ceasedDateDay: '24',
           ceasedDateMonth: '11',
-          ceasedDateYear: '2023'
+          ceasedDateYear: '2023',
+          startDateDay: '12',
+          startDateMonth: '12',
+          startDateYear: '2020'
         };
 
         expect(mapIndividualTrusteeToSession(<Page.IndividualTrusteesFormCommon>mockFormData)).toEqual({
@@ -258,7 +273,10 @@ describe('Individual Beneficial Owner page Mapper Service', () => {
           still_involved: 'No',
           ceased_date_day: '24',
           ceased_date_month: '11',
-          ceased_date_year: '2023'
+          ceased_date_year: '2023',
+          start_date_day: '12',
+          start_date_month: '12',
+          start_date_year: '2020'
         });
       });
 
@@ -274,7 +292,10 @@ describe('Individual Beneficial Owner page Mapper Service', () => {
           stillInvolved: '1',
           ceasedDateDay: '24',
           ceasedDateMonth: '11',
-          ceasedDateYear: '2023'
+          ceasedDateYear: '2023',
+          startDateDay: '14',
+          startDateMonth: '12',
+          startDateYear: '2020'
         };
 
         expect(mapIndividualTrusteeToSession(<Page.IndividualTrusteesFormCommon>mockFormData)).toEqual({
@@ -313,7 +334,10 @@ describe('Individual Beneficial Owner page Mapper Service', () => {
           still_involved: 'Yes',
           ceased_date_day: '',
           ceased_date_month: '',
-          ceased_date_year: ''
+          ceased_date_year: '',
+          start_date_day: '14',
+          start_date_month: '12',
+          start_date_year: '2020'
         });
       });
 
@@ -324,7 +348,10 @@ describe('Individual Beneficial Owner page Mapper Service', () => {
           dateBecameIPDay: '2',
           dateBecameIPMonth: '11',
           dateBecameIPYear: '2022',
-          is_service_address_same_as_usual_residential_address: yesNoResponse.No
+          is_service_address_same_as_usual_residential_address: yesNoResponse.No,
+          startDateDay: '14',
+          startDateMonth: '12',
+          startDateYear: '2020'
         };
         const mappedObj = mapIndividualTrusteeToSession(<Page.IndividualTrusteesFormCommon>mockFormData);
 
@@ -343,7 +370,10 @@ describe('Individual Beneficial Owner page Mapper Service', () => {
           stillInvolved: undefined,
           ceasedDateDay: '24',
           ceasedDateMonth: '11',
-          ceasedDateYear: '2023'
+          ceasedDateYear: '2023',
+          startDateDay: '14',
+          startDateMonth: '12',
+          startDateYear: '2020'
         };
 
         expect(mapIndividualTrusteeToSession(<Page.IndividualTrusteesFormCommon>mockFormData)).toEqual({
@@ -382,7 +412,10 @@ describe('Individual Beneficial Owner page Mapper Service', () => {
           still_involved: null,
           ceased_date_day: '',
           ceased_date_month: '',
-          ceased_date_year: ''
+          ceased_date_year: '',
+          start_date_day: '14',
+          start_date_month: '12',
+          start_date_year: '2020'
         });
       });
     });


### PR DESCRIPTION
### JIRA link
NA


### Change description
Some unit tests had warnings in them highlighted by VSCode
, such as object properties missing (object overlap warning) and cannot set value on a read-only property.
This is to fix a few of these issues in the tests.

### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
