### PR TITLE
UAR-1627 Remove old NOCs when resuming submissions

### DIFF
--- a/src/controllers/shared/common.resume.submission.controller.ts
+++ b/src/controllers/shared/common.resume.submission.controller.ts
@@ -113,12 +113,9 @@ const setWebApplicationData = (session: Session, appData: ApplicationData, trans
 
   if (isActiveFeature(config.FEATURE_FLAG_ENABLE_PROPERTY_OR_LAND_OWNER_NOC) && (!appData.entity_number)) {
     console.debug("Removing old NOCs");
-    appData[BeneficialOwnerIndividualKey] = (appData[BeneficialOwnerIndividualKey] as BeneficialOwnerIndividual[])
-      .map( boi => { delete boi[NonLegalFirmNoc]; return boi; } );
-    appData[BeneficialOwnerOtherKey] = (appData[BeneficialOwnerOtherKey] as BeneficialOwnerOther[] )
-      .map( boo => { delete boo[NonLegalFirmNoc]; return boo; } );
-    appData[BeneficialOwnerGovKey] = (appData[BeneficialOwnerGovKey] as BeneficialOwnerGov[])
-      .map( bog => { delete bog[NonLegalFirmNoc]; return bog; } );
+    appData[BeneficialOwnerIndividualKey].forEach(boi => { delete boi[NonLegalFirmNoc]; });
+    appData[BeneficialOwnerOtherKey].forEach(boo => { delete boo[NonLegalFirmNoc]; });
+    appData[BeneficialOwnerGovKey].forEach(bog => { delete bog[NonLegalFirmNoc]; });
   }
 
   setExtraData(session, appData);

--- a/src/controllers/shared/common.resume.submission.controller.ts
+++ b/src/controllers/shared/common.resume.submission.controller.ts
@@ -13,6 +13,7 @@ import { getOverseasEntity } from "../../service/overseas.entities.service";
 import {
   HasSoldLandKey,
   ID,
+  NonLegalFirmNoc,
   IsSecureRegisterKey,
   OverseasEntityKey,
   Transactionkey
@@ -108,6 +109,16 @@ const setWebApplicationData = (session: Session, appData: ApplicationData, trans
   }
   if (isActiveFeature(config.FEATURE_FLAG_ENABLE_TRUSTS_WEB)) {
     mapTrustApiReturnModelToWebModel(appData);
+  }
+
+  if (isActiveFeature(config.FEATURE_FLAG_ENABLE_PROPERTY_OR_LAND_OWNER_NOC)) {
+    console.log("\n\n** Remove old NOCs! **\n\n");
+    appData[BeneficialOwnerIndividualKey] = (appData[BeneficialOwnerIndividualKey] as BeneficialOwnerIndividual[])
+      .map( boi => { return { ...boi, [NonLegalFirmNoc]: undefined }; } );
+    appData[BeneficialOwnerOtherKey] = (appData[BeneficialOwnerOtherKey] as BeneficialOwnerOther[] )
+      .map( boo => { return { ...boo, [NonLegalFirmNoc]: undefined }; } );
+    appData[BeneficialOwnerGovKey] = (appData[BeneficialOwnerGovKey] as BeneficialOwnerGov[])
+      .map( bog => { return { ...bog, [NonLegalFirmNoc]: undefined }; } );
   }
 
   setExtraData(session, appData);

--- a/src/controllers/shared/common.resume.submission.controller.ts
+++ b/src/controllers/shared/common.resume.submission.controller.ts
@@ -111,14 +111,14 @@ const setWebApplicationData = (session: Session, appData: ApplicationData, trans
     mapTrustApiReturnModelToWebModel(appData);
   }
 
-  if (isActiveFeature(config.FEATURE_FLAG_ENABLE_PROPERTY_OR_LAND_OWNER_NOC)) {
-    console.log("\n\n** Remove old NOCs! **\n\n");
+  if (isActiveFeature(config.FEATURE_FLAG_ENABLE_PROPERTY_OR_LAND_OWNER_NOC) && (!appData.entity_number)) {
+    console.debug("Removing old NOCs");
     appData[BeneficialOwnerIndividualKey] = (appData[BeneficialOwnerIndividualKey] as BeneficialOwnerIndividual[])
-      .map( boi => { return { ...boi, [NonLegalFirmNoc]: undefined }; } );
+      .map( boi => { delete boi[NonLegalFirmNoc]; return boi; } );
     appData[BeneficialOwnerOtherKey] = (appData[BeneficialOwnerOtherKey] as BeneficialOwnerOther[] )
-      .map( boo => { return { ...boo, [NonLegalFirmNoc]: undefined }; } );
+      .map( boo => { delete boo[NonLegalFirmNoc]; return boo; } );
     appData[BeneficialOwnerGovKey] = (appData[BeneficialOwnerGovKey] as BeneficialOwnerGov[])
-      .map( bog => { return { ...bog, [NonLegalFirmNoc]: undefined }; } );
+      .map( bog => { delete bog[NonLegalFirmNoc]; return bog; } );
   }
 
   setExtraData(session, appData);

--- a/test/controllers/resume.submission.controller.spec.ts
+++ b/test/controllers/resume.submission.controller.spec.ts
@@ -43,7 +43,7 @@ import { startPaymentsSession } from "../../src/service/payment.service";
 import { isActiveFeature } from "../../src/utils/feature.flag";
 import { WhoIsRegisteringKey, WhoIsRegisteringType } from '../../src/model/who.is.making.filing.model';
 import { DueDiligenceKey } from '../../src/model/due.diligence.model';
-import { HasSoldLandKey, IsSecureRegisterKey, OverseasEntityKey, Transactionkey } from '../../src/model/data.types.model';
+import { EntityNumberKey, HasSoldLandKey, IsSecureRegisterKey, NatureOfControlType, OverseasEntityKey, Transactionkey } from '../../src/model/data.types.model';
 import { OverseasEntityDueDiligenceKey } from '../../src/model/overseas.entity.due.diligence.model';
 import { OVERSEAS_ENTITY_DUE_DILIGENCE_OBJECT_MOCK } from '../__mocks__/overseas.entity.due.diligence.mock';
 import { MOCK_GET_TRANSACTION_RESPONSE } from '../__mocks__/transaction.mock';
@@ -190,7 +190,7 @@ describe("Resume submission controller", () => {
     expect(mockSetExtraData).toHaveBeenCalledTimes(1);
     expect(mockCreateAndLogErrorRequest).not.toHaveBeenCalled();
     expect(mockMapTrustApiReturnModelToWebModel).toHaveBeenCalledTimes(1);
-    expect(mockIsActiveFeature).toHaveBeenCalledTimes(2);
+    expect(mockIsActiveFeature).toHaveBeenCalledTimes(3);
     expect(mockGetUrlWithTransactionIdAndSubmissionId).not.toHaveBeenCalled();
   });
 
@@ -222,7 +222,7 @@ describe("Resume submission controller", () => {
     expect(mockSetExtraData).toHaveBeenCalledTimes(1);
     expect(mockCreateAndLogErrorRequest).not.toHaveBeenCalled();
     expect(mockMapTrustApiReturnModelToWebModel).toHaveBeenCalledTimes(1);
-    expect(mockIsActiveFeature).toHaveBeenCalledTimes(2);
+    expect(mockIsActiveFeature).toHaveBeenCalledTimes(3);
     expect(mockGetUrlWithTransactionIdAndSubmissionId).toHaveBeenCalledTimes(1);
   });
 
@@ -249,4 +249,44 @@ describe("Resume submission controller", () => {
     expect(resp.text).toContain(SERVICE_UNAVAILABLE);
   });
 
+  test(`Remove old NOCs after resuming the OverseasEntity Registration submission and FEATURE_FLAG_ENABLE_PROPERTY_OR_LAND_OWNER_NOC is ON`, async () => {
+    mockIsActiveFeature.mockReturnValueOnce( true ); // REDIS flag
+    mockIsActiveFeature.mockReturnValueOnce( true ); // trusts feature flag
+    mockIsActiveFeature.mockReturnValueOnce( true ); // new NOCs
+
+    const mockAppData = {
+      ...APPLICATION_DATA_MOCK,
+      [EntityNumberKey]: null
+    };
+    mockGetOverseasEntity.mockReturnValueOnce( mockAppData );
+    const resp = await request(app).get(RESUME_SUBMISSION_URL);
+
+    expect(resp.status).toEqual(302);
+    expect(mockAppData.beneficial_owners_individual?.[0].non_legal_firm_members_nature_of_control_types).toEqual(undefined);
+    expect(mockAppData.beneficial_owners_government_or_public_authority?.[0].non_legal_firm_members_nature_of_control_types).toEqual(undefined);
+    expect(mockAppData.beneficial_owners_corporate?.[0].non_legal_firm_members_nature_of_control_types).toEqual(undefined);
+  });
+
+  test(`Do not remove old NOCs after resuming the OverseasEntity Registration submission and FEATURE_FLAG_ENABLE_PROPERTY_OR_LAND_OWNER_NOC is OFF`, async () => {
+    mockIsActiveFeature.mockReturnValueOnce( true ); // REDIS flag
+    mockIsActiveFeature.mockReturnValueOnce( true ); // trusts feature flag
+    mockIsActiveFeature.mockReturnValueOnce( false ); // new NOCs
+
+    const mockAppData = {
+      ...APPLICATION_DATA_MOCK,
+      [EntityNumberKey]: null
+    };
+    mockGetOverseasEntity.mockReturnValueOnce( mockAppData );
+    const resp = await request(app).get(RESUME_SUBMISSION_URL);
+
+    expect(resp.status).toEqual(302);
+    expect(mockAppData.beneficial_owners_individual?.[0].non_legal_firm_members_nature_of_control_types).toEqual(
+      [NatureOfControlType.APPOINT_OR_REMOVE_MAJORITY_BOARD_DIRECTORS]);
+    expect(mockAppData.beneficial_owners_government_or_public_authority?.[0].non_legal_firm_members_nature_of_control_types).toEqual(
+      [NatureOfControlType.OVER_25_PERCENT_OF_SHARES]
+    );
+    expect(mockAppData.beneficial_owners_corporate?.[0].non_legal_firm_members_nature_of_control_types).toEqual(
+      [NatureOfControlType.OVER_25_PERCENT_OF_SHARES]
+    );
+  });
 });

--- a/test/controllers/resume.submission.controller.spec.ts
+++ b/test/controllers/resume.submission.controller.spec.ts
@@ -26,6 +26,9 @@ import {
 } from '../__mocks__/text.mock';
 import {
   APPLICATION_DATA_MOCK,
+  BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK,
+  BENEFICIAL_OWNER_OTHER_OBJECT_MOCK,
+  BENEFICIAL_OWNER_GOV_OBJECT_MOCK,
   RESUME_SUBMISSION_URL,
   OVERSEAS_ENTITY_ID,
   TRANSACTION_ID,
@@ -49,6 +52,7 @@ import { OVERSEAS_ENTITY_DUE_DILIGENCE_OBJECT_MOCK } from '../__mocks__/overseas
 import { MOCK_GET_TRANSACTION_RESPONSE } from '../__mocks__/transaction.mock';
 import { mapTrustApiReturnModelToWebModel } from '../../src/utils/trusts';
 import { getUrlWithTransactionIdAndSubmissionId } from "../../src/utils/url";
+import { beneficialOwnerIndividualType, beneficialOwnerOtherType, beneficialOwnerGovType } from "../../src/model";
 
 const mockServiceAvailabilityMiddleware = serviceAvailabilityMiddleware as jest.Mock;
 mockServiceAvailabilityMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => next() );
@@ -77,6 +81,23 @@ const mockMapTrustApiReturnModelToWebModel = mapTrustApiReturnModelToWebModel as
 const mockGetUrlWithTransactionIdAndSubmissionId = getUrlWithTransactionIdAndSubmissionId as jest.Mock;
 
 const baseURL = `${config.CHS_URL}${config.REGISTER_AN_OVERSEAS_ENTITY_URL}`;
+
+const mockNocAppData = {
+  ...APPLICATION_DATA_MOCK,
+  [beneficialOwnerIndividualType.BeneficialOwnerIndividualKey]: [{
+    ...BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK,
+    non_legal_firm_members_nature_of_control_types: [NatureOfControlType.APPOINT_OR_REMOVE_MAJORITY_BOARD_DIRECTORS, NatureOfControlType.OVER_25_PERCENT_OF_SHARES]
+  }, BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK ],
+  [beneficialOwnerOtherType.BeneficialOwnerOtherKey]: [{
+    ...BENEFICIAL_OWNER_OTHER_OBJECT_MOCK,
+    non_legal_firm_members_nature_of_control_types: [NatureOfControlType.OVER_25_PERCENT_OF_VOTING_RIGHTS, NatureOfControlType.OVER_25_PERCENT_OF_SHARES]
+  }, BENEFICIAL_OWNER_OTHER_OBJECT_MOCK ],
+  [beneficialOwnerGovType.BeneficialOwnerGovKey]: [{
+    ...BENEFICIAL_OWNER_GOV_OBJECT_MOCK,
+    non_legal_firm_members_nature_of_control_types: [NatureOfControlType.SIGNIFICANT_INFLUENCE_OR_CONTROL, NatureOfControlType.OVER_25_PERCENT_OF_SHARES]
+  }, BENEFICIAL_OWNER_GOV_OBJECT_MOCK ],
+  [EntityNumberKey]: null
+};
 
 describe("Resume submission controller", () => {
 
@@ -254,15 +275,13 @@ describe("Resume submission controller", () => {
     mockIsActiveFeature.mockReturnValueOnce( true ); // trusts feature flag
     mockIsActiveFeature.mockReturnValueOnce( true ); // new NOCs
 
-    const mockAppData = {
-      ...APPLICATION_DATA_MOCK,
-      [EntityNumberKey]: null
-    };
+    const mockAppData = { ...mockNocAppData };
     mockGetOverseasEntity.mockReturnValueOnce( mockAppData );
     const resp = await request(app).get(RESUME_SUBMISSION_URL);
 
     expect(resp.status).toEqual(302);
     expect(mockAppData.beneficial_owners_individual?.[0].non_legal_firm_members_nature_of_control_types).toEqual(undefined);
+    expect(mockAppData.beneficial_owners_individual?.[1].non_legal_firm_members_nature_of_control_types).toEqual(undefined);
     expect(mockAppData.beneficial_owners_government_or_public_authority?.[0].non_legal_firm_members_nature_of_control_types).toEqual(undefined);
     expect(mockAppData.beneficial_owners_corporate?.[0].non_legal_firm_members_nature_of_control_types).toEqual(undefined);
   });
@@ -272,21 +291,22 @@ describe("Resume submission controller", () => {
     mockIsActiveFeature.mockReturnValueOnce( true ); // trusts feature flag
     mockIsActiveFeature.mockReturnValueOnce( false ); // new NOCs
 
-    const mockAppData = {
-      ...APPLICATION_DATA_MOCK,
-      [EntityNumberKey]: null
-    };
+    const mockAppData = { ...mockNocAppData };
     mockGetOverseasEntity.mockReturnValueOnce( mockAppData );
     const resp = await request(app).get(RESUME_SUBMISSION_URL);
 
     expect(resp.status).toEqual(302);
     expect(mockAppData.beneficial_owners_individual?.[0].non_legal_firm_members_nature_of_control_types).toEqual(
+      [NatureOfControlType.APPOINT_OR_REMOVE_MAJORITY_BOARD_DIRECTORS, NatureOfControlType.OVER_25_PERCENT_OF_SHARES]);
+    expect(mockAppData.beneficial_owners_individual?.[1].non_legal_firm_members_nature_of_control_types).toEqual(
       [NatureOfControlType.APPOINT_OR_REMOVE_MAJORITY_BOARD_DIRECTORS]);
     expect(mockAppData.beneficial_owners_government_or_public_authority?.[0].non_legal_firm_members_nature_of_control_types).toEqual(
-      [NatureOfControlType.OVER_25_PERCENT_OF_SHARES]
-    );
-    expect(mockAppData.beneficial_owners_corporate?.[0].non_legal_firm_members_nature_of_control_types).toEqual(
-      [NatureOfControlType.OVER_25_PERCENT_OF_SHARES]
-    );
+      [NatureOfControlType.SIGNIFICANT_INFLUENCE_OR_CONTROL, NatureOfControlType.OVER_25_PERCENT_OF_SHARES]);
+    expect(mockAppData.beneficial_owners_government_or_public_authority?.[1].non_legal_firm_members_nature_of_control_types).toEqual(
+      [NatureOfControlType.OVER_25_PERCENT_OF_SHARES]);
+    expect(mockNocAppData.beneficial_owners_corporate?.[0].non_legal_firm_members_nature_of_control_types).toEqual(
+      [NatureOfControlType.OVER_25_PERCENT_OF_VOTING_RIGHTS, NatureOfControlType.OVER_25_PERCENT_OF_SHARES]);
+    expect(mockAppData.beneficial_owners_corporate?.[1].non_legal_firm_members_nature_of_control_types).toEqual(
+      [NatureOfControlType.OVER_25_PERCENT_OF_SHARES]);
   });
 });

--- a/test/controllers/update/update.resume.submission.controller.spec.ts
+++ b/test/controllers/update/update.resume.submission.controller.spec.ts
@@ -26,6 +26,9 @@ import {
 } from '../../__mocks__/text.mock';
 import {
   APPLICATION_DATA_MOCK,
+  BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK,
+  BENEFICIAL_OWNER_OTHER_OBJECT_MOCK,
+  BENEFICIAL_OWNER_GOV_OBJECT_MOCK,
   RESUME_UPDATE_SUBMISSION_URL,
   OVERSEAS_ENTITY_ID,
   TRANSACTION_ID,
@@ -49,6 +52,7 @@ import { OverseasEntityDueDiligenceKey } from '../../../src/model/overseas.entit
 import { OVERSEAS_ENTITY_DUE_DILIGENCE_OBJECT_MOCK } from '../../__mocks__/overseas.entity.due.diligence.mock';
 import { MOCK_GET_TRANSACTION_RESPONSE } from '../../__mocks__/transaction.mock';
 import { mapTrustApiReturnModelToWebModel } from '../../../src/utils/trusts';
+import { beneficialOwnerIndividualType, beneficialOwnerOtherType, beneficialOwnerGovType } from "../../../src/model";
 
 const mockServiceAvailabilityMiddleware = serviceAvailabilityMiddleware as jest.Mock;
 mockServiceAvailabilityMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => next() );
@@ -78,6 +82,22 @@ mockCompanyAuthenticationMiddleware.mockImplementation((req: Request, res: Respo
 const mockMapTrustApiReturnModelToWebModel = mapTrustApiReturnModelToWebModel as jest.Mock;
 
 const baseURL = `${config.CHS_URL}${config.UPDATE_AN_OVERSEAS_ENTITY_URL}`;
+
+const mockNocAppData = {
+  ...APPLICATION_DATA_MOCK,
+  [beneficialOwnerIndividualType.BeneficialOwnerIndividualKey]: [{
+    ...BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK,
+    non_legal_firm_members_nature_of_control_types: [NatureOfControlType.APPOINT_OR_REMOVE_MAJORITY_BOARD_DIRECTORS, NatureOfControlType.OVER_25_PERCENT_OF_SHARES]
+  }, BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK ],
+  [beneficialOwnerOtherType.BeneficialOwnerOtherKey]: [{
+    ...BENEFICIAL_OWNER_OTHER_OBJECT_MOCK,
+    non_legal_firm_members_nature_of_control_types: [NatureOfControlType.OVER_25_PERCENT_OF_VOTING_RIGHTS, NatureOfControlType.OVER_25_PERCENT_OF_SHARES]
+  }, BENEFICIAL_OWNER_OTHER_OBJECT_MOCK ],
+  [beneficialOwnerGovType.BeneficialOwnerGovKey]: [{
+    ...BENEFICIAL_OWNER_GOV_OBJECT_MOCK,
+    non_legal_firm_members_nature_of_control_types: [NatureOfControlType.SIGNIFICANT_INFLUENCE_OR_CONTROL, NatureOfControlType.OVER_25_PERCENT_OF_SHARES]
+  }, BENEFICIAL_OWNER_GOV_OBJECT_MOCK ]
+};
 
 describe("Update Resume submission controller", () => {
 
@@ -241,19 +261,22 @@ describe("Update Resume submission controller", () => {
       mockIsActiveFeature.mockReturnValueOnce( true ); // trusts feature flag
       mockIsActiveFeature.mockReturnValueOnce( true ); // new NOCs
 
-      const mockAppData = {
-        ...APPLICATION_DATA_MOCK
-      };
+      const mockAppData = { ...mockNocAppData };
       mockGetOverseasEntity.mockReturnValueOnce( mockAppData );
       const resp = await request(app).get(RESUME_UPDATE_SUBMISSION_URL);
 
       expect(resp.status).toEqual(302);
       expect(mockAppData.beneficial_owners_individual?.[0].non_legal_firm_members_nature_of_control_types).toEqual(
+        [NatureOfControlType.APPOINT_OR_REMOVE_MAJORITY_BOARD_DIRECTORS, NatureOfControlType.OVER_25_PERCENT_OF_SHARES]);
+      expect(mockAppData.beneficial_owners_individual?.[1].non_legal_firm_members_nature_of_control_types).toEqual(
         [NatureOfControlType.APPOINT_OR_REMOVE_MAJORITY_BOARD_DIRECTORS]);
       expect(mockAppData.beneficial_owners_government_or_public_authority?.[0].non_legal_firm_members_nature_of_control_types).toEqual(
-        [NatureOfControlType.OVER_25_PERCENT_OF_SHARES]
-      );
-      expect(mockAppData.beneficial_owners_corporate?.[0].non_legal_firm_members_nature_of_control_types).toEqual(
+        [NatureOfControlType.SIGNIFICANT_INFLUENCE_OR_CONTROL, NatureOfControlType.OVER_25_PERCENT_OF_SHARES]);
+      expect(mockAppData.beneficial_owners_government_or_public_authority?.[1].non_legal_firm_members_nature_of_control_types).toEqual(
+        [NatureOfControlType.OVER_25_PERCENT_OF_SHARES]);
+      expect(mockNocAppData.beneficial_owners_corporate?.[0].non_legal_firm_members_nature_of_control_types).toEqual(
+        [NatureOfControlType.OVER_25_PERCENT_OF_VOTING_RIGHTS, NatureOfControlType.OVER_25_PERCENT_OF_SHARES]);
+      expect(mockAppData.beneficial_owners_corporate?.[1].non_legal_firm_members_nature_of_control_types).toEqual(
         [NatureOfControlType.OVER_25_PERCENT_OF_SHARES]);
     });
 
@@ -262,21 +285,23 @@ describe("Update Resume submission controller", () => {
       mockIsActiveFeature.mockReturnValueOnce( true ); // trusts feature flag
       mockIsActiveFeature.mockReturnValueOnce( false ); // new NOCs
 
-      const mockAppData = {
-        ...APPLICATION_DATA_MOCK
-      };
+      const mockAppData = { ...mockNocAppData };
       mockGetOverseasEntity.mockReturnValueOnce( mockAppData );
       const resp = await request(app).get(RESUME_UPDATE_SUBMISSION_URL);
 
       expect(resp.status).toEqual(302);
       expect(mockAppData.beneficial_owners_individual?.[0].non_legal_firm_members_nature_of_control_types).toEqual(
+        [NatureOfControlType.APPOINT_OR_REMOVE_MAJORITY_BOARD_DIRECTORS, NatureOfControlType.OVER_25_PERCENT_OF_SHARES]);
+      expect(mockAppData.beneficial_owners_individual?.[1].non_legal_firm_members_nature_of_control_types).toEqual(
         [NatureOfControlType.APPOINT_OR_REMOVE_MAJORITY_BOARD_DIRECTORS]);
       expect(mockAppData.beneficial_owners_government_or_public_authority?.[0].non_legal_firm_members_nature_of_control_types).toEqual(
-        [NatureOfControlType.OVER_25_PERCENT_OF_SHARES]
-      );
-      expect(mockAppData.beneficial_owners_corporate?.[0].non_legal_firm_members_nature_of_control_types).toEqual(
-        [NatureOfControlType.OVER_25_PERCENT_OF_SHARES]
-      );
+        [NatureOfControlType.SIGNIFICANT_INFLUENCE_OR_CONTROL, NatureOfControlType.OVER_25_PERCENT_OF_SHARES]);
+      expect(mockAppData.beneficial_owners_government_or_public_authority?.[1].non_legal_firm_members_nature_of_control_types).toEqual(
+        [NatureOfControlType.OVER_25_PERCENT_OF_SHARES]);
+      expect(mockNocAppData.beneficial_owners_corporate?.[0].non_legal_firm_members_nature_of_control_types).toEqual(
+        [NatureOfControlType.OVER_25_PERCENT_OF_VOTING_RIGHTS, NatureOfControlType.OVER_25_PERCENT_OF_SHARES]);
+      expect(mockAppData.beneficial_owners_corporate?.[1].non_legal_firm_members_nature_of_control_types).toEqual(
+        [NatureOfControlType.OVER_25_PERCENT_OF_SHARES]);
     });
   });
 });


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/UAR-1627

### Change description

* non_legal_firm_members_nature_of_control_types NOC set to undefined for all BOs
* Only applies when resuming registrations
* New unit tests added

TODO More testing and unit-tests

### Work checklist

- [X] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
