### PR TITLE
Feat/ROE-2641: Retrieve application data from DB for the `beneficial-owner-statements` page

### DIFF
--- a/src/utils/application.data.ts
+++ b/src/utils/application.data.ts
@@ -116,7 +116,7 @@ export const setApplicationData = async (sessionOrRequest: Request | Session | u
     }
 
     if (!ApplicationDataArrayType.includes(key)) {
-      appData = { ...appData, [key]: { ...data } } as ApplicationData;
+      appData = { ...appData, [key]: typeof data !== "object" ? data : { ...data } } as ApplicationData;
     } else {
       if (!appData[key]) {
         appData[key] = [];

--- a/src/utils/application.data.ts
+++ b/src/utils/application.data.ts
@@ -116,7 +116,7 @@ export const setApplicationData = async (sessionOrRequest: Request | Session | u
     }
 
     if (!ApplicationDataArrayType.includes(key)) {
-      appData = { ...appData, [key]: typeof data !== "object" ? data : { ...data } } as ApplicationData;
+      appData = { ...appData, [key]: data } as ApplicationData;
     } else {
       if (!appData[key]) {
         appData[key] = [];

--- a/src/utils/beneficial.owner.statements.ts
+++ b/src/utils/beneficial.owner.statements.ts
@@ -1,25 +1,39 @@
 import { NextFunction, Request, Response } from "express";
 import { Session } from "@companieshouse/node-session-handler";
-
 import * as config from "../config";
 import { logger } from "../utils/logger";
 import { ApplicationData } from "../model";
-import { checkBOsDetailsEntered, checkMOsDetailsEntered, getApplicationData, setExtraData } from "../utils/application.data";
-import { BeneficialOwnersStatementType, BeneficialOwnerStatementKey } from "../model/beneficial.owner.statement.model";
-import { EntityNameKey, EntityNumberKey } from "../model/data.types.model";
 import { saveAndContinue } from "../utils/save.and.continue";
 import { getUrlWithParamsToPath } from "../utils/url";
 import { isActiveFeature } from "./feature.flag";
-import { containsTrustData, getTrustArray } from "./trusts";
 
-export const getBeneficialOwnerStatements = async (req: Request, res: Response, next: NextFunction, registrationFlag: boolean, noChangeBackLink?: string): Promise<void> => {
+import { EntityNameKey, EntityNumberKey } from "../model/data.types.model";
+import { containsTrustData, getTrustArray } from "./trusts";
+import { BeneficialOwnersStatementType, BeneficialOwnerStatementKey } from "../model/beneficial.owner.statement.model";
+
+import {
+  checkBOsDetailsEntered,
+  checkMOsDetailsEntered,
+  fetchApplicationData,
+  setApplicationData,
+} from "../utils/application.data";
+
+export const getBeneficialOwnerStatements = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+  registrationFlag: boolean,
+  noChangeBackLink?: string
+): Promise<void> => {
+
   try {
+
     logger.debugRequest(req, `${req.method} ${req.route.path}`);
 
     let backLinkUrl: string;
     let noChangeFlag: boolean = false;
     let templateName: string;
-    const appData: ApplicationData = await getApplicationData(req.session);
+    const appData: ApplicationData = await fetchApplicationData(req, registrationFlag);
 
     if (noChangeBackLink) {
       backLinkUrl = noChangeBackLink;
@@ -29,15 +43,17 @@ export const getBeneficialOwnerStatements = async (req: Request, res: Response, 
       backLinkUrl = getChangeBackLinkUrl(registrationFlag, appData, req);
       templateName = config.BENEFICIAL_OWNER_STATEMENTS_PAGE;
     }
+
     return res.render(templateName, {
-      backLinkUrl: backLinkUrl,
-      templateName: templateName,
-      [BeneficialOwnerStatementKey]: appData[BeneficialOwnerStatementKey],
+      backLinkUrl,
+      templateName,
       registrationFlag,
       noChangeFlag,
       entity_number: appData[EntityNumberKey],
-      entity_name: appData[EntityNameKey]
+      entity_name: appData[EntityNameKey],
+      [BeneficialOwnerStatementKey]: appData[BeneficialOwnerStatementKey],
     });
+
   } catch (error) {
     logger.errorRequest(req, error);
     next(error);
@@ -58,31 +74,41 @@ const getChangeBackLinkUrl = (registrationFlag: boolean, appData: ApplicationDat
   return backLinkUrl;
 };
 
-export const postBeneficialOwnerStatements = async (req: Request, res: Response, next: NextFunction, registrationFlag: boolean, noChangeRedirectUrl?: string) => {
+export const postBeneficialOwnerStatements = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+  registrationFlag: boolean,
+  noChangeRedirectUrl?: string
+) => {
+
   try {
-    const redirectUrl = getRedirectUrl(req, registrationFlag, noChangeRedirectUrl);
+
     logger.debugRequest(req, `${req.method} ${config.BENEFICIAL_OWNER_STATEMENTS_PAGE}`);
 
     const session = req.session as Session;
     const boStatement = req.body[BeneficialOwnerStatementKey];
-    const appData: ApplicationData = await getApplicationData(session);
+    const appData: ApplicationData = await fetchApplicationData(req, registrationFlag);
+    const redirectUrl = getRedirectUrl(req, registrationFlag, noChangeRedirectUrl);
 
-    if (
-      registrationFlag &&
+    if (registrationFlag &&
       appData[BeneficialOwnerStatementKey] &&
-      (
-        (boStatement === BeneficialOwnersStatementType.NONE_IDENTIFIED && checkBOsDetailsEntered(appData)) ||
-        (boStatement === BeneficialOwnersStatementType.ALL_IDENTIFIED_ALL_DETAILS && checkMOsDetailsEntered(appData))
-      )
-    ) {
+      ((boStatement === BeneficialOwnersStatementType.NONE_IDENTIFIED && checkBOsDetailsEntered(appData)) ||
+        (boStatement === BeneficialOwnersStatementType.ALL_IDENTIFIED_ALL_DETAILS && checkMOsDetailsEntered(appData)))) {
       return res.redirect(`${getWarningRedirectUrl(req)}?${BeneficialOwnerStatementKey}=${boStatement}`);
     }
 
     appData[BeneficialOwnerStatementKey] = boStatement;
-    setExtraData(session, appData);
-    await saveAndContinue(req, session);
+
+    if (isActiveFeature(config.FEATURE_FLAG_ENABLE_REDIS_REMOVAL) && registrationFlag) {
+      await setApplicationData(req, boStatement, BeneficialOwnerStatementKey);
+    } else {
+      await setApplicationData(session, boStatement, BeneficialOwnerStatementKey);
+      await saveAndContinue(req, session);
+    }
 
     return res.redirect(redirectUrl);
+
   } catch (error) {
     logger.errorRequest(req, error);
     next(error);
@@ -93,9 +119,9 @@ const getRedirectUrl = (req: Request, registrationFlag: boolean, noChangeRedirec
   let redirectUrl: string;
   if (noChangeRedirectUrl) {
     redirectUrl = noChangeRedirectUrl;
-  } else if (registrationFlag){
+  } else if (registrationFlag) {
     redirectUrl = config.BENEFICIAL_OWNER_TYPE_URL;
-    if (isActiveFeature(config.FEATURE_FLAG_ENABLE_REDIS_REMOVAL)){
+    if (isActiveFeature(config.FEATURE_FLAG_ENABLE_REDIS_REMOVAL)) {
       redirectUrl = getUrlWithParamsToPath(config.BENEFICIAL_OWNER_TYPE_WITH_PARAMS_URL, req);
     }
   } else {
@@ -106,7 +132,7 @@ const getRedirectUrl = (req: Request, registrationFlag: boolean, noChangeRedirec
 
 const getWarningRedirectUrl = (req: Request) => {
   let warningRedirectUrl = config.BENEFICIAL_OWNER_DELETE_WARNING_URL;
-  if (isActiveFeature(config.FEATURE_FLAG_ENABLE_REDIS_REMOVAL)){
+  if (isActiveFeature(config.FEATURE_FLAG_ENABLE_REDIS_REMOVAL)) {
     warningRedirectUrl = getUrlWithParamsToPath(config.BENEFICIAL_OWNER_DELETE_WARNING_WITH_PARAMS_URL, req);
   }
   return warningRedirectUrl;


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/ROE-2641

### Change description

- Retrieves application data from the API for the `beneficial-owner-statements` page/screen
- Removes unnecessary spread operator in `setApplicationData` method
- Modifies tests to match new/updated functionality
- Includes minor formatting changes

### Work checklist

- [x] Tests added where applicable
- [x] UI changes meet accessibility criteria