### PR TITLE
UAR-1585 Add property land owner nocs for other BO

### DIFF
--- a/src/model/beneficial.owner.other.model.ts
+++ b/src/model/beneficial.owner.other.model.ts
@@ -1,4 +1,4 @@
-import { Address, InputDate, NatureOfControlType, yesNoResponse } from "./data.types.model";
+import { Address, InputDate, NatureOfControlJurisdiction, NatureOfControlType, yesNoResponse } from "./data.types.model";
 
 export const BeneficialOwnerOtherKey: string = "beneficial_owners_corporate";
 
@@ -21,7 +21,10 @@ export const BeneficialOwnerOtherKeys: string[] = [
   "ceased_date",
   "beneficial_owner_nature_of_control_types",
   "trustees_nature_of_control_types",
+  "trust_control_nature_of_control_types",
   "non_legal_firm_members_nature_of_control_types",
+  "owner_of_land_person_nature_of_control_jurisdictions",
+  "owner_of_land_other_entity_nature_of_control_jurisdictions",
   "is_on_sanctions_list",
   "trust_ids",
   "relevant_period"
@@ -43,7 +46,10 @@ export interface BeneficialOwnerOther {
   ceased_date?: InputDate;
   beneficial_owner_nature_of_control_types?: NatureOfControlType[];
   trustees_nature_of_control_types?: NatureOfControlType[];
+  trust_control_nature_of_control_types?: NatureOfControlType[];
   non_legal_firm_members_nature_of_control_types?: NatureOfControlType[];
+  owner_of_land_person_nature_of_control_jurisdictions?: NatureOfControlJurisdiction[];
+  owner_of_land_other_entity_nature_of_control_jurisdictions?: NatureOfControlJurisdiction[];
   is_on_sanctions_list?: yesNoResponse;
   trust_ids?: string[];
   relevant_period?: boolean;

--- a/src/utils/beneficial.owner.other.ts
+++ b/src/utils/beneficial.owner.other.ts
@@ -15,7 +15,12 @@ import {
   InputDateKeys,
   IsOnRegisterInCountryFormedInKey,
   IsOnSanctionsListKey,
-  NonLegalFirmNoc, PublicRegisterNameKey, RegistrationNumberKey,
+  NonLegalFirmNoc,
+  PublicRegisterNameKey,
+  RegistrationNumberKey,
+  OwnerOfLandOtherEntityJurisdictionsNoc,
+  OwnerOfLandPersonJurisdictionsNoc,
+  TrustControlNoc,
   TrusteesNoc
 } from "../model/data.types.model";
 import { PrincipalAddressKey, PrincipalAddressKeys, ServiceAddressKey, ServiceAddressKeys } from "../model/address.model";
@@ -28,6 +33,7 @@ import {
 import { v4 as uuidv4 } from 'uuid';
 import * as config from "../config";
 import { addActiveSubmissionBasePathToTemplateData } from "./template.data";
+import { isActiveFeature } from "./feature.flag";
 
 export const getBeneficialOwnerOther = (req: Request, res: Response, templateName: string, backLinkUrl: string) => {
   logger.debugRequest(req, `${req.method} ${req.route.path}`);
@@ -37,7 +43,9 @@ export const getBeneficialOwnerOther = (req: Request, res: Response, templateNam
   return res.render(templateName, {
     backLinkUrl: backLinkUrl,
     templateName: templateName,
-    ...appData, relevant_period: req.query["relevant-period"] === "true",
+    ...appData,
+    relevant_period: req.query["relevant-period"] === "true",
+    FEATURE_FLAG_ENABLE_PROPERTY_OR_LAND_OWNER_NOC: isActiveFeature(config.FEATURE_FLAG_ENABLE_PROPERTY_OR_LAND_OWNER_NOC)
   });
 };
 
@@ -62,7 +70,8 @@ export const getBeneficialOwnerOtherById = (req: Request, res: Response, next: N
       ...principalAddress,
       ...serviceAddress,
       [StartDateKey]: startDate,
-      entity_name: appData.entity_name
+      entity_name: appData.entity_name,
+      FEATURE_FLAG_ENABLE_PROPERTY_OR_LAND_OWNER_NOC: isActiveFeature(config.FEATURE_FLAG_ENABLE_PROPERTY_OR_LAND_OWNER_NOC)
     };
 
     // Redis removal work - Add extra template options if Redis Remove flag is true and on Registration journey
@@ -166,6 +175,12 @@ export const setBeneficialOwnerData = (reqBody: any, id: string): ApplicationDat
   data[BeneficialOwnerNoc] = (data[BeneficialOwnerNoc]) ? [].concat(data[BeneficialOwnerNoc]) : [];
   data[TrusteesNoc] = (data[TrusteesNoc]) ? [].concat(data[TrusteesNoc]) : [];
   data[NonLegalFirmNoc] = (data[NonLegalFirmNoc]) ? [].concat(data[NonLegalFirmNoc]) : [];
+
+  if (isActiveFeature(config.FEATURE_FLAG_ENABLE_PROPERTY_OR_LAND_OWNER_NOC)) {
+    data[TrustControlNoc] = data[TrustControlNoc] ? [].concat(data[TrustControlNoc]) : [];
+    data[OwnerOfLandPersonJurisdictionsNoc] = data[OwnerOfLandPersonJurisdictionsNoc] ? [].concat(data[OwnerOfLandPersonJurisdictionsNoc]) : [];
+    data[OwnerOfLandOtherEntityJurisdictionsNoc] = data[OwnerOfLandOtherEntityJurisdictionsNoc] ? [].concat(data[OwnerOfLandOtherEntityJurisdictionsNoc]) : [];
+  }
 
   data[IsOnSanctionsListKey] = (data[IsOnSanctionsListKey]) ? +data[IsOnSanctionsListKey] : '';
   data[IsOnRegisterInCountryFormedInKey] = (data[IsOnRegisterInCountryFormedInKey]) ? +data[IsOnRegisterInCountryFormedInKey] : '';

--- a/test/__mocks__/session.mock.ts
+++ b/test/__mocks__/session.mock.ts
@@ -381,7 +381,10 @@ export const UPDATE_BENEFICIAL_OWNER_OTHER_OBJECT_MOCK: beneficialOwnerOtherType
   is_on_register_in_country_formed_in: yesNoResponse.Yes,
   beneficial_owner_nature_of_control_types: [NatureOfControlType.OVER_25_PERCENT_OF_VOTING_RIGHTS],
   trustees_nature_of_control_types: [NatureOfControlType.APPOINT_OR_REMOVE_MAJORITY_BOARD_DIRECTORS],
+  trust_control_nature_of_control_types: [NatureOfControlType.OVER_25_PERCENT_OF_SHARES],
   non_legal_firm_members_nature_of_control_types: [NatureOfControlType.OVER_25_PERCENT_OF_SHARES],
+  owner_of_land_person_nature_of_control_jurisdictions: [NatureOfControlJurisdiction.ENGLAND_AND_WALES],
+  owner_of_land_other_entity_nature_of_control_jurisdictions: [NatureOfControlJurisdiction.SCOTLAND],
   is_on_sanctions_list: 0,
   ...START_DATE,
   trust_ids: ["8"]

--- a/test/controllers/beneficial.owner.other.controller.spec.ts
+++ b/test/controllers/beneficial.owner.other.controller.spec.ts
@@ -40,6 +40,7 @@ import { authentication } from "../../src/middleware/authentication.middleware";
 import app from "../../src/app";
 import {
   BENEFICIAL_OWNER_OTHER_PAGE,
+  BENEFICIAL_OWNER_TYPE_PAGE,
   BENEFICIAL_OWNER_OTHER_URL,
   BENEFICIAL_OWNER_OTHER_WITH_PARAMS_URL,
   BENEFICIAL_OWNER_TYPE_URL,
@@ -73,7 +74,10 @@ import {
   AddressKeys,
   EntityNumberKey,
   IsOnSanctionsListKey,
-  NatureOfControlType, PublicRegisterNameKey, RegistrationNumberKey,
+  NatureOfControlJurisdiction,
+  NatureOfControlType,
+  PublicRegisterNameKey,
+  RegistrationNumberKey,
   yesNoResponse
 } from "../../src/model/data.types.model";
 import { BeneficialOwnerOther, BeneficialOwnerOtherKey } from "../../src/model/beneficial.owner.other.model";
@@ -154,7 +158,36 @@ describe("BENEFICIAL OWNER OTHER controller", () => {
       expect(resp.text).toContain(YES_SANCTIONS_TEXT_IT);
       expect(resp.text).toContain(NO_SANCTIONS_TEXT_IT);
       expect(resp.text).toContain(SANCTIONS_HINT_TEXT_IT);
+      expect(resp.text).toContain(BO_NOC_HEADING);
       expect(resp.text).toContain(TRUSTS_NOC_HEADING);
+      expect(resp.text).toContain(FIRM_NOC_HEADING);
+      expect(resp.text).not.toContain(FIRM_NOC_HEADING_NEW);
+      expect(resp.text).not.toContain(TRUST_CONTROL_NOC_HEADING);
+      expect(resp.text).not.toContain(OWNER_OF_LAND_PERSON_NOC_HEADING);
+      expect(resp.text).not.toContain(OWNER_OF_LAND_OTHER_ENITY_NOC_HEADING);
+    });
+
+    test(`renders the ${BENEFICIAL_OWNER_OTHER_PAGE} page natures of control correctly when FEATURE_FLAG_ENABLE_PROPERTY_OR_LAND_OWNER_NOC is active`, async () => {
+      const appData = APPLICATION_DATA_MOCK;
+      delete appData[EntityNumberKey];
+
+      mockGetApplicationData.mockReturnValueOnce({ ...appData });
+
+      mockIsActiveFeature.mockReturnValueOnce(false); // FEATURE_FLAG_ENABLE_REDIS_REMOVAL
+      mockIsActiveFeature.mockReturnValueOnce(true); // FEATURE_FLAG_ENABLE_PROPERTY_OR_LAND_OWNER_NOC
+
+      const resp = await request(app).get(BENEFICIAL_OWNER_OTHER_URL);
+
+      expect(resp.status).toEqual(200);
+      expect(resp.text).toContain(config.LANDING_PAGE_URL);
+      expect(resp.text).toContain(BENEFICIAL_OWNER_OTHER_PAGE_HEADING);
+      expect(resp.text).toContain(BO_NOC_HEADING);
+      expect(resp.text).toContain(TRUSTS_NOC_HEADING);
+      expect(resp.text).not.toContain(FIRM_NOC_HEADING);
+      expect(resp.text).toContain(FIRM_NOC_HEADING_NEW);
+      expect(resp.text).toContain(TRUST_CONTROL_NOC_HEADING);
+      expect(resp.text).toContain(OWNER_OF_LAND_PERSON_NOC_HEADING);
+      expect(resp.text).toContain(OWNER_OF_LAND_OTHER_ENITY_NOC_HEADING);
     });
 
     test(`Renders the ${BENEFICIAL_OWNER_OTHER_PAGE} page without public register jurisdiction field`, async () => {
@@ -190,7 +223,36 @@ describe("BENEFICIAL OWNER OTHER controller", () => {
       expect(resp.text).toContain(YES_SANCTIONS_TEXT_IT);
       expect(resp.text).toContain(NO_SANCTIONS_TEXT_IT);
       expect(resp.text).toContain(SANCTIONS_HINT_TEXT_IT);
+      expect(resp.text).toContain(BO_NOC_HEADING);
       expect(resp.text).toContain(TRUSTS_NOC_HEADING);
+      expect(resp.text).toContain(FIRM_NOC_HEADING);
+      expect(resp.text).not.toContain(FIRM_NOC_HEADING_NEW);
+      expect(resp.text).not.toContain(TRUST_CONTROL_NOC_HEADING);
+      expect(resp.text).not.toContain(OWNER_OF_LAND_PERSON_NOC_HEADING);
+      expect(resp.text).not.toContain(OWNER_OF_LAND_OTHER_ENITY_NOC_HEADING);
+    });
+
+    test(`renders the ${BENEFICIAL_OWNER_OTHER_PAGE} page natures of control correctly when FEATURE_FLAG_ENABLE_PROPERTY_OR_LAND_OWNER_NOC is active`, async () => {
+      const appData = APPLICATION_DATA_MOCK;
+      delete appData[EntityNumberKey];
+
+      mockGetApplicationData.mockReturnValueOnce({ ...appData });
+
+      mockIsActiveFeature.mockReturnValueOnce(false); // FEATURE_FLAG_ENABLE_REDIS_REMOVAL
+      mockIsActiveFeature.mockReturnValueOnce(true); // FEATURE_FLAG_ENABLE_PROPERTY_OR_LAND_OWNER_NOC
+
+      const resp = await request(app).get(BENEFICIAL_OWNER_OTHER_WITH_PARAMS_URL);
+
+      expect(resp.status).toEqual(200);
+      expect(resp.text).toContain(config.LANDING_PAGE_URL);
+      expect(resp.text).toContain(BENEFICIAL_OWNER_OTHER_PAGE_HEADING);
+      expect(resp.text).toContain(BO_NOC_HEADING);
+      expect(resp.text).toContain(TRUSTS_NOC_HEADING);
+      expect(resp.text).not.toContain(FIRM_NOC_HEADING);
+      expect(resp.text).toContain(FIRM_NOC_HEADING_NEW);
+      expect(resp.text).toContain(TRUST_CONTROL_NOC_HEADING);
+      expect(resp.text).toContain(OWNER_OF_LAND_PERSON_NOC_HEADING);
+      expect(resp.text).toContain(OWNER_OF_LAND_OTHER_ENITY_NOC_HEADING);
     });
 
     test(`Renders the ${BENEFICIAL_OWNER_OTHER_PAGE} page without public register jurisdiction field`, async () => {
@@ -255,10 +317,9 @@ describe("BENEFICIAL OWNER OTHER controller", () => {
       expect(resp.text).toContain("country");
       expect(resp.text).toContain("BY 2");
       expect(resp.text).toContain(SAVE_AND_CONTINUE_BUTTON_TEXT);
-      expect(mockIsActiveFeature).toBeCalledTimes(2);
+      expect(mockIsActiveFeature).toBeCalledTimes(3);
       expect(mockGetUrlWithParamsToPath.mock.calls[0][0]).toEqual(config.BENEFICIAL_OWNER_TYPE_WITH_PARAMS_URL);
-      expect(mockGetUrlWithParamsToPath.mock.calls[1][0]).toEqual(config.ACTIVE_SUBMISSION_BASE_PATH);
-      const removePath = config.REGISTER_AN_OVERSEAS_ENTITY_URL + NEXT_PAGE_URL + config.BENEFICIAL_OWNER_OTHER_PAGE + config.REMOVE + BO_OTHER_ID_URL;
+      const removePath = config.REGISTER_AN_OVERSEAS_ENTITY_URL + config.BENEFICIAL_OWNER_OTHER_PAGE + config.REMOVE + BO_OTHER_ID_URL;
       expect(resp.text).toContain(removePath);
     });
 
@@ -277,7 +338,7 @@ describe("BENEFICIAL OWNER OTHER controller", () => {
       const beneficialOwnerOtherMock = { ...BENEFICIAL_OWNER_OTHER_OBJECT_MOCK, [IsOnSanctionsListKey]: "0" };
       mockPrepareData.mockReturnValueOnce(beneficialOwnerOtherMock);
       const resp = await request(app).post(BENEFICIAL_OWNER_OTHER_URL)
-        .send(BENEFICIAL_OWNER_OTHER_BODY_OBJECT_MOCK_WITH_ADDRESS);
+        .send({ ...BENEFICIAL_OWNER_OTHER_BODY_OBJECT_MOCK_WITH_ADDRESS });
 
       expect(resp.status).toEqual(302);
       const beneficialOwnerOther = mockSetApplicationData.mock.calls[0][1];
@@ -328,7 +389,7 @@ describe("BENEFICIAL OWNER OTHER controller", () => {
     test("Catch error when posting data", async () => {
       mockSetApplicationData.mockImplementationOnce( () => { throw new Error(MESSAGE_ERROR); });
       const resp = await request(app).post(BENEFICIAL_OWNER_OTHER_URL)
-        .send(BENEFICIAL_OWNER_OTHER_BODY_OBJECT_MOCK_WITH_ADDRESS);
+        .send({ ...BENEFICIAL_OWNER_OTHER_BODY_OBJECT_MOCK_WITH_ADDRESS });
 
       expect(resp.status).toEqual(500);
       expect(resp.text).toContain(SERVICE_UNAVAILABLE);
@@ -736,23 +797,79 @@ describe("BENEFICIAL OWNER OTHER controller", () => {
     });
 
     describe("Nature of control tests", () => {
-      test(`Renders the ${BENEFICIAL_OWNER_OTHER_PAGE} page with validation errors with correct nature of controls with FEATURE_FLAG_ENABLE_PROPERTY_OR_LAND_OWNER_NOC_30082024 ON`, async () => {
-        mockIsActiveFeature.mockReturnValueOnce(true); // FEATURE_FLAG_ENABLE_PROPERTY_OR_LAND_OWNER_NOC
+      test.each([
+        ["BO Noc", [NatureOfControlType.APPOINT_OR_REMOVE_MAJORITY_BOARD_DIRECTORS], null, null],
+        ["Trustee Noc", null, [NatureOfControlType.APPOINT_OR_REMOVE_MAJORITY_BOARD_DIRECTORS], null],
+        ["Non legal firm Noc", null, null, [NatureOfControlType.APPOINT_OR_REMOVE_MAJORITY_BOARD_DIRECTORS]]
+      ])(`redirect to the ${BENEFICIAL_OWNER_TYPE_PAGE} page when page data includes a nature of control - %s`, async (_desc, boNoc, trusteeNoc, nonLegalNoc) => {
+        mockPrepareData.mockImplementationOnce( () => ( { ...BENEFICIAL_OWNER_OTHER_BODY_OBJECT_MOCK_WITH_ADDRESS } ));
+
+        const body = {
+          ...BENEFICIAL_OWNER_OTHER_BODY_OBJECT_MOCK_WITH_ADDRESS,
+          beneficial_owner_nature_of_control_types: boNoc,
+          trustees_nature_of_control_types: trusteeNoc,
+          non_legal_firm_members_nature_of_control_types: nonLegalNoc
+        };
+
+        const resp = await request(app)
+          .post(BENEFICIAL_OWNER_OTHER_URL)
+          .send(body);
+
+        expect(resp.status).toEqual(302);
+        expect(resp.header.location).toEqual(BENEFICIAL_OWNER_TYPE_URL);
+      });
+
+      test.each([
+        ["BO Noc", [NatureOfControlType.APPOINT_OR_REMOVE_MAJORITY_BOARD_DIRECTORS], null, null, null, null, null],
+        ["Trustee Noc", null, [NatureOfControlType.APPOINT_OR_REMOVE_MAJORITY_BOARD_DIRECTORS], null, null, null, null],
+        ["Trust control Noc", null, null, [NatureOfControlType.APPOINT_OR_REMOVE_MAJORITY_BOARD_DIRECTORS], null, null, null],
+        ["Non legal firm Noc", null, null, null, [NatureOfControlType.APPOINT_OR_REMOVE_MAJORITY_BOARD_DIRECTORS], null, null],
+        ["Owner of land person Noc", null, null, null, null, [NatureOfControlJurisdiction.ENGLAND_AND_WALES], null],
+        ["Owner of land other entitiy Noc", null, null, null, null, null, [NatureOfControlJurisdiction.ENGLAND_AND_WALES]],
+      ])(`redirect to the ${BENEFICIAL_OWNER_TYPE_PAGE} page when page data includes a nature of control and FEATURE_FLAG_ENABLE_PROPERTY_OR_LAND_OWNER_NOC is ON - %s`, async (_desc, boNoc, trusteeNoc, trustControlNoc, nonLegalNoc, landPersonNoc, landOtherEntityNoc) => {
         mockIsActiveFeature.mockReturnValueOnce(true); // FEATURE_FLAG_ENABLE_PROPERTY_OR_LAND_OWNER_NOC
         mockIsActiveFeature.mockReturnValueOnce(false); // FEATURE_FLAG_ENABLE_REDIS_REMOVAL
+        mockIsActiveFeature.mockReturnValueOnce(true); // FEATURE_FLAG_ENABLE_PROPERTY_OR_LAND_OWNER_NOC
 
-        const resp = await request(app).post(BENEFICIAL_OWNER_OTHER_URL);
+        mockPrepareData.mockImplementationOnce( () => ( { ...BENEFICIAL_OWNER_OTHER_BODY_OBJECT_MOCK_WITH_ADDRESS } ));
 
+        const body = {
+          ...BENEFICIAL_OWNER_OTHER_BODY_OBJECT_MOCK_WITH_ADDRESS,
+          beneficial_owner_nature_of_control_types: boNoc,
+          trustees_nature_of_control_types: trusteeNoc,
+          trust_control_nature_of_control_types: trustControlNoc,
+          non_legal_firm_members_nature_of_control_types: nonLegalNoc,
+          owner_of_land_person_nature_of_control_jurisdictions: landPersonNoc,
+          owner_of_land_other_entity_nature_of_control_jurisdictions: landOtherEntityNoc
+        };
+
+        const resp = await request(app)
+          .post(BENEFICIAL_OWNER_OTHER_URL)
+          .send(body);
+
+        expect(resp.status).toEqual(302);
+        expect(resp.header.location).toEqual(BENEFICIAL_OWNER_TYPE_URL);
+      });
+
+      test(`renders the ${BENEFICIAL_OWNER_OTHER_PAGE} page with nature of control error when no nature of control is provided and FEATURE_FLAG_ENABLE_PROPERTY_OR_LAND_OWNER_NOC is ON`, async () => {
+        mockIsActiveFeature.mockReturnValueOnce(true); // FEATURE_FLAG_ENABLE_PROPERTY_OR_LAND_OWNER_NOC
+        mockIsActiveFeature.mockReturnValueOnce(false); // FEATURE_FLAG_ENABLE_REDIS_REMOVAL
+        mockIsActiveFeature.mockReturnValueOnce(true); // FEATURE_FLAG_ENABLE_PROPERTY_OR_LAND_OWNER_NOC
+
+        const beneficialOwnerIndividual = {
+          ...BENEFICIAL_OWNER_OTHER_OBJECT_MOCK,
+          beneficial_owner_nature_of_control_types: null,
+          trustees_nature_of_control_types: null,
+          trust_control_nature_of_control_types: null,
+          non_legal_firm_members_nature_of_control_types: null,
+          owner_of_land_person_nature_of_control_jurisdictions: null,
+          owner_of_land_other_entity_nature_of_control_jurisdictions: null
+        };
+        const resp = await request(app).post(BENEFICIAL_OWNER_OTHER_URL)
+          .send(beneficialOwnerIndividual);
         expect(resp.status).toEqual(200);
         expect(resp.text).toContain(BENEFICIAL_OWNER_OTHER_PAGE_HEADING);
-
-        expect(resp.text).toContain(BO_NOC_HEADING);
-        expect(resp.text).toContain(TRUSTS_NOC_HEADING);
-        expect(resp.text).toContain(FIRM_NOC_HEADING);
-        expect(resp.text).not.toContain(FIRM_NOC_HEADING_NEW);
-        expect(resp.text).not.toContain(TRUST_CONTROL_NOC_HEADING);
-        expect(resp.text).not.toContain(OWNER_OF_LAND_PERSON_NOC_HEADING);
-        expect(resp.text).not.toContain(OWNER_OF_LAND_OTHER_ENITY_NOC_HEADING);
+        expect(resp.text).toContain(ErrorMessages.SELECT_NATURE_OF_CONTROL);
       });
 
       test(`Renders the ${BENEFICIAL_OWNER_OTHER_PAGE} page with validation errors with correct nature of controls with FEATURE_FLAG_ENABLE_PROPERTY_OR_LAND_OWNER_NOC_30082024 OFF`, async () => {
@@ -781,9 +898,11 @@ describe("BENEFICIAL OWNER OTHER controller", () => {
     test(`Sets session data and renders the ${BENEFICIAL_OWNER_TYPE_URL} page`, async () => {
       mockIsActiveFeature.mockReturnValueOnce(false); // FEATURE_FLAG_ENABLE_PROPERTY_OR_LAND_OWNER_NOC
       mockIsActiveFeature.mockReturnValueOnce(true); // For FEATURE_FLAG_ENABLE_REDIS_REMOVAL
+      mockIsActiveFeature.mockReturnValueOnce(false); // FEATURE_FLAG_ENABLE_PROPERTY_OR_LAND_OWNER_NOC
 
       const beneficialOwnerOtherMock = { ...BENEFICIAL_OWNER_OTHER_OBJECT_MOCK, [IsOnSanctionsListKey]: "0" };
       mockPrepareData.mockReturnValueOnce(beneficialOwnerOtherMock);
+
       const resp = await request(app).post(BENEFICIAL_OWNER_OTHER_WITH_PARAMS_URL)
         .send(BENEFICIAL_OWNER_OTHER_BODY_OBJECT_MOCK_WITH_ADDRESS);
 
@@ -1247,6 +1366,60 @@ describe("BENEFICIAL OWNER OTHER controller", () => {
     });
 
     describe("Nature of control tests with url params", () => {
+      test.each([
+        ["BO Noc", [NatureOfControlType.APPOINT_OR_REMOVE_MAJORITY_BOARD_DIRECTORS], null, null],
+        ["Trustee Noc", null, [NatureOfControlType.APPOINT_OR_REMOVE_MAJORITY_BOARD_DIRECTORS], null],
+        ["Non legal firm Noc", null, null, [NatureOfControlType.APPOINT_OR_REMOVE_MAJORITY_BOARD_DIRECTORS]]
+      ])(`redirect to the ${BENEFICIAL_OWNER_TYPE_PAGE} page when page data includes a nature of control - %s`, async (_desc, boNoc, trusteeNoc, nonLegalNoc) => {
+        mockPrepareData.mockImplementationOnce( () => ( { ...BENEFICIAL_OWNER_OTHER_BODY_OBJECT_MOCK_WITH_ADDRESS } ));
+
+        const body = {
+          ...BENEFICIAL_OWNER_OTHER_BODY_OBJECT_MOCK_WITH_ADDRESS,
+          beneficial_owner_nature_of_control_types: boNoc,
+          trustees_nature_of_control_types: trusteeNoc,
+          non_legal_firm_members_nature_of_control_types: nonLegalNoc
+        };
+
+        const resp = await request(app)
+          .post(BENEFICIAL_OWNER_OTHER_WITH_PARAMS_URL)
+          .send(body);
+
+        expect(resp.status).toEqual(302);
+        expect(resp.header.location).toEqual(BENEFICIAL_OWNER_TYPE_URL);
+      });
+
+      test.each([
+        ["BO Noc", [NatureOfControlType.APPOINT_OR_REMOVE_MAJORITY_BOARD_DIRECTORS], null, null, null, null, null],
+        ["Trustee Noc", null, [NatureOfControlType.APPOINT_OR_REMOVE_MAJORITY_BOARD_DIRECTORS], null, null, null, null],
+        ["Trust control Noc", null, null, [NatureOfControlType.APPOINT_OR_REMOVE_MAJORITY_BOARD_DIRECTORS], null, null, null],
+        ["Non legal firm Noc", null, null, null, [NatureOfControlType.APPOINT_OR_REMOVE_MAJORITY_BOARD_DIRECTORS], null, null],
+        ["Owner of land person Noc", null, null, null, null, [NatureOfControlJurisdiction.ENGLAND_AND_WALES], null],
+        ["Owner of land other entitiy Noc", null, null, null, null, null, [NatureOfControlJurisdiction.ENGLAND_AND_WALES]],
+      ])(`redirect to the ${BENEFICIAL_OWNER_TYPE_PAGE} page when page data includes a nature of control and FEATURE_FLAG_ENABLE_PROPERTY_OR_LAND_OWNER_NOC is ON - %s`, async (_desc, boNoc, trusteeNoc, trustControlNoc, nonLegalNoc, landPersonNoc, landOtherEntityNoc) => {
+        mockIsActiveFeature.mockReturnValueOnce(true); // FEATURE_FLAG_ENABLE_PROPERTY_OR_LAND_OWNER_NOC
+        mockIsActiveFeature.mockReturnValueOnce(false); // FEATURE_FLAG_ENABLE_REDIS_REMOVAL
+        mockIsActiveFeature.mockReturnValueOnce(true); // FEATURE_FLAG_ENABLE_PROPERTY_OR_LAND_OWNER_NOC
+
+        mockPrepareData.mockImplementationOnce( () => ( { ...BENEFICIAL_OWNER_OTHER_BODY_OBJECT_MOCK_WITH_ADDRESS } ));
+
+        const body = {
+          ...BENEFICIAL_OWNER_OTHER_BODY_OBJECT_MOCK_WITH_ADDRESS,
+          beneficial_owner_nature_of_control_types: boNoc,
+          trustees_nature_of_control_types: trusteeNoc,
+          trust_control_nature_of_control_types: trustControlNoc,
+          non_legal_firm_members_nature_of_control_types: nonLegalNoc,
+          owner_of_land_person_nature_of_control_jurisdictions: landPersonNoc,
+          owner_of_land_other_entity_nature_of_control_jurisdictions: landOtherEntityNoc
+        };
+
+        const resp = await request(app)
+          .post(BENEFICIAL_OWNER_OTHER_WITH_PARAMS_URL)
+          .send(body);
+
+        expect(resp.status).toEqual(302);
+        expect(resp.header.location).toEqual(BENEFICIAL_OWNER_TYPE_URL);
+      });
+
       test(`Renders the ${BENEFICIAL_OWNER_OTHER_PAGE} page with validation errors with correct nature of controls with FEATURE_FLAG_ENABLE_PROPERTY_OR_LAND_OWNER_NOC_30082024 ON`, async () => {
         mockIsActiveFeature.mockReturnValueOnce(true); // FEATURE_FLAG_ENABLE_PROPERTY_OR_LAND_OWNER_NOC
         mockIsActiveFeature.mockReturnValueOnce(true); // FEATURE_FLAG_ENABLE_PROPERTY_OR_LAND_OWNER_NOC
@@ -1257,13 +1430,14 @@ describe("BENEFICIAL OWNER OTHER controller", () => {
         expect(resp.status).toEqual(200);
         expect(resp.text).toContain(BENEFICIAL_OWNER_OTHER_PAGE_HEADING);
 
+        expect(resp.text).toContain(ErrorMessages.SELECT_NATURE_OF_CONTROL);
         expect(resp.text).toContain(BO_NOC_HEADING);
         expect(resp.text).toContain(TRUSTS_NOC_HEADING);
-        expect(resp.text).toContain(FIRM_NOC_HEADING);
-        expect(resp.text).not.toContain(FIRM_NOC_HEADING_NEW);
-        expect(resp.text).not.toContain(TRUST_CONTROL_NOC_HEADING);
-        expect(resp.text).not.toContain(OWNER_OF_LAND_PERSON_NOC_HEADING);
-        expect(resp.text).not.toContain(OWNER_OF_LAND_OTHER_ENITY_NOC_HEADING);
+        expect(resp.text).not.toContain(FIRM_NOC_HEADING);
+        expect(resp.text).toContain(FIRM_NOC_HEADING_NEW);
+        expect(resp.text).toContain(TRUST_CONTROL_NOC_HEADING);
+        expect(resp.text).toContain(OWNER_OF_LAND_PERSON_NOC_HEADING);
+        expect(resp.text).toContain(OWNER_OF_LAND_OTHER_ENITY_NOC_HEADING);
       });
 
       test(`Renders the ${BENEFICIAL_OWNER_OTHER_PAGE} page with validation errors with correct nature of controls with FEATURE_FLAG_ENABLE_PROPERTY_OR_LAND_OWNER_NOC_30082024 OFF`, async () => {
@@ -1276,6 +1450,7 @@ describe("BENEFICIAL OWNER OTHER controller", () => {
         expect(resp.status).toEqual(200);
         expect(resp.text).toContain(BENEFICIAL_OWNER_OTHER_PAGE_HEADING);
 
+        expect(resp.text).toContain(ErrorMessages.SELECT_NATURE_OF_CONTROL);
         expect(resp.text).toContain(BO_NOC_HEADING);
         expect(resp.text).toContain(TRUSTS_NOC_HEADING);
         expect(resp.text).toContain(FIRM_NOC_HEADING);

--- a/views/includes/inputs/nature-of-control-checkboxes/non-legal-firm-nature-of-control-types.html
+++ b/views/includes/inputs/nature-of-control-checkboxes/non-legal-firm-nature-of-control-types.html
@@ -1,6 +1,6 @@
 {% set nonLegalLegendText = "The beneficial owner is a member of a firm that is not a legal person under its governing law, and:" %}
 
-{% if FEATURE_FLAG_ENABLE_PROPERTY_OR_LAND_OWNER_NOC and not entity_number and isBeneficialOwnerIndividual %}
+{% if FEATURE_FLAG_ENABLE_PROPERTY_OR_LAND_OWNER_NOC and not entity_number and (isBeneficialOwnerIndividual or isBeneficialOwnerOther) %}
   {% set nonLegalLegendText = "The beneficial owner has the right to exercise, or actually exercises, significant control or influence over the activities of a firm that is not a legal person under its governing law, and:" %}
 {% endif %}
 

--- a/views/includes/page-templates/beneficial-owner-nature-of-control-types.html
+++ b/views/includes/page-templates/beneficial-owner-nature-of-control-types.html
@@ -14,7 +14,7 @@
   {% include "includes/inputs/nature-of-control-checkboxes/trustees-nature-of-control-types.html" %}
 {% endif %}
 
-{% if FEATURE_FLAG_ENABLE_PROPERTY_OR_LAND_OWNER_NOC and not entity_number and isBeneficialOwnerIndividual %}
+{% if FEATURE_FLAG_ENABLE_PROPERTY_OR_LAND_OWNER_NOC and not entity_number and (isBeneficialOwnerIndividual or isBeneficialOwnerOther) %}
   {% set errorMessage = {} if errors.beneficial_owner_nature_of_control_types %}
   {% include "includes/inputs/nature-of-control-checkboxes/trust-control-nature-of-control-types.html" %}
 {% endif %}

--- a/views/includes/page-templates/beneficial-owner-other.html
+++ b/views/includes/page-templates/beneficial-owner-other.html
@@ -31,8 +31,13 @@
       {% endif %}
 
       {% set isBeneficialOwnerGov = false %}
+      {% set isBeneficialOwnerOther = true %}
       {% set natureOfControlText = "What is its nature of control?" %}
       {% include "includes/page-templates/beneficial-owner-nature-of-control-types.html" %}
+
+      {% if not entity_number %}
+        {% include "includes/page-templates/beneficial-owner-nature-of-control-jurisdictions.html" %}
+      {% endif %}
 
       {% include "includes/inputs/fields/is-on-sanctions-list-input.html" %}
 


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/UAR-1585

### Change description

* Added new natures of controls to the BO 'other' page on Registration journey
* Can be switched on/off with feature flag FEATURE_FLAG_ENABLE_PROPERTY_OR_LAND_OWNER_NOC_30082024
* Unit tests added and amended

### Work checklist

- [X] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
