### PR TITLE
Fix sonar test coverage by producing coverage file before sonar runs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ lint:
 	npm run lint
 
 .PHONY: sonar
-sonar:
+sonar: test-unit
 	npm run sonarqube
 
 .PHONY: test-unit


### PR DESCRIPTION
### JIRA link
NA


### Change description
Sonar pipeline job cannot find the coverage report file (lcov.info). The pipeline task calls 'sonar' target in the makefile, but the coverage report needs to run first. This PR changes the sonar target to depend on the 'test-unit' target that will produce the coverage report. (as per confirmation-statement-web which has coverage working)


### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
