### PR TITLE
Feat/ROE-2639: Retrieve application data from DB for the `due-diligence` page

### DIFF
--- a/src/controllers/due.diligence.controller.ts
+++ b/src/controllers/due.diligence.controller.ts
@@ -1,4 +1,7 @@
 import { NextFunction, Request, Response } from "express";
+import { getDueDiligencePage, postDueDiligencePage } from "../utils/due.diligence";
+import { isActiveFeature } from "../utils/feature.flag";
+import { getUrlWithParamsToPath } from "../utils/url";
 
 import {
   DUE_DILIGENCE_PAGE,
@@ -8,10 +11,6 @@ import {
   ENTITY_WITH_PARAMS_URL,
   WHO_IS_MAKING_FILING_WITH_PARAMS_URL
 } from "../config";
-
-import { getDueDiligencePage, postDueDiligencePage } from "../utils/due.diligence";
-import { isActiveFeature } from "../utils/feature.flag";
-import { getUrlWithParamsToPath } from "../utils/url";
 
 export const get = async (req: Request, res: Response, next: NextFunction) => {
   let backLinkUrl: string = WHO_IS_MAKING_FILING_URL;

--- a/src/utils/due.diligence.ts
+++ b/src/utils/due.diligence.ts
@@ -1,27 +1,40 @@
 import { NextFunction, Request, Response } from "express";
 import { Session } from "@companieshouse/node-session-handler";
-
 import { ApplicationData } from "../model";
 import { logger } from "../utils/logger";
+import { isRegistrationJourney } from "./url";
+import { saveAndContinue } from "../utils/save.and.continue";
+import { isActiveFeature } from "./feature.flag";
+import * as config from "../config";
+
+import { DueDiligenceKey, DueDiligenceKeys } from "../model/due.diligence.model";
+import { IdentityDateKey, IdentityDateKeys } from "../model/date.model";
+import { IdentityAddressKey, IdentityAddressKeys } from "../model/address.model";
+import { AddressKeys, InputDateKeys } from "../model/data.types.model";
+import { OverseasEntityDueDiligenceKey } from "../model/overseas.entity.due.diligence.model";
+
 import {
-  getApplicationData,
+  fetchApplicationData,
   setApplicationData,
   prepareData,
   mapDataObjectToFields,
   mapFieldsToDataObject,
 } from "../utils/application.data";
-import { DueDiligenceKey, DueDiligenceKeys } from "../model/due.diligence.model";
-import { OverseasEntityDueDiligenceKey } from "../model/overseas.entity.due.diligence.model";
-import { IdentityDateKey, IdentityDateKeys } from "../model/date.model";
-import { IdentityAddressKey, IdentityAddressKeys } from "../model/address.model";
-import { AddressKeys, InputDateKeys } from "../model/data.types.model";
-import { saveAndContinue } from "../utils/save.and.continue";
 
-export const getDueDiligencePage = async (req: Request, res: Response, next: NextFunction, templateName: string, backLinkUrl: string): Promise<void> => {
+export const getDueDiligencePage = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+  templateName: string,
+  backLinkUrl: string
+): Promise<void> => {
+
   try {
+
     logger.debugRequest(req, `${req.method} ${req.route.path}`);
 
-    const appData: ApplicationData = await getApplicationData(req.session);
+    const isRegistration = isRegistrationJourney(req);
+    const appData: ApplicationData = await fetchApplicationData(req, isRegistration);
     const agentData = appData[DueDiligenceKey];
 
     const identityAddress = (agentData?.[IdentityAddressKey]) ? mapDataObjectToFields(agentData[IdentityAddressKey], IdentityAddressKeys, AddressKeys) : {};
@@ -34,28 +47,35 @@ export const getDueDiligencePage = async (req: Request, res: Response, next: Nex
       ...identityAddress,
       [IdentityDateKey]: identityDate
     });
+
   } catch (error) {
     next(error);
   }
 };
 
 export const postDueDiligencePage = async (req: Request, res: Response, next: NextFunction, redirectUrl: string): Promise<void> => {
+
   try {
+
     logger.debugRequest(req, `${req.method} ${req.route.path}`);
 
+    const isRegistration: boolean = isRegistrationJourney(req);
     const session = req.session as Session;
     const agentData = prepareData(req.body, DueDiligenceKeys);
     agentData[IdentityAddressKey] = mapFieldsToDataObject(req.body, IdentityAddressKeys, AddressKeys);
     agentData[IdentityDateKey] = mapFieldsToDataObject(req.body, IdentityDateKeys, InputDateKeys);
 
-    await setApplicationData(session, agentData, DueDiligenceKey);
-
-    // Empty OverseasEntityDueDiligence object
-    await setApplicationData(session, {}, OverseasEntityDueDiligenceKey);
-
-    await saveAndContinue(req, session);
+    if (isActiveFeature(config.FEATURE_FLAG_ENABLE_REDIS_REMOVAL) && isRegistration) {
+      await setApplicationData(req, agentData, DueDiligenceKey);
+      await setApplicationData(req, {}, OverseasEntityDueDiligenceKey); // set OverseasEntityDueDiligence object to empty
+    } else {
+      await setApplicationData(session, agentData, DueDiligenceKey);
+      await setApplicationData(session, {}, OverseasEntityDueDiligenceKey); // set OverseasEntityDueDiligence object to empty
+      await saveAndContinue(req, session);
+    }
 
     return res.redirect(redirectUrl);
+
   } catch (error) {
     next(error);
   }

--- a/test/controllers/due.diligence.controller.spec.ts
+++ b/test/controllers/due.diligence.controller.spec.ts
@@ -16,11 +16,9 @@ import app from "../../src/app";
 
 import { saveAndContinue } from "../../src/utils/save.and.continue";
 import { authentication } from "../../src/middleware/authentication.middleware";
-
 import { ApplicationDataType } from '../../src/model';
 import { ErrorMessages } from '../../src/validation/error.messages';
 import { hasPresenter } from "../../src/middleware/navigation/has.presenter.middleware";
-
 import { EMAIL_ADDRESS } from "../__mocks__/session.mock";
 import { DueDiligenceKey } from '../../src/model/due.diligence.model';
 import { getTwoMonthOldDate } from "../__mocks__/fields/date.mock";
@@ -72,7 +70,7 @@ import {
 
 mockCsrfProtectionMiddleware.mockClear();
 const mockHasPresenterMiddleware = hasPresenter as jest.Mock;
-mockHasPresenterMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => next() );
+mockHasPresenterMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => next());
 
 const mockGetApplicationData = getApplicationData as jest.Mock;
 const mockFetchApplicationData = fetchApplicationData as jest.Mock;
@@ -81,12 +79,12 @@ const mockSaveAndContinue = saveAndContinue as jest.Mock;
 const mockPrepareData = prepareData as jest.Mock;
 
 const mockAuthenticationMiddleware = authentication as jest.Mock;
-mockAuthenticationMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => next() );
+mockAuthenticationMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => next());
 
 const mockIsActiveFeature = isActiveFeature as jest.Mock;
 
 const mockServiceAvailabilityMiddleware = serviceAvailabilityMiddleware as jest.Mock;
-mockServiceAvailabilityMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => next() );
+mockServiceAvailabilityMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => next());
 
 const NEXT_PAGE_URL = "/NEXT_PAGE";
 
@@ -109,8 +107,9 @@ describe("DUE_DILIGENCE controller", () => {
 
   describe("GET tests", () => {
 
-    test(`renders the ${DUE_DILIGENCE_PAGE}`, async () => {
-      mockFetchApplicationData.mockReturnValueOnce( { [DueDiligenceKey]: null } );
+    test(`renders the ${DUE_DILIGENCE_PAGE} when the REDIS_removal flag is set to OFF`, async () => {
+      mockIsActiveFeature.mockReturnValue(false);
+      mockFetchApplicationData.mockReturnValueOnce({ [DueDiligenceKey]: null });
       const resp = await request(app).get(DUE_DILIGENCE_URL);
 
       expect(resp.status).toEqual(200);
@@ -127,10 +126,11 @@ describe("DUE_DILIGENCE controller", () => {
       expect(resp.text).toContain(DUE_DILIGENCE_PARTNER_NAME_HINT_TEXT);
       expect(resp.text).toContain(SAVE_AND_CONTINUE_BUTTON_TEXT);
       expect(resp.text).not.toContain(PAGE_TITLE_ERROR);
+      expect(mockFetchApplicationData).toHaveBeenCalledTimes(1);
     });
 
     test(`renders the ${DUE_DILIGENCE_PAGE} page on GET method with session data populated`, async () => {
-      mockFetchApplicationData.mockReturnValueOnce( { [DueDiligenceKey]: DUE_DILIGENCE_OBJECT_MOCK } );
+      mockFetchApplicationData.mockReturnValueOnce({ [DueDiligenceKey]: DUE_DILIGENCE_OBJECT_MOCK });
       const resp = await request(app).get(DUE_DILIGENCE_URL);
 
       expect(resp.status).toEqual(200);
@@ -147,7 +147,7 @@ describe("DUE_DILIGENCE controller", () => {
     });
 
     test(`catch error when renders the ${DUE_DILIGENCE_PAGE} page on GET method`, async () => {
-      mockFetchApplicationData.mockImplementationOnce( () => { throw new Error(ANY_MESSAGE_ERROR); });
+      mockFetchApplicationData.mockImplementationOnce(() => { throw new Error(ANY_MESSAGE_ERROR); });
       const resp = await request(app).get(DUE_DILIGENCE_URL);
 
       expect(resp.status).toEqual(500);
@@ -157,8 +157,10 @@ describe("DUE_DILIGENCE controller", () => {
 
   describe("GET with url Params tests", () => {
 
-    test(`renders the ${DUE_DILIGENCE_PAGE}`, async () => {
-      mockFetchApplicationData.mockReturnValueOnce( { [DueDiligenceKey]: null } );
+    test(`renders the ${DUE_DILIGENCE_PAGE} when the REDIS_removal flag is set to ON`, async () => {
+      mockIsActiveFeature.mockReturnValueOnce(false); // SERVICE OFFLINE FEATURE FLAG
+      mockIsActiveFeature.mockReturnValue(true); // FEATURE_FLAG_ENABLE_REDIS_REMOVAL
+      mockFetchApplicationData.mockReturnValueOnce({ [DueDiligenceKey]: null });
       const resp = await request(app).get(DUE_DILIGENCE_WITH_PARAMS_URL);
 
       expect(resp.status).toEqual(200);
@@ -175,10 +177,11 @@ describe("DUE_DILIGENCE controller", () => {
       expect(resp.text).toContain(DUE_DILIGENCE_PARTNER_NAME_HINT_TEXT);
       expect(resp.text).toContain(SAVE_AND_CONTINUE_BUTTON_TEXT);
       expect(resp.text).not.toContain(PAGE_TITLE_ERROR);
+      expect(mockFetchApplicationData).toHaveBeenCalledTimes(1);
     });
 
     test(`renders the ${DUE_DILIGENCE_PAGE} page on GET method with session data populated`, async () => {
-      mockFetchApplicationData.mockReturnValueOnce( { [DueDiligenceKey]: DUE_DILIGENCE_OBJECT_MOCK } );
+      mockFetchApplicationData.mockReturnValueOnce({ [DueDiligenceKey]: DUE_DILIGENCE_OBJECT_MOCK });
       const resp = await request(app).get(DUE_DILIGENCE_WITH_PARAMS_URL);
 
       expect(resp.status).toEqual(200);
@@ -195,7 +198,7 @@ describe("DUE_DILIGENCE controller", () => {
     });
 
     test(`renders the ${DUE_DILIGENCE_PAGE} page on GET method with correct back link url when REDIS removal feature flag is off`, async () => {
-      mockFetchApplicationData.mockReturnValueOnce( { [DueDiligenceKey]: DUE_DILIGENCE_OBJECT_MOCK } );
+      mockFetchApplicationData.mockReturnValueOnce({ [DueDiligenceKey]: DUE_DILIGENCE_OBJECT_MOCK });
       mockIsActiveFeature.mockReturnValue(false);
       const resp = await request(app).get(DUE_DILIGENCE_WITH_PARAMS_URL);
       expect(resp.status).toEqual(200);
@@ -204,7 +207,7 @@ describe("DUE_DILIGENCE controller", () => {
     });
 
     test(`renders the ${DUE_DILIGENCE_PAGE} page on GET method with correct back link url when REDIS removal feature flag is on`, async () => {
-      mockFetchApplicationData.mockReturnValueOnce( { [DueDiligenceKey]: DUE_DILIGENCE_OBJECT_MOCK } );
+      mockFetchApplicationData.mockReturnValueOnce({ [DueDiligenceKey]: DUE_DILIGENCE_OBJECT_MOCK });
       mockIsActiveFeature.mockReturnValue(true);
       const resp = await request(app).get(DUE_DILIGENCE_WITH_PARAMS_URL);
       expect(resp.status).toEqual(200);
@@ -213,7 +216,7 @@ describe("DUE_DILIGENCE controller", () => {
     });
 
     test(`catch error when renders the ${DUE_DILIGENCE_PAGE} page on GET method`, async () => {
-      mockFetchApplicationData.mockImplementationOnce( () => { throw new Error(ANY_MESSAGE_ERROR); });
+      mockFetchApplicationData.mockImplementationOnce(() => { throw new Error(ANY_MESSAGE_ERROR); });
       const resp = await request(app).get(DUE_DILIGENCE_WITH_PARAMS_URL);
 
       expect(resp.status).toEqual(500);
@@ -223,8 +226,10 @@ describe("DUE_DILIGENCE controller", () => {
 
   describe("POST tests", () => {
 
-    test(`redirect to ${ENTITY_PAGE} page after a successful post from ${DUE_DILIGENCE_PAGE} page`, async () => {
-      mockPrepareData.mockReturnValueOnce({ ...DUE_DILIGENCE_OBJECT_MOCK } );
+    test(`redirect to ${ENTITY_PAGE} page after a successful post from ${DUE_DILIGENCE_PAGE} page when the REDIS_removal flag is set to OFF`, async () => {
+      mockIsActiveFeature.mockReturnValue(false);
+      mockSetApplicationData.mockReturnValue(true);
+      mockPrepareData.mockReturnValueOnce({ ...DUE_DILIGENCE_OBJECT_MOCK });
 
       const twoMonthOldDate = getTwoMonthOldDate();
 
@@ -239,11 +244,13 @@ describe("DUE_DILIGENCE controller", () => {
 
       expect(resp.status).toEqual(302);
       expect(resp.text).toContain(`${FOUND_REDIRECT_TO} ${ENTITY_URL}`);
+      expect(mockFetchApplicationData).toHaveBeenCalledTimes(0);
       expect(mockSaveAndContinue).toHaveBeenCalledTimes(1);
+      expect(mockSetApplicationData).toHaveBeenCalledTimes(2);
     });
 
     test("renders the next page and no errors are reported if email has leading and trailing spaces", async () => {
-      mockPrepareData.mockReturnValueOnce({ ...DUE_DILIGENCE_OBJECT_MOCK } );
+      mockPrepareData.mockReturnValueOnce({ ...DUE_DILIGENCE_OBJECT_MOCK });
 
       const twoMonthOldDate = getTwoMonthOldDate();
 
@@ -266,7 +273,7 @@ describe("DUE_DILIGENCE controller", () => {
     });
 
     test("renders the next page and no errors are reported if identity date has leading and trailing spaces", async () => {
-      mockPrepareData.mockReturnValueOnce({ ...DUE_DILIGENCE_OBJECT_MOCK } );
+      mockPrepareData.mockReturnValueOnce({ ...DUE_DILIGENCE_OBJECT_MOCK });
 
       const twoMonthOldDate = getTwoMonthOldDate();
 
@@ -543,7 +550,7 @@ describe("DUE_DILIGENCE controller", () => {
     });
 
     test("Test email is valid with long email address", async () => {
-      mockPrepareData.mockReturnValueOnce({ ...DUE_DILIGENCE_OBJECT_MOCK } );
+      mockPrepareData.mockReturnValueOnce({ ...DUE_DILIGENCE_OBJECT_MOCK });
       const dueDiligenceData = {
         ...DUE_DILIGENCE_REQ_BODY_OBJECT_MOCK,
         email: "vsocarroll@QQQQQQQT123465798U123456789V123456789W123456789X123456789Y123456.companieshouse.gov.uk" };
@@ -563,7 +570,7 @@ describe("DUE_DILIGENCE controller", () => {
     });
 
     test("Test email is valid with long email name and address", async () => {
-      mockPrepareData.mockReturnValueOnce({ ...DUE_DILIGENCE_OBJECT_MOCK } );
+      mockPrepareData.mockReturnValueOnce({ ...DUE_DILIGENCE_OBJECT_MOCK });
       const dueDiligenceData = {
         ...DUE_DILIGENCE_REQ_BODY_OBJECT_MOCK,
         email: "socarrollA123456789B132456798C123456798D123456789@T123465798U123456789V123456789W123456789X123456789Y123456.companieshouse.gov.uk" };
@@ -583,7 +590,7 @@ describe("DUE_DILIGENCE controller", () => {
     });
 
     test("Test email is valid with very long email name and address", async () => {
-      mockPrepareData.mockReturnValueOnce({ ...DUE_DILIGENCE_OBJECT_MOCK } );
+      mockPrepareData.mockReturnValueOnce({ ...DUE_DILIGENCE_OBJECT_MOCK });
       const dueDiligenceData = {
         ...DUE_DILIGENCE_REQ_BODY_OBJECT_MOCK,
         email: "socarrollA123456789B132456798C123456798D123456789E123456789F123XX@T123465798U123456789V123456789W123456789X123456789Y123456.companieshouse.gov.uk" };
@@ -733,7 +740,7 @@ describe("DUE_DILIGENCE controller", () => {
     });
 
     test(`catch error when renders the ${DUE_DILIGENCE_PAGE} page on POST method`, async () => {
-      mockSetApplicationData.mockImplementationOnce( () => { throw new Error(ANY_MESSAGE_ERROR); });
+      mockSetApplicationData.mockImplementationOnce(() => { throw new Error(ANY_MESSAGE_ERROR); });
 
       const twoMonthOldDate = getTwoMonthOldDate();
 
@@ -754,10 +761,11 @@ describe("DUE_DILIGENCE controller", () => {
 
   describe("POST with url params tests", () => {
 
-    test(`redirect to ${ENTITY_PAGE} page after a successful post from ${DUE_DILIGENCE_PAGE} page with url params`, async () => {
-      mockIsActiveFeature.mockReturnValueOnce(true); // For FEATURE_FLAG_ENABLE_REDIS_REMOVAL
-
-      mockPrepareData.mockReturnValueOnce({ ...DUE_DILIGENCE_OBJECT_MOCK } );
+    test(`redirect to ${ENTITY_PAGE} page after a successful post from ${DUE_DILIGENCE_PAGE} page with url params when the REDIS_removal flag is set to ON`, async () => {
+      mockIsActiveFeature.mockReturnValue(false); // SERVICE OFFLINE FEATURE FLAG
+      mockIsActiveFeature.mockReturnValue(true); // FEATURE_FLAG_ENABLE_REDIS_REMOVAL
+      mockSetApplicationData.mockReturnValue(true);
+      mockPrepareData.mockReturnValueOnce({ ...DUE_DILIGENCE_OBJECT_MOCK });
 
       const twoMonthOldDate = getTwoMonthOldDate();
 
@@ -772,15 +780,17 @@ describe("DUE_DILIGENCE controller", () => {
 
       expect(resp.status).toEqual(302);
       expect(resp.text).toContain(NEXT_PAGE_URL);
-      expect(mockSaveAndContinue).toHaveBeenCalledTimes(1);
       expect(mockGetUrlWithParamsToPath).toHaveBeenCalledTimes(1);
       expect(mockGetUrlWithParamsToPath.mock.calls[0][0]).toEqual(ENTITY_WITH_PARAMS_URL);
+      expect(mockFetchApplicationData).toHaveBeenCalledTimes(0);
+      expect(mockSaveAndContinue).toHaveBeenCalledTimes(0);
+      expect(mockSetApplicationData).toHaveBeenCalledTimes(2);
     });
 
     test("renders the next page and no errors are reported if email has leading and trailing spaces", async () => {
       mockIsActiveFeature.mockReturnValueOnce(true); // For FEATURE_FLAG_ENABLE_REDIS_REMOVAL
 
-      mockPrepareData.mockReturnValueOnce({ ...DUE_DILIGENCE_OBJECT_MOCK } );
+      mockPrepareData.mockReturnValueOnce({ ...DUE_DILIGENCE_OBJECT_MOCK });
 
       const twoMonthOldDate = getTwoMonthOldDate();
 
@@ -805,7 +815,7 @@ describe("DUE_DILIGENCE controller", () => {
     test("renders the next page and no errors are reported if identity date has leading and trailing spaces", async () => {
       mockIsActiveFeature.mockReturnValueOnce(true); // For FEATURE_FLAG_ENABLE_REDIS_REMOVAL
 
-      mockPrepareData.mockReturnValueOnce({ ...DUE_DILIGENCE_OBJECT_MOCK } );
+      mockPrepareData.mockReturnValueOnce({ ...DUE_DILIGENCE_OBJECT_MOCK });
 
       const twoMonthOldDate = getTwoMonthOldDate();
 
@@ -1086,7 +1096,7 @@ describe("DUE_DILIGENCE controller", () => {
     test("Test email is valid with long email address", async () => {
       mockIsActiveFeature.mockReturnValueOnce(true); // For FEATURE_FLAG_ENABLE_REDIS_REMOVAL
 
-      mockPrepareData.mockReturnValueOnce({ ...DUE_DILIGENCE_OBJECT_MOCK } );
+      mockPrepareData.mockReturnValueOnce({ ...DUE_DILIGENCE_OBJECT_MOCK });
       const dueDiligenceData = {
         ...DUE_DILIGENCE_REQ_BODY_OBJECT_MOCK,
         email: "vsocarroll@QQQQQQQT123465798U123456789V123456789W123456789X123456789Y123456.companieshouse.gov.uk" };
@@ -1108,7 +1118,7 @@ describe("DUE_DILIGENCE controller", () => {
     test("Test email is valid with long email name and address", async () => {
       mockIsActiveFeature.mockReturnValueOnce(true); // For FEATURE_FLAG_ENABLE_REDIS_REMOVAL
 
-      mockPrepareData.mockReturnValueOnce({ ...DUE_DILIGENCE_OBJECT_MOCK } );
+      mockPrepareData.mockReturnValueOnce({ ...DUE_DILIGENCE_OBJECT_MOCK });
       const dueDiligenceData = {
         ...DUE_DILIGENCE_REQ_BODY_OBJECT_MOCK,
         email: "socarrollA123456789B132456798C123456798D123456789@T123465798U123456789V123456789W123456789X123456789Y123456.companieshouse.gov.uk" };
@@ -1130,7 +1140,7 @@ describe("DUE_DILIGENCE controller", () => {
     test("Test email is valid with very long email name and address", async () => {
       mockIsActiveFeature.mockReturnValueOnce(true); // For FEATURE_FLAG_ENABLE_REDIS_REMOVAL
 
-      mockPrepareData.mockReturnValueOnce({ ...DUE_DILIGENCE_OBJECT_MOCK } );
+      mockPrepareData.mockReturnValueOnce({ ...DUE_DILIGENCE_OBJECT_MOCK });
       const dueDiligenceData = {
         ...DUE_DILIGENCE_REQ_BODY_OBJECT_MOCK,
         email: "socarrollA123456789B132456798C123456798D123456789E123456789F123XX@T123465798U123456789V123456789W123456789X123456789Y123456.companieshouse.gov.uk" };
@@ -1280,7 +1290,7 @@ describe("DUE_DILIGENCE controller", () => {
     });
 
     test(`catch error when renders the ${DUE_DILIGENCE_PAGE} page on POST method`, async () => {
-      mockSetApplicationData.mockImplementationOnce( () => { throw new Error(ANY_MESSAGE_ERROR); });
+      mockSetApplicationData.mockImplementationOnce(() => { throw new Error(ANY_MESSAGE_ERROR); });
 
       const twoMonthOldDate = getTwoMonthOldDate();
 

--- a/test/controllers/presenter.controller.spec.ts
+++ b/test/controllers/presenter.controller.spec.ts
@@ -80,10 +80,10 @@ const mockHasOverseasNameMiddleware = hasOverseasName as jest.Mock;
 mockHasOverseasNameMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => next() );
 
 const mockGetApplicationData = getApplicationData as jest.Mock;
-mockGetApplicationData.mockReturnValue( APPLICATION_DATA_MOCK );
+mockGetApplicationData.mockReturnValue(APPLICATION_DATA_MOCK);
 
 const mockFetchApplicationData = fetchApplicationData as jest.Mock;
-mockFetchApplicationData.mockReturnValue( APPLICATION_DATA_MOCK );
+mockFetchApplicationData.mockReturnValue(APPLICATION_DATA_MOCK);
 
 const mockSetApplicationData = setApplicationData as jest.Mock;
 const mockAuthenticationMiddleware = authentication as jest.Mock;

--- a/test/controllers/update/due.diligence.overseas.entity.controller.spec.ts
+++ b/test/controllers/update/due.diligence.overseas.entity.controller.spec.ts
@@ -6,17 +6,19 @@ jest.mock('../../../src/middleware/navigation/update/has.who.is.making.update.mi
 jest.mock('../../../src/middleware/service.availability.middleware');
 jest.mock('../../../src/utils/save.and.continue');
 
+import { describe, expect, test, jest, beforeEach } from "@jest/globals";
+import { NextFunction, Request, Response } from "express";
+
 // import remove journey middleware mock before app to prevent real function being used instead of mock
 import mockJourneyDetectionMiddleware from "../../__mocks__/journey.detection.middleware.mock";
 import mockCsrfProtectionMiddleware from "../../__mocks__/csrfProtectionMiddleware.mock";
-import { describe, expect, test, jest, beforeEach } from "@jest/globals";
-import { NextFunction, Request, Response } from "express";
 import request from "supertest";
+
 import app from "../../../src/app";
+
 import { hasWhoIsMakingUpdate } from "../../../src/middleware/navigation/update/has.who.is.making.update.middleware";
 import { OverseasEntityDueDiligenceKey } from "../../../src/model/overseas.entity.due.diligence.model";
 import { serviceAvailabilityMiddleware } from "../../../src/middleware/service.availability.middleware";
-import { getApplicationData, setApplicationData, prepareData } from "../../../src/utils/application.data";
 import { authentication } from "../../../src/middleware/authentication.middleware";
 import { companyAuthentication } from "../../../src/middleware/company.authentication.middleware";
 import { ApplicationDataType } from '../../../src/model';
@@ -25,10 +27,14 @@ import { EMPTY_IDENTITY_DATE_REQ_BODY_MOCK, getTwoMonthOldDate } from "../../__m
 import { ErrorMessages } from '../../../src/validation/error.messages';
 import { DateTime } from "luxon";
 import { OVERSEAS_ENTITY_DUE_DILIGENCE_WITH_INVALID_CHARACTERS_FIELDS_MOCK } from "../../__mocks__/validation.mock";
+
+import { getApplicationData, setApplicationData, prepareData } from "../../../src/utils/application.data";
+
 import {
   DUE_DILIGENCE_REQ_BODY_OBJECT_MOCK,
   DUE_DILIGENCE_REQ_BODY_OBJECT_MOCK_FOR_IDENTITY_DATE
 } from "../../__mocks__/due.diligence.mock";
+
 import {
   OVERSEAS_ENTITY_DUE_DILIGENCE_OBJECT_MOCK,
   OVERSEAS_ENTITY_DUE_DILIGENCE_REQ_BODY_OBJECT_MOCK_WITH_EMAIL_CONTAINING_LEADING_AND_TRAILING_SPACES,
@@ -36,6 +42,7 @@ import {
   OVERSEAS_ENTITY_DUE_DILIGENCE_REQ_BODY_MAX_LENGTH_FIELDS_MOCK,
   OVERSEAS_ENTITY_DUE_DILIGENCE_REQ_BODY_OBJECT_MOCK
 } from "../../__mocks__/overseas.entity.due.diligence.mock";
+
 import {
   WHO_IS_MAKING_UPDATE_URL,
   UPDATE_DUE_DILIGENCE_OVERSEAS_ENTITY_PAGE,
@@ -43,6 +50,7 @@ import {
   UPDATE_REVIEW_OVERSEAS_ENTITY_INFORMATION_PAGE,
   UPDATE_REVIEW_OVERSEAS_ENTITY_INFORMATION_URL
 } from "../../../src/config";
+
 import {
   ANY_MESSAGE_ERROR,
   SERVICE_UNAVAILABLE,

--- a/test/controllers/update/update.due.diligence.controller.spec.ts
+++ b/test/controllers/update/update.due.diligence.controller.spec.ts
@@ -7,19 +7,38 @@ jest.mock("../../../src/utils/logger");
 jest.mock('../../../src/utils/application.data');
 jest.mock('../../../src/utils/save.and.continue');
 
+import { NextFunction, Request, Response } from "express";
+import { beforeEach, expect, jest, test, describe } from "@jest/globals";
+
 // import remove journey middleware mock before app to prevent real function being used instead of mock
 import mockJourneyDetectionMiddleware from "../../__mocks__/journey.detection.middleware.mock";
 import mockCsrfProtectionMiddleware from "../../__mocks__/csrfProtectionMiddleware.mock";
-import { NextFunction, Request, Response } from "express";
-import { beforeEach, expect, jest, test, describe } from "@jest/globals";
 import request from "supertest";
+
+import app from "../../../src/app";
+
+import { ErrorMessages } from '../../../src/validation/error.messages';
+import { authentication } from "../../../src/middleware/authentication.middleware";
+import { companyAuthentication } from "../../../src/middleware/company.authentication.middleware";
+import { serviceAvailabilityMiddleware } from "../../../src/middleware/service.availability.middleware";
+import { logger } from "../../../src/utils/logger";
+import { ApplicationDataType } from '../../../src/model';
+import { hasWhoIsMakingUpdate } from "../../../src/middleware/navigation/update/has.who.is.making.update.middleware";
+import { EMAIL_ADDRESS } from "../../__mocks__/session.mock";
+import { DueDiligenceKey } from '../../../src/model/due.diligence.model';
+import { getTwoMonthOldDate } from "../../__mocks__/fields/date.mock";
+import { DUE_DILIGENCE_WITH_INVALID_CHARACTERS_FIELDS_MOCK } from "../../__mocks__/validation.mock";
+import { DateTime } from "luxon";
+import { saveAndContinue } from "../../../src/utils/save.and.continue";
+
+import { getApplicationData, setApplicationData, prepareData, fetchApplicationData } from "../../../src/utils/application.data";
+
 import {
   UPDATE_DUE_DILIGENCE_PAGE,
   UPDATE_DUE_DILIGENCE_URL,
   UPDATE_REVIEW_OVERSEAS_ENTITY_INFORMATION_PAGE,
   UPDATE_REVIEW_OVERSEAS_ENTITY_INFORMATION_URL
 } from "../../../src/config";
-import app from "../../../src/app";
 
 import {
   ANY_MESSAGE_ERROR,
@@ -46,21 +65,6 @@ import {
   DUE_DILIGENCE_REQ_BODY_OBJECT_MOCK
 } from "../../__mocks__/due.diligence.mock";
 
-import { ErrorMessages } from '../../../src/validation/error.messages';
-import { getApplicationData, setApplicationData, prepareData } from "../../../src/utils/application.data";
-import { authentication } from "../../../src/middleware/authentication.middleware";
-import { companyAuthentication } from "../../../src/middleware/company.authentication.middleware";
-import { serviceAvailabilityMiddleware } from "../../../src/middleware/service.availability.middleware";
-import { logger } from "../../../src/utils/logger";
-import { ApplicationDataType } from '../../../src/model';
-import { hasWhoIsMakingUpdate } from "../../../src/middleware/navigation/update/has.who.is.making.update.middleware";
-import { EMAIL_ADDRESS } from "../../__mocks__/session.mock";
-import { DueDiligenceKey } from '../../../src/model/due.diligence.model';
-import { getTwoMonthOldDate } from "../../__mocks__/fields/date.mock";
-import { DUE_DILIGENCE_WITH_INVALID_CHARACTERS_FIELDS_MOCK } from "../../__mocks__/validation.mock";
-import { DateTime } from "luxon";
-import { saveAndContinue } from "../../../src/utils/save.and.continue";
-
 mockJourneyDetectionMiddleware.mockClear();
 mockCsrfProtectionMiddleware.mockClear();
 const mockAuthenticationMiddleware = authentication as jest.Mock;
@@ -77,6 +81,7 @@ mockServiceAvailabilityMiddleware.mockImplementation((req: Request, res: Respons
 
 const mockLoggerDebugRequest = logger.debugRequest as jest.Mock;
 const mockGetApplicationData = getApplicationData as jest.Mock;
+const mockFetchApplicationData = fetchApplicationData as jest.Mock;
 const mockSetApplicationData = setApplicationData as jest.Mock;
 const mockPrepareData = prepareData as jest.Mock;
 const mockSaveAndContinue = saveAndContinue as jest.Mock;
@@ -86,12 +91,13 @@ describe("Update due diligence controller tests", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockGetApplicationData.mockReset();
+    mockFetchApplicationData.mockReset();
     mockSetApplicationData.mockReset();
   });
 
   describe("GET tests", () => {
     test(`renders the ${UPDATE_DUE_DILIGENCE_PAGE}`, async () => {
-      mockGetApplicationData.mockReturnValueOnce({ [DueDiligenceKey]: null });
+      mockFetchApplicationData.mockReturnValueOnce({ [DueDiligenceKey]: null });
       const resp = await request(app).get(UPDATE_DUE_DILIGENCE_URL);
 
       expect(resp.status).toEqual(200);
@@ -115,7 +121,7 @@ describe("Update due diligence controller tests", () => {
     });
 
     test(`renders the ${UPDATE_DUE_DILIGENCE_PAGE} page on GET method with session data populated`, async () => {
-      mockGetApplicationData.mockReturnValueOnce( { [DueDiligenceKey]: DUE_DILIGENCE_OBJECT_MOCK } );
+      mockFetchApplicationData.mockReturnValueOnce({ [DueDiligenceKey]: DUE_DILIGENCE_OBJECT_MOCK } );
       const resp = await request(app).get(UPDATE_DUE_DILIGENCE_URL);
 
       expect(resp.status).toEqual(200);
@@ -279,6 +285,7 @@ describe("Update due diligence controller tests", () => {
       expect(resp.text).not.toContain(ErrorMessages.DATE_NOT_IN_PAST_OR_TODAY);
       expect(resp.text).not.toContain(ErrorMessages.IDENTITY_CHECK_DATE_NOT_WITHIN_PAST_3_MONTHS);
     });
+
     test(`renders the ${UPDATE_DUE_DILIGENCE_PAGE} page with only DAY error when identity date day is empty`, async () => {
       const dueDiligenceData = { ...DUE_DILIGENCE_REQ_BODY_OBJECT_MOCK_FOR_IDENTITY_DATE };
       dueDiligenceData["identity_date-month"] = "11";


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/ROE-2639

### Change description

- Retrieves application data from the API for the `due-diligence` page/screen
- Modifies tests to match new/updated functionality
- Includes minor formatting changes

### Work checklist

- [x] Tests added where applicable
- [x] UI changes meet accessibility criteria