### PR TITLE
Feat/ROE-2638: Retrieve application data from DB for the `overseas-entity-due-diligence` page

### DIFF
--- a/src/utils/overseas.due.diligence.ts
+++ b/src/utils/overseas.due.diligence.ts
@@ -2,27 +2,40 @@ import { NextFunction, Request, Response } from "express";
 import { Session } from "@companieshouse/node-session-handler";
 import { ApplicationData } from "../model";
 import { logger } from "../utils/logger";
-import {
-  getApplicationData,
-  setApplicationData,
-  prepareData,
-  mapDataObjectToFields,
-  mapFieldsToDataObject,
-} from "../utils/application.data";
+import { isRegistrationJourney } from "./url";
+import { isActiveFeature } from "./feature.flag";
+import * as config from "../config";
+import { saveAndContinue } from "./save.and.continue";
+
 import { DueDiligenceKey } from "../model/due.diligence.model";
 import { IdentityAddressKey, IdentityAddressKeys } from "../model/address.model";
 import { AddressKeys, InputDateKeys } from "../model/data.types.model";
 import { IdentityDateKey, IdentityDateKeys } from "../model/date.model";
 import { OverseasEntityDueDiligenceKey, OverseasEntityDueDiligenceKeys } from "../model/overseas.entity.due.diligence.model";
-import { saveAndContinue } from "./save.and.continue";
 
-export const getDueDiligence = async (req: Request, res: Response, next: NextFunction, templateName: string, backLinkUrl: string): Promise<void> => {
+import {
+  setApplicationData,
+  prepareData,
+  mapDataObjectToFields,
+  mapFieldsToDataObject,
+  fetchApplicationData,
+} from "../utils/application.data";
+
+export const getDueDiligence = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+  templateName: string,
+  backLinkUrl: string
+): Promise<void> => {
+
   try {
+
     logger.debugRequest(req, `${req.method} ${req.route.path}`);
 
-    const appData: ApplicationData = await getApplicationData(req.session);
+    const isRegistration = isRegistrationJourney(req);
+    const appData: ApplicationData = await fetchApplicationData(req, isRegistration);
     const data = appData[OverseasEntityDueDiligenceKey];
-
     const identityAddress = (data?.[IdentityAddressKey]) ? mapDataObjectToFields(data[IdentityAddressKey], IdentityAddressKeys, AddressKeys) : {};
     const identityDate = (data?.[IdentityDateKey]) ? mapDataObjectToFields(data[IdentityDateKey], IdentityDateKeys, InputDateKeys) : {};
 
@@ -33,28 +46,35 @@ export const getDueDiligence = async (req: Request, res: Response, next: NextFun
       ...identityAddress,
       [IdentityDateKey]: identityDate
     });
+
   } catch (error) {
     next(error);
   }
 };
 
 export const postDueDiligence = async (req: Request, res: Response, next: NextFunction, redirectUrl: string): Promise<void> => {
+
   try {
+
     logger.debugRequest(req, `${req.method} ${req.route.path}`);
 
+    const isRegistration = isRegistrationJourney(req);
     const session = req.session as Session;
     const data = prepareData(req.body, OverseasEntityDueDiligenceKeys);
     data[IdentityAddressKey] = mapFieldsToDataObject(req.body, IdentityAddressKeys, AddressKeys);
     data[IdentityDateKey] = mapFieldsToDataObject(req.body, IdentityDateKeys, InputDateKeys);
 
-    await setApplicationData(session, data, OverseasEntityDueDiligenceKey);
-
-    // Empty DueDiligence object
-    await setApplicationData(session, {}, DueDiligenceKey);
-
-    await saveAndContinue(req, session);
+    if (isActiveFeature(config.FEATURE_FLAG_ENABLE_REDIS_REMOVAL) && isRegistration) {
+      await setApplicationData(req, data, OverseasEntityDueDiligenceKey);
+      await setApplicationData(req, {}, DueDiligenceKey); // set DueDiligence object to empty
+    } else {
+      await setApplicationData(session, data, OverseasEntityDueDiligenceKey);
+      await setApplicationData(session, {}, DueDiligenceKey); // set DueDiligence object to empty
+      await saveAndContinue(req, session);
+    }
 
     return res.redirect(redirectUrl);
+
   } catch (error) {
     next(error);
   }

--- a/test/controllers/update/due.diligence.overseas.entity.controller.spec.ts
+++ b/test/controllers/update/due.diligence.overseas.entity.controller.spec.ts
@@ -5,6 +5,7 @@ jest.mock("../../../src/utils/application.data");
 jest.mock('../../../src/middleware/navigation/update/has.who.is.making.update.middleware');
 jest.mock('../../../src/middleware/service.availability.middleware');
 jest.mock('../../../src/utils/save.and.continue');
+jest.mock("../../../src/utils/url");
 
 import { describe, expect, test, jest, beforeEach } from "@jest/globals";
 import { NextFunction, Request, Response } from "express";
@@ -23,12 +24,13 @@ import { authentication } from "../../../src/middleware/authentication.middlewar
 import { companyAuthentication } from "../../../src/middleware/company.authentication.middleware";
 import { ApplicationDataType } from '../../../src/model';
 import { EMAIL_ADDRESS } from "../../__mocks__/session.mock";
-import { EMPTY_IDENTITY_DATE_REQ_BODY_MOCK, getTwoMonthOldDate } from "../../__mocks__/fields/date.mock";
 import { ErrorMessages } from '../../../src/validation/error.messages';
 import { DateTime } from "luxon";
 import { OVERSEAS_ENTITY_DUE_DILIGENCE_WITH_INVALID_CHARACTERS_FIELDS_MOCK } from "../../__mocks__/validation.mock";
+import { isRegistrationJourney } from "../../../src/utils/url";
 
-import { getApplicationData, setApplicationData, prepareData } from "../../../src/utils/application.data";
+import { EMPTY_IDENTITY_DATE_REQ_BODY_MOCK, getTwoMonthOldDate } from "../../__mocks__/fields/date.mock";
+import { fetchApplicationData, setApplicationData, prepareData } from "../../../src/utils/application.data";
 
 import {
   DUE_DILIGENCE_REQ_BODY_OBJECT_MOCK,
@@ -69,12 +71,12 @@ import {
 
 mockJourneyDetectionMiddleware.mockClear();
 mockCsrfProtectionMiddleware.mockClear();
-const mockGetApplicationData = getApplicationData as jest.Mock;
+const mockFetchApplicationData = fetchApplicationData as jest.Mock;
 const mockSetApplicationData = setApplicationData as jest.Mock;
 const mockAuthenticationMiddleware = authentication as jest.Mock;
 
 const mockCompanyAuthenticationMiddleware = companyAuthentication as jest.Mock;
-mockCompanyAuthenticationMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => next() );
+mockCompanyAuthenticationMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => next());
 
 const mockHasWhoIsMakingUpdate = hasWhoIsMakingUpdate as jest.Mock;
 mockHasWhoIsMakingUpdate.mockImplementation((req: Request, res: Response, next: NextFunction) => next());
@@ -85,6 +87,9 @@ mockAuthenticationMiddleware.mockImplementation((req: Request, res: Response, ne
 const mockServiceAvailabilityMiddleware = serviceAvailabilityMiddleware as jest.Mock;
 mockServiceAvailabilityMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => next());
 
+const mockIsRegistrationJourney = isRegistrationJourney as jest.Mock;
+mockIsRegistrationJourney.mockReturnValue(false);
+
 describe("UPDATE DUE DILIGENCE OVERSEAS ENTITY controller", () => {
 
   beforeEach(() => {
@@ -94,7 +99,7 @@ describe("UPDATE DUE DILIGENCE OVERSEAS ENTITY controller", () => {
 
   describe("GET tests", () => {
     test(`renders the ${UPDATE_DUE_DILIGENCE_OVERSEAS_ENTITY_PAGE} page`, async () => {
-      mockGetApplicationData.mockReturnValueOnce({ [OverseasEntityDueDiligenceKey]: null });
+      mockFetchApplicationData.mockReturnValueOnce({ [OverseasEntityDueDiligenceKey]: null });
       const resp = await request(app).get(UPDATE_DUE_DILIGENCE_OVERSEAS_ENTITY_URL);
 
       expect(resp.status).toEqual(200);
@@ -112,7 +117,7 @@ describe("UPDATE DUE DILIGENCE OVERSEAS ENTITY controller", () => {
     });
 
     test(`renders the ${UPDATE_DUE_DILIGENCE_OVERSEAS_ENTITY_PAGE} page on GET method with session data populated`, async () => {
-      mockGetApplicationData.mockReturnValueOnce({ [OverseasEntityDueDiligenceKey]: OVERSEAS_ENTITY_DUE_DILIGENCE_OBJECT_MOCK });
+      mockFetchApplicationData.mockReturnValueOnce({ [OverseasEntityDueDiligenceKey]: OVERSEAS_ENTITY_DUE_DILIGENCE_OBJECT_MOCK });
       const resp = await request(app).get(UPDATE_DUE_DILIGENCE_OVERSEAS_ENTITY_URL);
 
       expect(resp.status).toEqual(200);
@@ -125,7 +130,7 @@ describe("UPDATE DUE DILIGENCE OVERSEAS ENTITY controller", () => {
     });
 
     test(`catch error when renders the ${UPDATE_DUE_DILIGENCE_OVERSEAS_ENTITY_PAGE} page on GET method`, async () => {
-      mockGetApplicationData.mockImplementationOnce(() => { throw new Error(ANY_MESSAGE_ERROR); });
+      mockFetchApplicationData.mockImplementationOnce(() => { throw new Error(ANY_MESSAGE_ERROR); });
       const resp = await request(app).get(UPDATE_DUE_DILIGENCE_OVERSEAS_ENTITY_URL);
 
       expect(resp.status).toEqual(500);


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/ROE-2638

### Change description

- Retrieves application data from the API for the `overseas-entity-due-diligence` page/screen
- Modifies tests to match new/updated functionality
- Includes minor formatting changes

### Work checklist

- [x] Tests added where applicable
- [x] UI changes meet accessibility criteria