### PR TITLE
Feature/uar 1635 save resume deselect nocs

### DIFF
--- a/src/controllers/beneficial.owner.type.controller.ts
+++ b/src/controllers/beneficial.owner.type.controller.ts
@@ -12,35 +12,19 @@ import {
 } from "../model/beneficial.owner.type.model";
 import { isActiveFeature } from '../utils/feature.flag';
 import { getUrlWithParamsToPath } from "../utils/url";
+import { beneficialOwnersTypeEmptyNOCList } from "../validation/async";
+import { FormattedValidationErrors, formatValidationError, } from "../middleware/validation.middleware";
+import { ValidationError } from "express-validator";
+import { BeneficialOwnerIndividualKey } from "../model/beneficial.owner.individual.model";
+import { BeneficialOwnerOtherKey } from "../model/beneficial.owner.other.model";
+import { BeneficialOwnerGovKey } from "../model/beneficial.owner.gov.model";
+import { NonLegalFirmNoc } from "../model/data.types.model";
 
 export const get = async (req: Request, res: Response, next: NextFunction) => {
   try {
     logger.debugRequest(req, `${req.method} ${req.route.path}`);
 
-    const appData: ApplicationData = await getApplicationData(req.session);
-    const requiresTrusts: boolean = checkEntityRequiresTrusts(appData);
-
-    logger.infoRequest(req, `${config.BENEFICIAL_OWNER_TYPE_PAGE} requiresTrusts=${requiresTrusts}`);
-
-    if (isActiveFeature(config.FEATURE_FLAG_ENABLE_REDIS_REMOVAL)) {
-      return res.render(config.BENEFICIAL_OWNER_TYPE_PAGE, {
-        // Even though the value of this feature flag is available in the template via the OE_CONFIGS variable, passing it in
-        // like this enables unit tests to assert different outcomes, based on whether it is set or not
-        FEATURE_FLAG_ENABLE_REDIS_REMOVAL: true,
-        activeSubmissionBasePath: getUrlWithParamsToPath(config.ACTIVE_SUBMISSION_BASE_PATH, req),
-        backLinkUrl: getUrlWithParamsToPath(config.BENEFICIAL_OWNER_STATEMENTS_WITH_PARAMS_URL, req),
-        templateName: config.BENEFICIAL_OWNER_TYPE_PAGE,
-        requiresTrusts,
-        ...appData,
-      });
-    }
-
-    return res.render(config.BENEFICIAL_OWNER_TYPE_PAGE, {
-      backLinkUrl: config.BENEFICIAL_OWNER_STATEMENTS_URL,
-      templateName: config.BENEFICIAL_OWNER_TYPE_PAGE,
-      requiresTrusts,
-      ...appData,
-    });
+    return await getPageRender(req, res);
   } catch (error) {
     logger.errorRequest(req, error);
     next(error);
@@ -57,14 +41,30 @@ export const postSubmit = async (req: Request, res: Response) => {
   const appData: ApplicationData = await getApplicationData(req.session);
   const requiresTrusts: boolean = checkEntityRequiresTrusts(appData);
   let nextPageUrl = config.CHECK_YOUR_ANSWERS_URL;
+
+  const errors = await getValidationErrors(appData, req);
+
+  if (errors.length) {
+    return await getPageRender(req, res, formatValidationError(errors));
+  }
+
   if (isActiveFeature(config.FEATURE_FLAG_ENABLE_REDIS_REMOVAL)) {
     nextPageUrl = getUrlWithParamsToPath(config.CHECK_YOUR_ANSWERS_WITH_PARAMS_URL, req);
   }
+
   if (requiresTrusts) {
     nextPageUrl = isActiveFeature(config.FEATURE_FLAG_ENABLE_TRUSTS_WEB)
       ? getTrustLandingUrl(appData, req)
       : config.TRUST_INFO_URL;
   }
+
+  if (isActiveFeature(config.FEATURE_FLAG_ENABLE_PROPERTY_OR_LAND_OWNER_NOC)) {
+    console.debug("Removing old NOCs");
+    appData?.[BeneficialOwnerIndividualKey]?.forEach(boi => { delete boi[NonLegalFirmNoc]; });
+    appData?.[BeneficialOwnerOtherKey]?.forEach(boo => { delete boo[NonLegalFirmNoc]; });
+    appData?.[BeneficialOwnerGovKey]?.forEach(bog => { delete bog[NonLegalFirmNoc]; });
+  }
+
   return res.redirect(nextPageUrl);
 };
 
@@ -95,4 +95,40 @@ const getNextPage = (req: Request): string => {
     }
     return config.MANAGING_OFFICER_URL;
   }
+};
+
+// Get validation errors that depend on an asynchronous request
+const getValidationErrors = async (appData: ApplicationData, req: Request): Promise<ValidationError[]> => {
+  const beneficialOwnersTypeEmptyNOCListErrors = await beneficialOwnersTypeEmptyNOCList(req, appData);
+
+  return [...beneficialOwnersTypeEmptyNOCListErrors];
+};
+
+const getPageRender = async (req: Request, res: Response, errors?: FormattedValidationErrors) => {
+  const appData: ApplicationData = await getApplicationData(req.session);
+  const requiresTrusts: boolean = checkEntityRequiresTrusts(appData);
+
+  logger.infoRequest(req, `${config.BENEFICIAL_OWNER_TYPE_PAGE} requiresTrusts=${requiresTrusts}`);
+
+  if (isActiveFeature(config.FEATURE_FLAG_ENABLE_REDIS_REMOVAL)) {
+    return res.render(config.BENEFICIAL_OWNER_TYPE_PAGE, {
+      // Even though the value of this feature flag is available in the template via the OE_CONFIGS variable, passing it in
+      // like this enables unit tests to assert different outcomes, based on whether it is set or not
+      FEATURE_FLAG_ENABLE_REDIS_REMOVAL: true,
+      activeSubmissionBasePath: getUrlWithParamsToPath(config.ACTIVE_SUBMISSION_BASE_PATH, req),
+      backLinkUrl: getUrlWithParamsToPath(config.BENEFICIAL_OWNER_STATEMENTS_WITH_PARAMS_URL, req),
+      templateName: config.BENEFICIAL_OWNER_TYPE_PAGE,
+      requiresTrusts,
+      ...appData,
+      errors,
+    });
+  }
+
+  return res.render(config.BENEFICIAL_OWNER_TYPE_PAGE, {
+    backLinkUrl: config.BENEFICIAL_OWNER_STATEMENTS_URL,
+    templateName: config.BENEFICIAL_OWNER_TYPE_PAGE,
+    requiresTrusts,
+    ...appData,
+    errors,
+  });
 };

--- a/src/controllers/shared/common.resume.submission.controller.ts
+++ b/src/controllers/shared/common.resume.submission.controller.ts
@@ -13,7 +13,6 @@ import { getOverseasEntity } from "../../service/overseas.entities.service";
 import {
   HasSoldLandKey,
   ID,
-  NonLegalFirmNoc,
   IsSecureRegisterKey,
   OverseasEntityKey,
   Transactionkey
@@ -109,13 +108,6 @@ const setWebApplicationData = (session: Session, appData: ApplicationData, trans
   }
   if (isActiveFeature(config.FEATURE_FLAG_ENABLE_TRUSTS_WEB)) {
     mapTrustApiReturnModelToWebModel(appData);
-  }
-
-  if (isActiveFeature(config.FEATURE_FLAG_ENABLE_PROPERTY_OR_LAND_OWNER_NOC) && (!appData.entity_number)) {
-    console.debug("Removing old NOCs");
-    appData[BeneficialOwnerIndividualKey].forEach(boi => { delete boi[NonLegalFirmNoc]; });
-    appData[BeneficialOwnerOtherKey].forEach(boo => { delete boo[NonLegalFirmNoc]; });
-    appData[BeneficialOwnerGovKey].forEach(bog => { delete bog[NonLegalFirmNoc]; });
   }
 
   setExtraData(session, appData);

--- a/src/controllers/update/beneficial.owner.type.controller.ts
+++ b/src/controllers/update/beneficial.owner.type.controller.ts
@@ -23,6 +23,10 @@ import { saveAndContinue } from "../../utils/save.and.continue";
 import { Session } from "@companieshouse/node-session-handler";
 import { validationResult } from "express-validator/src/validation-result";
 import { FormattedValidationErrors, formatValidationError } from "../../middleware/validation.middleware";
+import { isActiveFeature } from "../../utils/feature.flag";
+import { NonLegalFirmNoc } from "../../model/data.types.model";
+import { beneficialOwnersTypeEmptyNOCList } from "../../validation/async";
+import { ValidationError } from "express-validator";
 
 type BeneficialOwnerTypePageProperties = {
   backLinkUrl: string;
@@ -62,21 +66,8 @@ const getPageProperties = async (
 export const get = async (req: Request, res: Response, next: NextFunction) => {
   try {
     logger.debugRequest(req, `${req.method} ${req.route.path}`);
-    const appData: ApplicationData = await getApplicationData(req.session);
 
-    const checkIsRedirect = checkAndReviewBeneficialOwner(appData);
-    if (checkIsRedirect && checkIsRedirect !== "") {
-      return res.redirect(checkIsRedirect);
-    }
-
-    const checkMoRedirect = checkAndReviewManagingOfficers(appData);
-    if (checkMoRedirect){
-      return res.redirect(checkMoRedirect);
-    }
-
-    const pageProps = await getPageProperties(req);
-
-    return res.render(pageProps.templateName, pageProps);
+    return await getPageRender(req, res);
   } catch (error) {
     logger.errorRequest(req, error);
     next(error);
@@ -103,6 +94,12 @@ export const postSubmit = async (req: Request, res: Response, next: NextFunction
 
     const appData: ApplicationData = await getApplicationData(req.session);
 
+    const errors = await getValidationErrors(appData, req);
+
+    if (errors.length) {
+      return await getPageRender(req, res, formatValidationError(errors));
+    }
+
     if (!appData.update?.trust_data_fetched) {
       const session = req.session as Session;
       await retrieveTrustData(req, appData);
@@ -115,6 +112,13 @@ export const postSubmit = async (req: Request, res: Response, next: NextFunction
     // If no trusts have been reviewed yet then no trusts should get moved by this
     moveReviewableTrustsIntoReview(appData);
     resetReviewStatusOnAllTrustsToBeReviewed(appData);
+
+    if (isActiveFeature(config.FEATURE_FLAG_ENABLE_PROPERTY_OR_LAND_OWNER_NOC)) {
+      console.debug("Removing old NOCs");
+      appData?.[BeneficialOwnerIndividualKey]?.forEach(boi => { delete boi[NonLegalFirmNoc]; });
+      appData?.[BeneficialOwnerOtherKey]?.forEach(boo => { delete boo[NonLegalFirmNoc]; });
+      appData?.[BeneficialOwnerGovKey]?.forEach(bog => { delete bog[NonLegalFirmNoc]; });
+    }
 
     if (hasTrustsToReview(appData)) {
       return res.redirect(config.UPDATE_MANAGE_TRUSTS_INTERRUPT_URL);
@@ -151,4 +155,29 @@ const getNextPage = (beneficialOwnerTypeChoices: BeneficialOwnerTypeChoice | Man
       default:
         return config.UPDATE_BENEFICIAL_OWNER_INDIVIDUAL_URL;
   }
+};
+
+// Get validation errors that depend on an asynchronous request
+const getValidationErrors = async (appData: ApplicationData, req: Request): Promise<ValidationError[]> => {
+  const beneficialOwnersTypeEmptyNOCListErrors = await beneficialOwnersTypeEmptyNOCList(req, appData);
+
+  return [...beneficialOwnersTypeEmptyNOCListErrors];
+};
+
+const getPageRender = async (req: Request, res: Response, errors?: FormattedValidationErrors) => {
+  const appData: ApplicationData = await getApplicationData(req.session);
+
+  const checkIsRedirect = checkAndReviewBeneficialOwner(appData);
+  if (checkIsRedirect && checkIsRedirect !== "") {
+    return res.redirect(checkIsRedirect);
+  }
+
+  const checkMoRedirect = checkAndReviewManagingOfficers(appData);
+  if (checkMoRedirect){
+    return res.redirect(checkMoRedirect);
+  }
+
+  const pageProps = await getPageProperties(req, errors);
+
+  return res.render(pageProps.templateName, pageProps);
 };

--- a/src/validation/async/index.ts
+++ b/src/validation/async/index.ts
@@ -158,6 +158,7 @@ export const filingPeriodTrustCeaseDateValidations = async (req: Request) => is_
 export const beneficialOwnersTypeEmptyNOCList = async (req: Request, appData: ApplicationData): Promise<ValidationError[]> => {
   const allowedUrls = [
     [config.REGISTER_AN_OVERSEAS_ENTITY_URL, config.BENEFICIAL_OWNER_TYPE_PAGE],
+    [config.UPDATE_AN_OVERSEAS_ENTITY_URL, config.UPDATE_BENEFICIAL_OWNER_TYPE_PAGE]
   ];
 
   const allowed: boolean = isAllowedUrls(allowedUrls, req);
@@ -203,6 +204,6 @@ const checkIfBeneficialOwnerHasNOC = (beneficialOwner): string[] => {
       !bo?.trust_control_nature_of_control_types?.length &&
       !bo?.owner_of_land_person_nature_of_control_jurisdictions?.length &&
       !bo?.owner_of_land_other_entity_nature_of_control_jurisdictions?.length
-  ).map(bo => `${bo.first_name} ${bo.last_name}`);
+  ).map(bo => bo?.first_name ?? bo?.name);
 };
 

--- a/test/controllers/resume.submission.controller.spec.ts
+++ b/test/controllers/resume.submission.controller.spec.ts
@@ -26,9 +26,6 @@ import {
 } from '../__mocks__/text.mock';
 import {
   APPLICATION_DATA_MOCK,
-  BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK,
-  BENEFICIAL_OWNER_OTHER_OBJECT_MOCK,
-  BENEFICIAL_OWNER_GOV_OBJECT_MOCK,
   RESUME_SUBMISSION_URL,
   OVERSEAS_ENTITY_ID,
   TRANSACTION_ID,
@@ -46,13 +43,12 @@ import { startPaymentsSession } from "../../src/service/payment.service";
 import { isActiveFeature } from "../../src/utils/feature.flag";
 import { WhoIsRegisteringKey, WhoIsRegisteringType } from '../../src/model/who.is.making.filing.model';
 import { DueDiligenceKey } from '../../src/model/due.diligence.model';
-import { EntityNumberKey, HasSoldLandKey, IsSecureRegisterKey, NatureOfControlType, OverseasEntityKey, Transactionkey } from '../../src/model/data.types.model';
+import { HasSoldLandKey, IsSecureRegisterKey, OverseasEntityKey, Transactionkey } from '../../src/model/data.types.model';
 import { OverseasEntityDueDiligenceKey } from '../../src/model/overseas.entity.due.diligence.model';
 import { OVERSEAS_ENTITY_DUE_DILIGENCE_OBJECT_MOCK } from '../__mocks__/overseas.entity.due.diligence.mock';
 import { MOCK_GET_TRANSACTION_RESPONSE } from '../__mocks__/transaction.mock';
 import { mapTrustApiReturnModelToWebModel } from '../../src/utils/trusts';
 import { getUrlWithTransactionIdAndSubmissionId } from "../../src/utils/url";
-import { beneficialOwnerIndividualType, beneficialOwnerOtherType, beneficialOwnerGovType } from "../../src/model";
 
 const mockServiceAvailabilityMiddleware = serviceAvailabilityMiddleware as jest.Mock;
 mockServiceAvailabilityMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => next() );
@@ -81,23 +77,6 @@ const mockMapTrustApiReturnModelToWebModel = mapTrustApiReturnModelToWebModel as
 const mockGetUrlWithTransactionIdAndSubmissionId = getUrlWithTransactionIdAndSubmissionId as jest.Mock;
 
 const baseURL = `${config.CHS_URL}${config.REGISTER_AN_OVERSEAS_ENTITY_URL}`;
-
-const mockNocAppData = {
-  ...APPLICATION_DATA_MOCK,
-  [beneficialOwnerIndividualType.BeneficialOwnerIndividualKey]: [{
-    ...BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK,
-    non_legal_firm_members_nature_of_control_types: [NatureOfControlType.APPOINT_OR_REMOVE_MAJORITY_BOARD_DIRECTORS, NatureOfControlType.OVER_25_PERCENT_OF_SHARES]
-  }, BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK ],
-  [beneficialOwnerOtherType.BeneficialOwnerOtherKey]: [{
-    ...BENEFICIAL_OWNER_OTHER_OBJECT_MOCK,
-    non_legal_firm_members_nature_of_control_types: [NatureOfControlType.OVER_25_PERCENT_OF_VOTING_RIGHTS, NatureOfControlType.OVER_25_PERCENT_OF_SHARES]
-  }, BENEFICIAL_OWNER_OTHER_OBJECT_MOCK ],
-  [beneficialOwnerGovType.BeneficialOwnerGovKey]: [{
-    ...BENEFICIAL_OWNER_GOV_OBJECT_MOCK,
-    non_legal_firm_members_nature_of_control_types: [NatureOfControlType.SIGNIFICANT_INFLUENCE_OR_CONTROL, NatureOfControlType.OVER_25_PERCENT_OF_SHARES]
-  }, BENEFICIAL_OWNER_GOV_OBJECT_MOCK ],
-  [EntityNumberKey]: null
-};
 
 describe("Resume submission controller", () => {
 
@@ -211,7 +190,7 @@ describe("Resume submission controller", () => {
     expect(mockSetExtraData).toHaveBeenCalledTimes(1);
     expect(mockCreateAndLogErrorRequest).not.toHaveBeenCalled();
     expect(mockMapTrustApiReturnModelToWebModel).toHaveBeenCalledTimes(1);
-    expect(mockIsActiveFeature).toHaveBeenCalledTimes(3);
+    expect(mockIsActiveFeature).toHaveBeenCalledTimes(2);
     expect(mockGetUrlWithTransactionIdAndSubmissionId).not.toHaveBeenCalled();
   });
 
@@ -243,7 +222,7 @@ describe("Resume submission controller", () => {
     expect(mockSetExtraData).toHaveBeenCalledTimes(1);
     expect(mockCreateAndLogErrorRequest).not.toHaveBeenCalled();
     expect(mockMapTrustApiReturnModelToWebModel).toHaveBeenCalledTimes(1);
-    expect(mockIsActiveFeature).toHaveBeenCalledTimes(3);
+    expect(mockIsActiveFeature).toHaveBeenCalledTimes(2);
     expect(mockGetUrlWithTransactionIdAndSubmissionId).toHaveBeenCalledTimes(1);
   });
 
@@ -268,45 +247,5 @@ describe("Resume submission controller", () => {
 
     expect(resp.status).toEqual(500);
     expect(resp.text).toContain(SERVICE_UNAVAILABLE);
-  });
-
-  test(`Remove old NOCs after resuming the OverseasEntity Registration submission and FEATURE_FLAG_ENABLE_PROPERTY_OR_LAND_OWNER_NOC is ON`, async () => {
-    mockIsActiveFeature.mockReturnValueOnce( true ); // REDIS flag
-    mockIsActiveFeature.mockReturnValueOnce( true ); // trusts feature flag
-    mockIsActiveFeature.mockReturnValueOnce( true ); // new NOCs
-
-    const mockAppData = { ...mockNocAppData };
-    mockGetOverseasEntity.mockReturnValueOnce( mockAppData );
-    const resp = await request(app).get(RESUME_SUBMISSION_URL);
-
-    expect(resp.status).toEqual(302);
-    expect(mockAppData.beneficial_owners_individual?.[0].non_legal_firm_members_nature_of_control_types).toEqual(undefined);
-    expect(mockAppData.beneficial_owners_individual?.[1].non_legal_firm_members_nature_of_control_types).toEqual(undefined);
-    expect(mockAppData.beneficial_owners_government_or_public_authority?.[0].non_legal_firm_members_nature_of_control_types).toEqual(undefined);
-    expect(mockAppData.beneficial_owners_corporate?.[0].non_legal_firm_members_nature_of_control_types).toEqual(undefined);
-  });
-
-  test(`Do not remove old NOCs after resuming the OverseasEntity Registration submission and FEATURE_FLAG_ENABLE_PROPERTY_OR_LAND_OWNER_NOC is OFF`, async () => {
-    mockIsActiveFeature.mockReturnValueOnce( true ); // REDIS flag
-    mockIsActiveFeature.mockReturnValueOnce( true ); // trusts feature flag
-    mockIsActiveFeature.mockReturnValueOnce( false ); // new NOCs
-
-    const mockAppData = { ...mockNocAppData };
-    mockGetOverseasEntity.mockReturnValueOnce( mockAppData );
-    const resp = await request(app).get(RESUME_SUBMISSION_URL);
-
-    expect(resp.status).toEqual(302);
-    expect(mockAppData.beneficial_owners_individual?.[0].non_legal_firm_members_nature_of_control_types).toEqual(
-      [NatureOfControlType.APPOINT_OR_REMOVE_MAJORITY_BOARD_DIRECTORS, NatureOfControlType.OVER_25_PERCENT_OF_SHARES]);
-    expect(mockAppData.beneficial_owners_individual?.[1].non_legal_firm_members_nature_of_control_types).toEqual(
-      [NatureOfControlType.APPOINT_OR_REMOVE_MAJORITY_BOARD_DIRECTORS]);
-    expect(mockAppData.beneficial_owners_government_or_public_authority?.[0].non_legal_firm_members_nature_of_control_types).toEqual(
-      [NatureOfControlType.SIGNIFICANT_INFLUENCE_OR_CONTROL, NatureOfControlType.OVER_25_PERCENT_OF_SHARES]);
-    expect(mockAppData.beneficial_owners_government_or_public_authority?.[1].non_legal_firm_members_nature_of_control_types).toEqual(
-      [NatureOfControlType.OVER_25_PERCENT_OF_SHARES]);
-    expect(mockNocAppData.beneficial_owners_corporate?.[0].non_legal_firm_members_nature_of_control_types).toEqual(
-      [NatureOfControlType.OVER_25_PERCENT_OF_VOTING_RIGHTS, NatureOfControlType.OVER_25_PERCENT_OF_SHARES]);
-    expect(mockAppData.beneficial_owners_corporate?.[1].non_legal_firm_members_nature_of_control_types).toEqual(
-      [NatureOfControlType.OVER_25_PERCENT_OF_SHARES]);
   });
 });

--- a/test/controllers/update/update.beneficial.owner.type.controller.spec.ts
+++ b/test/controllers/update/update.beneficial.owner.type.controller.spec.ts
@@ -75,6 +75,8 @@ import { retrieveTrustData } from "../../../src/utils/update/trust.model.fetch";
 import { saveAndContinue } from "../../../src/utils/save.and.continue";
 import { BeneficialOwnerTypeChoice, BeneficialOwnerTypeKey } from "../../../src/model/beneficial.owner.type.model";
 import { RELEVANT_PERIOD_QUERY_PARAM } from "../../../src/config";
+import { beneficialOwnerIndividualType } from "../../../src/model";
+import { NatureOfControlType } from "../../../src/model/data.types.model";
 
 mockJourneyDetectionMiddleware.mockClear();
 mockCsrfProtectionMiddleware.mockClear();
@@ -261,6 +263,62 @@ describe("BENEFICIAL OWNER TYPE controller", () => {
 
       expect(resp.status).toEqual(302);
       expect(resp.header.location).toContain(config.UPDATE_MANAGE_TRUSTS_INTERRUPT_URL);
+    });
+
+    test('redirects to manage trusts interrupt and remove old NOCs after submission and FEATURE_FLAG_ENABLE_PROPERTY_OR_LAND_OWNER_NOC is ON', async () => {
+      mockIsActiveFeature.mockReturnValueOnce(true);
+      mockRetrieveTrustData.mockReturnValueOnce(Promise.resolve());
+      mockSaveAndContinue.mockReturnValueOnce(Promise.resolve());
+      mockSetExtraData.mockReturnValueOnce(null);
+      const mockAppData = {
+        ...APPLICATION_DATA_UPDATE_NO_BO_OR_MO_TO_REVIEW,
+        [beneficialOwnerIndividualType.BeneficialOwnerIndividualKey]: [{
+          ...BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK,
+          non_legal_firm_members_nature_of_control_types: [NatureOfControlType.APPOINT_OR_REMOVE_MAJORITY_BOARD_DIRECTORS, NatureOfControlType.OVER_25_PERCENT_OF_SHARES]
+        }, BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK ]
+      };
+      mockGetApplicationData.mockReturnValue(mockAppData);
+
+      mockHasTrustsToReview.mockReturnValueOnce(true);
+
+      const resp = await request(app).post(config.UPDATE_BENEFICIAL_OWNER_TYPE_SUBMIT_URL);
+
+      expect(mockRetrieveTrustData).toHaveBeenCalled();
+      expect(mockHasTrustsToReview).toHaveBeenCalled();
+      expect(mockSaveAndContinue).toHaveBeenCalled();
+
+      expect(resp.status).toEqual(302);
+      expect(resp.header.location).toContain(config.UPDATE_MANAGE_TRUSTS_INTERRUPT_URL);
+      expect(mockAppData.beneficial_owners_individual?.[0].non_legal_firm_members_nature_of_control_types).toEqual(undefined);
+      expect(mockAppData.beneficial_owners_individual?.[1].non_legal_firm_members_nature_of_control_types).toEqual(undefined);
+    });
+
+    test('redirects to manage trusts interrupt and not remove old NOCs after submission and FEATURE_FLAG_ENABLE_PROPERTY_OR_LAND_OWNER_NOC is OFF', async () => {
+      mockIsActiveFeature.mockReturnValueOnce(false);
+      mockRetrieveTrustData.mockReturnValueOnce(Promise.resolve());
+      mockSaveAndContinue.mockReturnValueOnce(Promise.resolve());
+      mockSetExtraData.mockReturnValueOnce(null);
+      const mockAppData = {
+        ...APPLICATION_DATA_UPDATE_NO_BO_OR_MO_TO_REVIEW,
+        [beneficialOwnerIndividualType.BeneficialOwnerIndividualKey]: [{
+          ...BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK,
+          non_legal_firm_members_nature_of_control_types: [NatureOfControlType.APPOINT_OR_REMOVE_MAJORITY_BOARD_DIRECTORS, NatureOfControlType.OVER_25_PERCENT_OF_SHARES]
+        }, BENEFICIAL_OWNER_INDIVIDUAL_OBJECT_MOCK ]
+      };
+      mockGetApplicationData.mockReturnValue(mockAppData);
+
+      mockHasTrustsToReview.mockReturnValueOnce(true);
+
+      const resp = await request(app).post(config.UPDATE_BENEFICIAL_OWNER_TYPE_SUBMIT_URL);
+
+      expect(mockRetrieveTrustData).toHaveBeenCalled();
+      expect(mockHasTrustsToReview).toHaveBeenCalled();
+      expect(mockSaveAndContinue).toHaveBeenCalled();
+
+      expect(resp.status).toEqual(302);
+      expect(resp.header.location).toContain(config.UPDATE_MANAGE_TRUSTS_INTERRUPT_URL);
+      expect(mockAppData.beneficial_owners_individual?.[0].non_legal_firm_members_nature_of_control_types).toEqual(
+        [NatureOfControlType.APPOINT_OR_REMOVE_MAJORITY_BOARD_DIRECTORS, NatureOfControlType.OVER_25_PERCENT_OF_SHARES]);
     });
 
     test('redirects to manage trusts interrupt if update in app data', async () => {


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/UAR-1635

### Change description
Save and Resume: Deselect invalid NOCs when returning to web journey after new NOCs are implemented.
Add error message if nature of control is an empty list

### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
