### PR TITLE
ROECCT-289: Add Matomo tracking to relevant period pages - continued

### DIFF
--- a/views/includes/page-templates/trust-involved.html
+++ b/views/includes/page-templates/trust-involved.html
@@ -231,7 +231,7 @@
               },
         checked: typeOfTrustee == pageData.trusteeType.RELEVANT_PERIOD_INDIVIDUAL_BENEFICIARY,
               attributes: {
-                "data-event-id": "individual-radio-option"
+                "data-event-id": "individual-relevant-period-radio-option"
               }
               }, {
               value: pageData.trusteeType.RELEVANT_PERIOD_LEGAL_ENTITY,
@@ -241,7 +241,7 @@
               },
               checked: typeOfTrustee == pageData.trusteeType.RELEVANT_PERIOD_LEGAL_ENTITY,
               attributes: {
-                "data-event-id": "legal-entity-radio-option"
+                "data-event-id": "legal-entity-relevant-period-radio-option"
               }
               }
             ]


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/ROECCT-289

### Change description

This is a continuation of the ROECCT-289 branch which was already merged. Additional info on this ticket shows some tracking IDs are unclear. This PR hopes to resolve these issues.

### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
