### PR TITLE
Uar 1587 add nocs review update page no change

### DIFF
--- a/views/includes/check-your-answers/beneficial-owner-gov.html
+++ b/views/includes/check-your-answers/beneficial-owner-gov.html
@@ -31,38 +31,44 @@
   {% include "includes/check-your-answers/nocs/beneficial-owner-noc.html" %}
 {% endset %}
 
+{% set bogBeneficialOwnerNonLegalFirmNOCs %}
+  {% set boNOCNonLegalTypesArray = bog.non_legal_firm_members_nature_of_control_types %}
+  {% include "includes/check-your-answers/nocs/beneficial-owner-member-of-firm-noc.html" %}
+{% endset %}
+
+{% set bogBeneficialOwnerTrustControlNOCs %}
+  {% set boNOCTrustControlTypesArray = bog.trust_control_nature_of_control_types %}
+  {% include "includes/check-your-answers/nocs/beneficial-owner-trust-control-noc.html" %}
+{% endset %}
+
+{% set bogBeneficialOwnerNonLegalFirmControlNOCs %}
+  {% set boNOCNonLegalFirmControlTypesArray = bog.non_legal_firm_control_nature_of_control_types %}
+  {% include "includes/check-your-answers/nocs/beneficial-owner-member-of-firm-control-noc.html" %}
+{% endset %}
+
+{% set bogOwnerOfLandPersonNOCs %}
+  {% set boNOCOwnerOfLandPersonJurisdictionsArray = bog.owner_of_land_person_nature_of_control_jurisdictions %}
+  {% include "includes/check-your-answers/nocs/beneficial-owner-owner-of-land-person-noc.html" %}
+{% endset %}
+
+{% set bogOwnerOfLandOtherEntityNOCs %}
+  {% set boNOCOwnerOfLandOtherEntityJurisdictionsArray = bog.owner_of_land_other_entity_nature_of_control_jurisdictions %}
+  {% include "includes/check-your-answers/nocs/beneficial-owner-owner-of-land-other-entity-noc.html" %}
+{% endset %}
+
+{# Initialize boNOCHtml with individual NOCs #}
+{% set boNOCHtml = bogBeneficialOwnerIndividualNOCs %}
+
 {% if not FEATURE_FLAG_ENABLE_PROPERTY_OR_LAND_OWNER_NOC %}
-  {% set bogBeneficialOwnerNonLegalFirmNOCs %}
-    {% set boNOCNonLegalTypesArray = bog.non_legal_firm_members_nature_of_control_types %}
-    {% include "includes/check-your-answers/nocs/beneficial-owner-member-of-firm-noc.html" %}
-  {% endset %}
+  {# Add non-legal firm NOCs if the feature flag is disabled #}
+  {% set boNOCHtml = boNOCHtml + bogBeneficialOwnerNonLegalFirmNOCs %}
 {% else %}
-  {% set bogBeneficialOwnerTrustControlNOCs %}
-    {% set boNOCTrustControlTypesArray = bog.trust_control_nature_of_control_types %}
-    {% include "includes/check-your-answers/nocs/beneficial-owner-trust-control-noc.html" %}
-  {% endset %}
-
-  {% set bogBeneficialOwnerNonLegalFirmControlNOCs %}
-    {% set boNOCNonLegalFirmControlTypesArray = bog.non_legal_firm_control_nature_of_control_types %}
-    {% include "includes/check-your-answers/nocs/beneficial-owner-member-of-firm-control-noc.html" %}
-  {% endset %}
-
-  {% set bogOwnerOfLandPersonNOCs %}
-    {% set boNOCOwnerOfLandPersonJurisdictionsArray = bog.owner_of_land_person_nature_of_control_jurisdictions %}
-    {% include "includes/check-your-answers/nocs/beneficial-owner-owner-of-land-person-noc.html" %}
-  {% endset %}
-
-  {% set bogOwnerOfLandOtherEntityNOCs %}
-    {% set boNOCOwnerOfLandOtherEntityJurisdictionsArray = bog.owner_of_land_other_entity_nature_of_control_jurisdictions %}
-    {% include "includes/check-your-answers/nocs/beneficial-owner-owner-of-land-other-entity-noc.html" %}
-  {% endset %}
-{% endif %}
-
-{% set boNOCArray = [] %}
-{% if not FEATURE_FLAG_ENABLE_PROPERTY_OR_LAND_OWNER_NOC %}
-  {% set boNOCArray = bogBeneficialOwnerIndividualNOCs + bogBeneficialOwnerNonLegalFirmNOCs %}
-{% else %}
-  {% set boNOCArray = bogBeneficialOwnerIndividualNOCs + bogBeneficialOwnerTrustControlNOCs + bogBeneficialOwnerNonLegalFirmControlNOCs + bogOwnerOfLandPersonNOCs + bogOwnerOfLandOtherEntityNOCs %}
+  {% if inNoChangeJourney %}
+    {# Add non-legal firm NOCs if in no change journey #}
+    {% set boNOCHtml = boNOCHtml + bogBeneficialOwnerNonLegalFirmNOCs %}
+  {% endif %}
+  {# Add control and land owner NOCs if the feature flag is enabled #}
+  {% set boNOCHtml = boNOCHtml + bogBeneficialOwnerTrustControlNOCs + bogBeneficialOwnerNonLegalFirmControlNOCs + bogOwnerOfLandPersonNOCs + bogOwnerOfLandOtherEntityNOCs %}
 {% endif %}
 
 {% set bogIsOnSanctionsListHtml %}
@@ -220,7 +226,7 @@
           text: "Nature of control"
         },
         value: {
-          html: boNOCArray
+          html: boNOCHtml
         },
         actions: {
           items: [CREATE_CHANGE_LINK(

--- a/views/includes/check-your-answers/beneficial-owner-individual.html
+++ b/views/includes/check-your-answers/beneficial-owner-individual.html
@@ -50,38 +50,44 @@
   {% include "includes/check-your-answers/nocs/beneficial-owner-trustee-of-trust-noc.html" %}
 {% endset %}
 
+{% set boiBeneficialOwnerNonLegalFirmNOCs %}
+  {% set boNOCNonLegalTypesArray = boi.non_legal_firm_members_nature_of_control_types %}
+  {% include "includes/check-your-answers/nocs/beneficial-owner-member-of-firm-noc.html" %}
+{% endset %}
+
+{% set boiBeneficialOwnerTrustControlNOCs %}
+  {% set boNOCTrustControlTypesArray = boi.trust_control_nature_of_control_types %}
+  {% include "includes/check-your-answers/nocs/beneficial-owner-trust-control-noc.html" %}
+{% endset %}
+
+{% set boiBeneficialOwnerNonLegalFirmControlNOCs %}
+  {% set boNOCNonLegalFirmControlTypesArray = boi.non_legal_firm_control_nature_of_control_types %}
+  {% include "includes/check-your-answers/nocs/beneficial-owner-member-of-firm-control-noc.html" %}
+{% endset %}
+
+{% set boiOwnerOfLandPersonNOCs %}
+  {% set boNOCOwnerOfLandPersonJurisdictionsArray = boi.owner_of_land_person_nature_of_control_jurisdictions %}
+  {% include "includes/check-your-answers/nocs/beneficial-owner-owner-of-land-person-noc.html" %}
+{% endset %}
+
+{% set boiOwnerOfLandOtherEntityNOCs %}
+  {% set boNOCOwnerOfLandOtherEntityJurisdictionsArray = boi.owner_of_land_other_entity_nature_of_control_jurisdictions %}
+  {% include "includes/check-your-answers/nocs/beneficial-owner-owner-of-land-other-entity-noc.html" %}
+{% endset %}
+
+{# Initialize boNOCHtml with individual and trustee NOCs #}
+{% set boNOCHtml = boiBeneficialOwnerIndividualNOCs + boiBeneficialOwnerTrusteeNOCs %}
+
 {% if not FEATURE_FLAG_ENABLE_PROPERTY_OR_LAND_OWNER_NOC %}
-  {% set boiBeneficialOwnerNonLegalFirmNOCs %}
-    {% set boNOCNonLegalTypesArray = boi.non_legal_firm_members_nature_of_control_types %}
-    {% include "includes/check-your-answers/nocs/beneficial-owner-member-of-firm-noc.html" %}
-  {% endset %}
-{% else %}
-  {% set boiBeneficialOwnerTrustControlNOCs %}
-    {% set boNOCTrustControlTypesArray = boi.trust_control_nature_of_control_types %}
-    {% include "includes/check-your-answers/nocs/beneficial-owner-trust-control-noc.html" %}
-  {% endset %}
-
-  {% set boiBeneficialOwnerNonLegalFirmControlNOCs %}
-    {% set boNOCNonLegalFirmControlTypesArray = boi.non_legal_firm_control_nature_of_control_types %}
-    {% include "includes/check-your-answers/nocs/beneficial-owner-member-of-firm-control-noc.html" %}
-  {% endset %}
-
-  {% set boiOwnerOfLandPersonNOCs %}
-    {% set boNOCOwnerOfLandPersonJurisdictionsArray = boi.owner_of_land_person_nature_of_control_jurisdictions %}
-    {% include "includes/check-your-answers/nocs/beneficial-owner-owner-of-land-person-noc.html" %}
-  {% endset %}
-
-  {% set boiOwnerOfLandOtherEntityNOCs %}
-    {% set boNOCOwnerOfLandOtherEntityJurisdictionsArray = boi.owner_of_land_other_entity_nature_of_control_jurisdictions %}
-    {% include "includes/check-your-answers/nocs/beneficial-owner-owner-of-land-other-entity-noc.html" %}
-  {% endset %}
-{% endif %}
-
-{% set boNOCArray = [] %}
-{% if not FEATURE_FLAG_ENABLE_PROPERTY_OR_LAND_OWNER_NOC %}
-  {% set boNOCArray = boiBeneficialOwnerIndividualNOCs + boiBeneficialOwnerTrusteeNOCs + boiBeneficialOwnerNonLegalFirmNOCs %}
-{% else %}
-  {% set boNOCArray = boiBeneficialOwnerIndividualNOCs + boiBeneficialOwnerTrusteeNOCs + boiBeneficialOwnerTrustControlNOCs + boiBeneficialOwnerNonLegalFirmControlNOCs + boiOwnerOfLandPersonNOCs + boiOwnerOfLandOtherEntityNOCs %}
+  {# Add non-legal firm NOCs if the feature flag is disabled #}
+  {% set boNOCHtml = boNOCHtml + boiBeneficialOwnerNonLegalFirmNOCs %}
+{% else %} 
+  {% if inNoChangeJourney %}
+    {# Add non-legal firm NOCs if in no change journey #}
+    {% set boNOCHtml = boNOCHtml + boiBeneficialOwnerNonLegalFirmNOCs %}
+  {% endif %}
+  {# Add control and land owner NOCs if the feature flag is enabled #}
+  {% set boNOCHtml = boNOCHtml + boiBeneficialOwnerTrustControlNOCs + boiBeneficialOwnerNonLegalFirmControlNOCs + boiOwnerOfLandPersonNOCs + boiOwnerOfLandOtherEntityNOCs %}
 {% endif %}
 
 {% set boiIsOnSanctionsListHtml %}
@@ -240,7 +246,7 @@
     text: "Nature of control"
   },
   value: {
-    html: boNOCArray
+    html: boNOCHtml
   },
   actions: {
     items: [CREATE_CHANGE_LINK(

--- a/views/includes/check-your-answers/beneficial-owner-other.html
+++ b/views/includes/check-your-answers/beneficial-owner-other.html
@@ -46,38 +46,44 @@
   {% include "includes/check-your-answers/nocs/beneficial-owner-trustee-of-trust-noc.html" %}
 {% endset %}
 
+{% set bocBeneficialOwnerNonLegalFirmNOCs %}
+  {% set boNOCNonLegalTypesArray = boc.non_legal_firm_members_nature_of_control_types %}
+  {% include "includes/check-your-answers/nocs/beneficial-owner-member-of-firm-noc.html" %}
+{% endset %}
+
+{% set bocBeneficialOwnerTrustControlNOCs %}
+  {% set boNOCTrustControlTypesArray = boc.trust_control_nature_of_control_types %}
+  {% include "includes/check-your-answers/nocs/beneficial-owner-trust-control-noc.html" %}
+{% endset %}
+
+{% set bocBeneficialOwnerNonLegalFirmControlNOCs %}
+  {% set boNOCNonLegalFirmControlTypesArray = boc.non_legal_firm_control_nature_of_control_types %}
+  {% include "includes/check-your-answers/nocs/beneficial-owner-member-of-firm-control-noc.html" %}
+{% endset %}
+
+{% set bocOwnerOfLandPersonNOCs %}
+  {% set boNOCOwnerOfLandPersonJurisdictionsArray = boc.owner_of_land_person_nature_of_control_jurisdictions %}
+  {% include "includes/check-your-answers/nocs/beneficial-owner-owner-of-land-person-noc.html" %}
+{% endset %}
+
+{% set bocOwnerOfLandOtherEntityNOCs %}
+  {% set boNOCOwnerOfLandOtherEntityJurisdictionsArray = boc.owner_of_land_other_entity_nature_of_control_jurisdictions %}
+  {% include "includes/check-your-answers/nocs/beneficial-owner-owner-of-land-other-entity-noc.html" %}
+{% endset %}
+
+{# Initialize boNOCHtml with individual and trustee NOCs #}
+{% set boNOCHtml = bocBeneficialOwnerIndividualNOCs + bocBeneficialOwnerTrusteeNOCs %}
+
 {% if not FEATURE_FLAG_ENABLE_PROPERTY_OR_LAND_OWNER_NOC %}
-  {% set bocBeneficialOwnerNonLegalFirmNOCs %}
-    {% set boNOCNonLegalTypesArray = boc.non_legal_firm_members_nature_of_control_types %}
-    {% include "includes/check-your-answers/nocs/beneficial-owner-member-of-firm-noc.html" %}
-  {% endset %}
+  {# Add non-legal firm NOCs if the feature flag is disabled #}
+  {% set boNOCHtml = boNOCHtml + bocBeneficialOwnerNonLegalFirmNOCs %}
 {% else %}
-  {% set bocBeneficialOwnerTrustControlNOCs %}
-    {% set boNOCTrustControlTypesArray = boc.trust_control_nature_of_control_types %}
-    {% include "includes/check-your-answers/nocs/beneficial-owner-trust-control-noc.html" %}
-  {% endset %}
-
-  {% set bocBeneficialOwnerNonLegalFirmControlNOCs %}
-    {% set boNOCNonLegalFirmControlTypesArray = boc.non_legal_firm_control_nature_of_control_types %}
-    {% include "includes/check-your-answers/nocs/beneficial-owner-member-of-firm-control-noc.html" %}
-  {% endset %}
-
-  {% set bocOwnerOfLandPersonNOCs %}
-    {% set boNOCOwnerOfLandPersonJurisdictionsArray = boc.owner_of_land_person_nature_of_control_jurisdictions %}
-    {% include "includes/check-your-answers/nocs/beneficial-owner-owner-of-land-person-noc.html" %}
-  {% endset %}
-
-  {% set bocOwnerOfLandOtherEntityNOCs %}
-    {% set boNOCOwnerOfLandOtherEntityJurisdictionsArray = boc.owner_of_land_other_entity_nature_of_control_jurisdictions %}
-    {% include "includes/check-your-answers/nocs/beneficial-owner-owner-of-land-other-entity-noc.html" %}
-  {% endset %}
-{% endif %}
-
-{% set boNOCArray = [] %}
-{% if not FEATURE_FLAG_ENABLE_PROPERTY_OR_LAND_OWNER_NOC %}
-  {% set boNOCArray = bocBeneficialOwnerIndividualNOCs + bocBeneficialOwnerTrusteeNOCs + bocBeneficialOwnerNonLegalFirmNOCs %}
-{% else %}
-  {% set boNOCArray = bocBeneficialOwnerIndividualNOCs + bocBeneficialOwnerTrusteeNOCs + bocBeneficialOwnerTrustControlNOCs + bocBeneficialOwnerNonLegalFirmControlNOCs + bocOwnerOfLandPersonNOCs + bocOwnerOfLandOtherEntityNOCs %}
+  {% if inNoChangeJourney %}
+    {# Add non-legal firm NOCs if in no change journey #}
+    {% set boNOCHtml = boNOCHtml + bocBeneficialOwnerNonLegalFirmNOCs %}
+  {% endif %}
+  {# Add control and land owner NOCs if the feature flag is enabled #}
+  {% set boNOCHtml = boNOCHtml + bocBeneficialOwnerTrustControlNOCs + bocBeneficialOwnerNonLegalFirmControlNOCs + bocOwnerOfLandPersonNOCs + bocOwnerOfLandOtherEntityNOCs %}
 {% endif %}
 
 {% set bocIsOnSanctionsListHtml %}
@@ -249,7 +255,7 @@
           text: "Nature of control"
         },
         value: {
-          html: boNOCArray
+          html: boNOCHtml
         },
         actions: {
           items: [CREATE_CHANGE_LINK(


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/UAR-1587


### Change description
Update the 'Review' page to include the new NOCs for a no change update/remove journey.

- Agreed with Vernon - If feature flag is active then we still want to show the invalid NOC (member of a firm) as the user will not have a chance to remove it during no-change and they should be aware of the current state of their data before submitting.


### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
