### PR TITLE
feat/roe-2671: retrieve application data from the DB for the `trust-historical-beneficial-owner` page

### DIFF
--- a/src/utils/trust.former.bo.ts
+++ b/src/utils/trust.former.bo.ts
@@ -1,22 +1,25 @@
 import { NextFunction, Request, Response } from 'express';
+import { Session } from '@companieshouse/node-session-handler';
+import { ValidationError, validationResult } from 'express-validator';
+
 import * as config from '../config';
 import { logger } from '../utils/logger';
 import { TrusteeType } from '../model/trustee.type.model';
-import { getApplicationData, setExtraData } from '../utils/application.data';
-import { getTrustByIdFromApp, saveHistoricalBoInTrust, saveTrustInApp } from '../utils/trusts';
-import { mapBeneficialOwnerToSession, mapFormerTrusteeByIdFromSessionToPage } from '../utils/trust/historical.beneficial.owner.mapper';
 import * as CommonTrustDataMapper from '../utils/trust/common.trust.data.mapper';
 import { ApplicationData } from '../model';
 import * as PageModel from '../model/trust.page.model';
 import { saveAndContinue } from '../utils/save.and.continue';
-import { Session } from '@companieshouse/node-session-handler';
-import { FormattedValidationErrors, formatValidationError } from '../middleware/validation.middleware';
-import { ValidationError, validationResult } from 'express-validator';
 import { safeRedirect } from '../utils/http.ext';
 import { isActiveFeature } from './feature.flag';
-import { getUrlWithParamsToPath } from './url';
-import { filingPeriodTrustCeaseDateValidations, filingPeriodTrustStartDateValidations } from '../validation/async';
+
+import { getUrlWithParamsToPath, isRegistrationJourney } from './url';
 import { checkTrustLegalEntityBeneficialOwnerStillInvolved } from '../validation/stillInvolved.validation';
+import { fetchApplicationData, setExtraData } from '../utils/application.data';
+import { FormattedValidationErrors, formatValidationError } from '../middleware/validation.middleware';
+import { getTrustByIdFromApp, saveHistoricalBoInTrust, saveTrustInApp } from '../utils/trusts';
+import { mapBeneficialOwnerToSession, mapFormerTrusteeByIdFromSessionToPage } from '../utils/trust/historical.beneficial.owner.mapper';
+import { filingPeriodTrustCeaseDateValidations, filingPeriodTrustStartDateValidations } from '../validation/async';
+import { updateOverseasEntity } from "../service/overseas.entities.service";
 
 export const HISTORICAL_BO_TEXTS = {
   title: 'Tell us about the former beneficial owner',
@@ -46,8 +49,8 @@ const getPageProperties = async (
   errors?: FormattedValidationErrors,
 ): Promise<TrustHistoricalBeneficialOwnerProperties> => {
 
-  const appData = await getApplicationData(req.session);
-
+  const isRegistration = isRegistrationJourney(req);
+  const appData: ApplicationData = await fetchApplicationData(req, isRegistration);
   const { templateName, template } = getPageTemplate(isUpdate, req.url);
 
   return ({
@@ -68,13 +71,15 @@ const getPageProperties = async (
 };
 
 export const getTrustFormerBo = async (req: Request, res: Response, next: NextFunction, isUpdate: boolean): Promise<void> => {
+
   try {
+
     logger.debugRequest(req, `${req.method} ${req.route.path}`);
 
+    const isRegistration = isRegistrationJourney(req);
+    const appData: ApplicationData = await fetchApplicationData(req, isRegistration);
     const trustId = req.params[config.ROUTE_PARAM_TRUST_ID];
     const trusteeId = req.params[config.ROUTE_PARAM_TRUSTEE_ID];
-    const appData: ApplicationData = await getApplicationData(req.session);
-
     const formData: PageModel.TrustHistoricalBeneficialOwnerForm = mapFormerTrusteeByIdFromSessionToPage(
       appData,
       trustId,
@@ -83,64 +88,55 @@ export const getTrustFormerBo = async (req: Request, res: Response, next: NextFu
     const pageProps = await getPageProperties(req, trustId, isUpdate, formData);
 
     return res.render(pageProps.template, pageProps);
+
   } catch (error) {
     logger.errorRequest(req, error);
-
     return next(error);
   }
 };
 
 export const postTrustFormerBo = async (req: Request, res: Response, next: NextFunction, isUpdate: boolean) => {
+
   try {
+
     logger.debugRequest(req, `${req.method} ${req.route.path}`);
 
+    const session = req.session as Session;
+    const isRegistration = isRegistrationJourney(req);
+    let appData: ApplicationData = await fetchApplicationData(req, isRegistration);
+
     const trustId = req.params[config.ROUTE_PARAM_TRUST_ID];
-
-    // convert form data to application (session) object
-    const boData = mapBeneficialOwnerToSession(req.body);
-
-    // get trust data from session
-    let appData: ApplicationData = await getApplicationData(req.session);
-
-    // check for errors
+    const boData = mapBeneficialOwnerToSession(req.body); // convert form data to application (session) object
     const errorList = validationResult(req);
     const errors = await getValidationErrors(appData, req);
     const formData: PageModel.TrustHistoricalBeneficialOwnerForm = req.body as PageModel.TrustHistoricalBeneficialOwnerForm;
 
-    // if no errors present rerender the page
     if (!errorList.isEmpty() || errors.length) {
       const errorListArray = !errorList.isEmpty() ? errorList.array() : [];
-
-      const pageProps = await getPageProperties(
+      const pageProps = await getPageProperties (
         req,
         trustId,
         isUpdate,
         formData,
         formatValidationError([...errorListArray, ...errors]),
       );
-
       return res.render(pageProps.template, pageProps);
     }
 
-    // save (add/update) bo to trust
-    const updatedTrust = saveHistoricalBoInTrust(
-      getTrustByIdFromApp(appData, trustId),
-      boData,
-    );
-
-    // update trust in application data
+    const updatedTrust = saveHistoricalBoInTrust(getTrustByIdFromApp(appData, trustId), boData,);
     appData = saveTrustInApp(appData, updatedTrust);
-
-    // save to session
-    const session = req.session as Session;
     setExtraData(session, appData);
 
-    await saveAndContinue(req, session);
+    if (isActiveFeature(config.FEATURE_FLAG_ENABLE_REDIS_REMOVAL) && isRegistration) {
+      await updateOverseasEntity(req, session, appData);
+    } else {
+      await saveAndContinue(req, session);
+    }
 
     return safeRedirect(res, getTrustInvolvedUrl(isUpdate, trustId, req));
+
   } catch (error) {
     logger.errorRequest(req, error);
-
     return next(error);
   }
 };

--- a/test/controllers/update/update.trusts.historical.beneficial.owner.controller.spec.ts
+++ b/test/controllers/update/update.trusts.historical.beneficial.owner.controller.spec.ts
@@ -10,24 +10,20 @@ jest.mock('../../../src/utils/trusts');
 jest.mock('../../../src/utils/trust/common.trust.data.mapper');
 jest.mock('../../../src/middleware/navigation/update/has.presenter.middleware');
 jest.mock('../../../src/middleware/service.availability.middleware');
+jest.mock('../../../src/service/overseas.entities.service');
+jest.mock('../../../src/utils/url');
+
+import { NextFunction, Request, Response } from "express";
+import { constants } from 'http2';
+import { Params } from 'express-serve-static-core';
+import request from "supertest";
+import { Session } from '@companieshouse/node-session-handler';
 
 import mockCsrfProtectionMiddleware from "../../__mocks__/csrfProtectionMiddleware.mock";
-import { constants } from 'http2';
-import { beforeEach, describe, expect, jest, test } from '@jest/globals';
-import { NextFunction, Request, Response } from "express";
-import { Params } from 'express-serve-static-core';
-import { Session } from '@companieshouse/node-session-handler';
-import request from "supertest";
 import app from "../../../src/app";
-import { get, post } from "../../../src/controllers/trust.historical.beneficial.owner.controller";
-import { HISTORICAL_BO_TEXTS } from '../../../src/utils/trust.former.bo';
-import { ANY_MESSAGE_ERROR, PAGE_TITLE_ERROR } from '../../__mocks__/text.mock';
+
 import { authentication } from '../../../src/middleware/authentication.middleware';
 import { hasTrustWithIdUpdate } from '../../../src/middleware/navigation/has.trust.middleware';
-import { UPDATE_TRUSTS_INDIVIDUALS_OR_ENTITIES_INVOLVED_URL, TRUST_HISTORICAL_BENEFICIAL_OWNER_URL } from '../../../src/config';
-import { Trust, TrustHistoricalBeneficialOwner, TrustKey } from '../../../src/model/trust.model';
-import { getApplicationData, setExtraData } from '../../../src/utils/application.data';
-import { getTrustByIdFromApp, saveHistoricalBoInTrust, saveTrustInApp } from '../../../src/utils/trusts';
 import { mapBeneficialOwnerToSession } from '../../../src/utils/trust/historical.beneficial.owner.mapper';
 import { mapCommonTrustDataToPage } from '../../../src/utils/trust/common.trust.data.mapper';
 import { companyAuthentication } from '../../../src/middleware/company.authentication.middleware';
@@ -35,10 +31,29 @@ import { hasUpdatePresenter } from '../../../src/middleware/navigation/update/ha
 import { serviceAvailabilityMiddleware } from '../../../src/middleware/service.availability.middleware';
 import { isActiveFeature } from '../../../src/utils/feature.flag';
 import { ErrorMessages } from '../../../src/validation/error.messages';
+import { updateOverseasEntity } from "../../../src/service/overseas.entities.service";
+import { isRegistrationJourney } from "../../../src/utils/url";
+import { HISTORICAL_BO_TEXTS } from '../../../src/utils/trust.former.bo';
+
+import { get, post } from "../../../src/controllers/trust.historical.beneficial.owner.controller";
+import { Trust, TrustHistoricalBeneficialOwner, TrustKey } from '../../../src/model/trust.model';
+import { fetchApplicationData, getApplicationData, setExtraData } from '../../../src/utils/application.data';
+import { getTrustByIdFromApp, saveHistoricalBoInTrust, saveTrustInApp } from '../../../src/utils/trusts';
+
+import {
+  ANY_MESSAGE_ERROR,
+  PAGE_TITLE_ERROR
+} from '../../__mocks__/text.mock';
+
+import {
+  UPDATE_TRUSTS_INDIVIDUALS_OR_ENTITIES_INVOLVED_URL,
+  TRUST_HISTORICAL_BENEFICIAL_OWNER_URL
+} from '../../../src/config';
 
 mockCsrfProtectionMiddleware.mockClear();
 const mockIsActiveFeature = isActiveFeature as jest.Mock;
 const mockGetApplicationData = getApplicationData as jest.Mock;
+const mockFetchApplicationData = fetchApplicationData as jest.Mock;
 
 const mockAuthentication = (authentication as jest.Mock);
 mockAuthentication.mockImplementation((_, __, next: NextFunction) => next());
@@ -55,7 +70,14 @@ mockHasTrustWithIdUpdate.mockImplementation((_, __, next: NextFunction) => next(
 const mockServiceAvailabilityMiddleware = (serviceAvailabilityMiddleware as jest.Mock);
 mockServiceAvailabilityMiddleware.mockImplementation((_, __, next: NextFunction) => next());
 
+const mockUpdateOverseasEntity = updateOverseasEntity as jest.Mock;
+mockUpdateOverseasEntity.mockReturnValue(true);
+
+const mockIsRegistrationJourney = isRegistrationJourney as jest.Mock;
+mockIsRegistrationJourney.mockReturnValue(false);
+
 describe('Trust Historical Beneficial Owner Controller', () => {
+
   const trustId = '99999';
   const pageUrl = UPDATE_TRUSTS_INDIVIDUALS_OR_ENTITIES_INVOLVED_URL + "/" + trustId + TRUST_HISTORICAL_BENEFICIAL_OWNER_URL;
 
@@ -87,7 +109,6 @@ describe('Trust Historical Beneficial Owner Controller', () => {
   };
 
   let mockAppData = {};
-
   let mockReq = {} as Request;
   const mockRes = {
     render: jest.fn() as any,
@@ -97,9 +118,7 @@ describe('Trust Historical Beneficial Owner Controller', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-
     mockIsActiveFeature.mockReturnValue(true);
-
     mockAppData = {
       [TrustKey]: [
         mockTrust1Data,
@@ -107,7 +126,6 @@ describe('Trust Historical Beneficial Owner Controller', () => {
         mockTrust3Data,
       ],
     };
-
     mockReq = {
       params: {
         trustId: trustId,
@@ -123,21 +141,21 @@ describe('Trust Historical Beneficial Owner Controller', () => {
   describe('GET unit tests', () => {
     test('catch error when renders the page', async () => {
       const error = new Error(ANY_MESSAGE_ERROR);
-      mockGetApplicationData.mockImplementationOnce(() => { throw error; });
-
+      mockFetchApplicationData.mockImplementationOnce(() => { throw error; });
       await get(mockReq, mockRes, mockNext);
-
       expect(mockNext).toBeCalledTimes(1);
       expect(mockNext).toBeCalledWith(error);
     });
   });
 
   describe('POST unit tests', () => {
+
     test('Save', async () => {
       const mockBoData = {} as TrustHistoricalBeneficialOwner;
       (mapBeneficialOwnerToSession as jest.Mock).mockReturnValue(mockBoData);
 
       mockGetApplicationData.mockReturnValue(mockAppData);
+      mockFetchApplicationData.mockReturnValue(mockAppData);
 
       const mockUpdatedTrust = {} as Trust;
       (saveHistoricalBoInTrust as jest.Mock).mockReturnValue(mockBoData);
@@ -152,16 +170,12 @@ describe('Trust Historical Beneficial Owner Controller', () => {
 
       expect(mapBeneficialOwnerToSession).toBeCalledTimes(1);
       expect(mapBeneficialOwnerToSession).toBeCalledWith(mockReq.body);
-
       expect(getTrustByIdFromApp).toBeCalledTimes(1);
       expect(getTrustByIdFromApp).toBeCalledWith(mockAppData, trustId);
-
       expect(saveHistoricalBoInTrust).toBeCalledTimes(1);
       expect(saveHistoricalBoInTrust).toBeCalledWith(mockTrust, mockBoData);
-
       expect(saveTrustInApp).toBeCalledTimes(1);
       expect(saveTrustInApp).toBeCalledWith(mockAppData, mockUpdatedTrust);
-
       expect(setExtraData as jest.Mock).toBeCalledWith(
         mockReq.session,
         mockUpdatedAppData,
@@ -197,7 +211,6 @@ describe('Trust Historical Beneficial Owner Controller', () => {
       expect(resp.text).toContain(PAGE_TITLE_ERROR);
       expect(resp.text).toContain(ErrorMessages.START_DATE_BEFORE_FILING_DATE);
       expect(resp.text).toContain(ErrorMessages.CEASED_DATE_BEFORE_FILING_DATE);
-
       expect(authentication).toBeCalledTimes(1);
       expect(hasTrustWithIdUpdate).toBeCalledTimes(1);
     });
@@ -205,9 +218,7 @@ describe('Trust Historical Beneficial Owner Controller', () => {
     test('catch error when renders the page', async () => {
       const error = new Error(ANY_MESSAGE_ERROR);
       (mapBeneficialOwnerToSession as jest.Mock).mockImplementationOnce(() => { throw error; });
-
       await post(mockReq, mockRes, mockNext);
-
       expect(mockNext).toBeCalledTimes(1);
       expect(mockNext).toBeCalledWith(error);
     });
@@ -222,7 +233,6 @@ describe('Trust Historical Beneficial Owner Controller', () => {
           }
         }
       };
-
       mockReq = {
         session: {} as Session,
         headers: {},
@@ -240,35 +250,29 @@ describe('Trust Historical Beneficial Owner Controller', () => {
       expect(resp.text).toContain(PAGE_TITLE_ERROR);
       expect(resp.text).not.toContain(ErrorMessages.START_DATE_BEFORE_FILING_DATE);
       expect(resp.text).not.toContain(ErrorMessages.CEASED_DATE_BEFORE_FILING_DATE);
-
       expect(authentication).toBeCalledTimes(1);
       expect(hasTrustWithIdUpdate).toBeCalledTimes(1);
     });
   });
 
   describe('Endpoint Access tests', () => {
+
     test('successfully access GET method and render', async () => {
       (mapCommonTrustDataToPage as jest.Mock).mockReturnValue({ trustName: 'dummyName' });
-
       const resp = await request(app).get(pageUrl);
-
       expect(resp.text).toContain('dummyName');
-
       expect(resp.status).toEqual(constants.HTTP_STATUS_OK);
       expect(resp.text).toContain(HISTORICAL_BO_TEXTS.title);
       expect(resp.text).not.toContain(PAGE_TITLE_ERROR);
-
       expect(authentication).toBeCalledTimes(1);
       expect(hasTrustWithIdUpdate).toBeCalledTimes(1);
     });
 
     test('successfully access POST method', async () => {
       const resp = await request(app).post(pageUrl).send({});
-
       expect(resp.status).toEqual(constants.HTTP_STATUS_OK);
       expect(resp.text).toContain(HISTORICAL_BO_TEXTS.title);
       expect(resp.text).toContain(PAGE_TITLE_ERROR);
-
       expect(authentication).toBeCalledTimes(1);
       expect(hasTrustWithIdUpdate).toBeCalledTimes(1);
     });


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/ROE-2671

### Change description

- Retrieves application data from the API for the `trust-historical-beneficial-owner` page/screen
- Modifies tests to match new/updated functionality
- Includes minor formatting changes

### Work checklist

- [x] Tests added where applicable
- [x] UI changes meet accessibility criteria