### PR TITLE
ROECCT-306: Fix update information page displaying incorrect message when update data is null

### DIFF
--- a/src/utils/relevant.period.ts
+++ b/src/utils/relevant.period.ts
@@ -6,6 +6,6 @@ export const checkRelevantPeriod = (appData: ApplicationData): boolean =>
   appData.update?.change_beneficiary_relevant_period === "CHANGE_BENEFICIARY_RELEVANT_PERIOD";
 
 export const checkRPStatementsExist = (appData: ApplicationData): boolean =>
-  appData.update?.change_bo_relevant_period !== undefined ||
-  appData.update?.trustee_involved_relevant_period !== undefined ||
-  appData.update?.change_beneficiary_relevant_period !== undefined ;
+  !!appData.update?.change_bo_relevant_period ||
+  !!appData.update?.trustee_involved_relevant_period ||
+  !!appData.update?.change_beneficiary_relevant_period ;

--- a/src/utils/relevant.period.ts
+++ b/src/utils/relevant.period.ts
@@ -6,6 +6,6 @@ export const checkRelevantPeriod = (appData: ApplicationData): boolean =>
   appData.update?.change_beneficiary_relevant_period === "CHANGE_BENEFICIARY_RELEVANT_PERIOD";
 
 export const checkRPStatementsExist = (appData: ApplicationData): boolean =>
-  !!appData.update?.change_bo_relevant_period ||
-  !!appData.update?.trustee_involved_relevant_period ||
-  !!appData.update?.change_beneficiary_relevant_period ;
+  (!!appData.update?.change_bo_relevant_period && appData.update?.change_bo_relevant_period !== "NO_CHANGE_BO_RELEVANT_PERIOD") ||
+  (!!appData.update?.trustee_involved_relevant_period && appData.update?.trustee_involved_relevant_period !== "NO_TRUSTEE_INVOLVED_RELEVANT_PERIOD") ||
+  (!!appData.update?.change_beneficiary_relevant_period && appData.update?.change_beneficiary_relevant_period !== "NO_CHANGE_BENEFICIARY_RELEVANT_PERIOD");

--- a/test/utils/relevant.period.spec.ts
+++ b/test/utils/relevant.period.spec.ts
@@ -1,0 +1,182 @@
+import { beforeEach, describe, expect, test, jest } from '@jest/globals';
+import { checkRelevantPeriod, checkRPStatementsExist } from '../../src/utils/relevant.period';
+import {
+  APPLICATION_DATA_UPDATE_BO_MOCK,
+  UPDATE_OBJECT_MOCK_RELEVANT_PERIOD_CHANGE,
+  UPDATE_OBJECT_MOCK_RELEVANT_PERIOD_NO_CHANGE,
+} from "../__mocks__/session.mock";
+import { relevantPeriodType } from '../../src/model';
+
+const appData = {
+  ...APPLICATION_DATA_UPDATE_BO_MOCK,
+  update: {}
+};
+
+const mockCheckRelevantPeriod = checkRelevantPeriod as jest.Mock;
+const mockCheckRPStatementsExist = checkRPStatementsExist as jest.Mock;
+
+describe('relevant period test suite', () => {
+  describe('check relevant period', () => {
+    beforeEach (() => {
+      jest.clearAllMocks();
+
+      appData.update = {
+        change_bo_relevant_period: undefined,
+        trustee_involved_relevant_period: undefined,
+        change_beneficiary_relevant_period: undefined
+      };
+    });
+
+    test('should return true if change_bo_relevant_period is selected', () => {
+      appData.update = { change_bo_relevant_period: relevantPeriodType.ChangeBoRelevantPeriodType.YES };
+
+      expect(mockCheckRelevantPeriod(appData)).toBeTruthy();
+
+      expect(appData.update).toHaveProperty("change_bo_relevant_period", "CHANGE_BO_RELEVANT_PERIOD");
+      expect(appData.update).not.toHaveProperty("trustee_involved_relevant_period");
+      expect(appData.update).not.toHaveProperty("change_beneficiary_relevant_period");
+    });
+
+    test('should return true if trustee_involved_relevant_period is selected', () => {
+      appData.update = { trustee_involved_relevant_period: relevantPeriodType.TrusteeInvolvedRelevantPeriodType.YES };
+
+      expect(mockCheckRelevantPeriod(appData)).toBeTruthy();
+
+      expect(appData.update).not.toHaveProperty("change_bo_relevant_period");
+      expect(appData.update).toHaveProperty("trustee_involved_relevant_period", "TRUSTEE_INVOLVED_RELEVANT_PERIOD");
+      expect(appData.update).not.toHaveProperty("change_beneficiary_relevant_period");
+    });
+
+    test('should return true if change_beneficiary_relevant_period is selected', () => {
+      appData.update = { change_beneficiary_relevant_period: relevantPeriodType.ChangeBeneficiaryRelevantPeriodType.YES };
+
+      expect(mockCheckRelevantPeriod(appData)).toBeTruthy();
+
+      expect(appData.update).not.toHaveProperty("change_bo_relevant_period");
+      expect(appData.update).not.toHaveProperty("trustee_involved_relevant_period");
+      expect(appData.update).toHaveProperty("change_beneficiary_relevant_period", "CHANGE_BENEFICIARY_RELEVANT_PERIOD");
+    });
+
+    test('should return true if multiple options are selected', () => {
+      appData.update = UPDATE_OBJECT_MOCK_RELEVANT_PERIOD_CHANGE;
+
+      expect(mockCheckRelevantPeriod(appData)).toBeTruthy();
+
+      expect(appData.update).toHaveProperty("change_bo_relevant_period", "CHANGE_BO_RELEVANT_PERIOD");
+      expect(appData.update).toHaveProperty("trustee_involved_relevant_period", "TRUSTEE_INVOLVED_RELEVANT_PERIOD");
+      expect(appData.update).toHaveProperty("change_beneficiary_relevant_period", "CHANGE_BENEFICIARY_RELEVANT_PERIOD");
+    });
+
+    test('should return false if relevant periods are not selected', () => {
+      appData.update = UPDATE_OBJECT_MOCK_RELEVANT_PERIOD_NO_CHANGE;
+
+      expect(mockCheckRelevantPeriod(appData)).toBeFalsy();
+
+      expect(appData.update).toHaveProperty("change_bo_relevant_period");
+      expect(appData.update).not.toHaveProperty("change_bo_relevant_period", "CHANGE_BO_RELEVANT_PERIOD");
+      expect(appData.update).toHaveProperty("trustee_involved_relevant_period");
+      expect(appData.update).not.toHaveProperty("trustee_involved_relevant_period", "TRUSTEE_INVOLVED_RELEVANT_PERIOD");
+      expect(appData.update).toHaveProperty("change_beneficiary_relevant_period");
+      expect(appData.update).not.toHaveProperty("change_beneficiary_relevant_period", "CHANGE_BENEFICIARY_RELEVANT_PERIOD");
+    });
+
+    test('should return false if relevant periods are undefined', () => {
+      expect(mockCheckRelevantPeriod(appData)).toBeFalsy();
+
+      expect(appData.update).toHaveProperty("change_bo_relevant_period", undefined);
+      expect(appData.update).toHaveProperty("trustee_involved_relevant_period", undefined);
+      expect(appData.update).toHaveProperty("change_beneficiary_relevant_period", undefined);
+    });
+
+    test('should return false if relevant periods are null', () => {
+      appData.update = {
+        change_bo_relevant_period: null,
+        trustee_involved_relevant_period: null,
+        change_beneficiary_relevant_period: null
+      };
+
+      expect(mockCheckRelevantPeriod(appData)).toBeFalsy();
+
+      expect(appData.update).toHaveProperty("change_bo_relevant_period", null);
+      expect(appData.update).toHaveProperty("trustee_involved_relevant_period", null);
+      expect(appData.update).toHaveProperty("change_beneficiary_relevant_period", null);
+    });
+  });
+
+  describe('check RP statements exists', () => {
+    beforeEach (() => {
+      jest.clearAllMocks();
+
+      appData.update = {
+        change_bo_relevant_period: undefined,
+        trustee_involved_relevant_period: undefined,
+        change_beneficiary_relevant_period: undefined
+      };
+    });
+
+    test('should return true if change_bo_relevant_period exists', () => {
+      appData.update = { change_bo_relevant_period: relevantPeriodType.ChangeBoRelevantPeriodType.YES };
+
+      expect(mockCheckRPStatementsExist(appData)).toBeTruthy();
+
+      expect(appData.update).toHaveProperty("change_bo_relevant_period", "CHANGE_BO_RELEVANT_PERIOD");
+      expect(appData.update).not.toHaveProperty("trustee_involved_relevant_period");
+      expect(appData.update).not.toHaveProperty("change_beneficiary_relevant_period");
+    });
+
+    test('should return true if trustee_involved_relevant_period exists', () => {
+      appData.update = { trustee_involved_relevant_period: relevantPeriodType.TrusteeInvolvedRelevantPeriodType.YES };
+
+      expect(mockCheckRPStatementsExist(appData)).toBeTruthy();
+
+      expect(appData.update).not.toHaveProperty("change_bo_relevant_period");
+      expect(appData.update).toHaveProperty("trustee_involved_relevant_period", "TRUSTEE_INVOLVED_RELEVANT_PERIOD");
+      expect(appData.update).not.toHaveProperty("change_beneficiary_relevant_period");
+    });
+
+    test('should return true if change_beneficiary_relevant_period exists', () => {
+      appData.update = { change_beneficiary_relevant_period: relevantPeriodType.ChangeBeneficiaryRelevantPeriodType.YES };
+
+      expect(mockCheckRPStatementsExist(appData)).toBeTruthy();
+
+      expect(appData.update).not.toHaveProperty("change_bo_relevant_period");
+      expect(appData.update).not.toHaveProperty("trustee_involved_relevant_period");
+      expect(appData.update).toHaveProperty("change_beneficiary_relevant_period", "CHANGE_BENEFICIARY_RELEVANT_PERIOD");
+    });
+
+    test('should return false if relevant periods are not selected', () => {
+      appData.update = UPDATE_OBJECT_MOCK_RELEVANT_PERIOD_NO_CHANGE;
+
+      expect(mockCheckRPStatementsExist(appData)).toBeFalsy();
+
+      expect(appData.update).toHaveProperty("change_bo_relevant_period");
+      expect(appData.update).not.toHaveProperty("change_bo_relevant_period", "CHANGE_BO_RELEVANT_PERIOD");
+      expect(appData.update).toHaveProperty("trustee_involved_relevant_period");
+      expect(appData.update).not.toHaveProperty("trustee_involved_relevant_period", "TRUSTEE_INVOLVED_RELEVANT_PERIOD");
+      expect(appData.update).toHaveProperty("change_beneficiary_relevant_period");
+      expect(appData.update).not.toHaveProperty("change_beneficiary_relevant_period", "CHANGE_BENEFICIARY_RELEVANT_PERIOD");
+    });
+
+    test('should return false if relevant periods are undefined', () => {
+      expect(mockCheckRPStatementsExist(appData)).toBeFalsy();
+
+      expect(appData.update).toHaveProperty("change_bo_relevant_period", undefined);
+      expect(appData.update).toHaveProperty("trustee_involved_relevant_period", undefined);
+      expect(appData.update).toHaveProperty("change_beneficiary_relevant_period", undefined);
+    });
+
+    test('should return false if relevant periods are null', () => {
+      appData.update = {
+        change_bo_relevant_period: null,
+        trustee_involved_relevant_period: null,
+        change_beneficiary_relevant_period: null
+      };
+
+      expect(mockCheckRPStatementsExist(appData)).toBeFalsy();
+
+      expect(appData.update).toHaveProperty("change_bo_relevant_period", null);
+      expect(appData.update).toHaveProperty("trustee_involved_relevant_period", null);
+      expect(appData.update).toHaveProperty("change_beneficiary_relevant_period", null);
+    });
+  });
+});

--- a/views/update/review-update-statement.html
+++ b/views/update/review-update-statement.html
@@ -103,7 +103,7 @@ update.filing_date["year"]) %}
       {% if isRemoveJourney %}
         <h1 class="govuk-heading-xl">Review the information before submitting</h1>
       {% else %}
-        {% if feature_flag_relevant_period === "true" and not pageParams.isRPStatementExists %}
+        {% if feature_flag_relevant_period === "true" and not pageParams.isRPStatementExists and not pageParams.noChangeFlag %}
           <h1 class="govuk-heading-xl">Check your answers before submitting</h1>
         {% else %}
           <h1 class="govuk-heading-xl">Review the information before submitting this update statement</h1>


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/ROECCT-306

### Change description

Previously the review update statement page was displaying the incorrect message to users when a no change journey was selected. Although the code checks for undefined update data, investigation has shown that the app data being received was null, which the code currently doesn't check for.

This change should fix this error, by modifying the checkRPStatementsExist to check for all falsy values.

### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
