### PR TITLE
ROECCT-289: Fix Matomo problems caused by Content Security Policy

### DIFF
--- a/views/includes/relevant-period-start-goal-button.html
+++ b/views/includes/relevant-period-start-goal-button.html
@@ -2,10 +2,32 @@
     {{ govukButton({
         text: "Continue",
         attributes: {
-            "id": "submit",
-            "onclick": "_paq.push(['trackGoal', '" + PIWIK_RELEVANT_PERIOD_START_GOAL_ID + "'])"
+            "id": "submit"
         }
     }) }}
 {% else %}
     {% include "includes/continue-button.html" %}
 {% endif %}
+
+<script nonce={{ cspNonce | dump | safe }}>
+    function trackGoal(elementId, goalId) {
+            document
+                .getElementById(elementId)
+                .addEventListener("click", () => {
+                    _paq.push(["trackGoal", goalId]);
+                });
+        }
+
+
+        function addGoalEventListeners() {
+            trackGoal("submit", {{PIWIK_RELEVANT_PERIOD_START_GOAL_ID}} );
+        }
+
+        if (document.readyState === "loading") {
+            document.addEventListener("DOMContentLoaded", function (e) {
+                addGoalEventListeners()
+            });
+        } else {
+            addGoalEventListeners()
+        }
+</script>

--- a/views/includes/remove-start-goal-button.html
+++ b/views/includes/remove-start-goal-button.html
@@ -2,10 +2,32 @@
     {{ govukButton({
         text: "Continue",
         attributes: {
-            "id": "submit",
-            "onclick": "_paq.push(['trackGoal', '" + PIWIK_REMOVE_START_GOAL_ID + "'])"
+            "id": "submit"
         }
     }) }}
 {% else %}
     {% include "includes/continue-button.html" %}
 {% endif %}
+
+<script nonce={{ cspNonce | dump | safe }}>
+    function trackGoal(elementId, goalId) {
+            document
+                .getElementById(elementId)
+                .addEventListener("click", () => {
+                    _paq.push(["trackGoal", goalId]);
+                });
+        }
+
+
+        function addGoalEventListeners() {
+            trackGoal("submit", {{PIWIK_REMOVE_START_GOAL_ID}} );
+        }
+
+        if (document.readyState === "loading") {
+            document.addEventListener("DOMContentLoaded", function (e) {
+                addGoalEventListeners()
+            });
+        } else {
+            addGoalEventListeners()
+        }
+</script>

--- a/views/includes/update-start-goal-button.html
+++ b/views/includes/update-start-goal-button.html
@@ -2,10 +2,32 @@
     {{ govukButton({
         text: "Continue",
         attributes: {
-            "id": "submit",
-            "onclick": "_paq.push(['trackGoal', '" + PIWIK_UPDATE_START_GOAL_ID + "'])"
+            "id": "submit"
         }
     }) }}
 {% else %}
     {% include "includes/continue-button.html" %}
 {% endif %}
+
+<script nonce={{ cspNonce | dump | safe }}>
+    function trackGoal(elementId, goalId) {
+            document
+                .getElementById(elementId)
+                .addEventListener("click", () => {
+                    _paq.push(["trackGoal", goalId]);
+                });
+        }
+
+
+        function addGoalEventListeners() {
+            trackGoal("submit", {{PIWIK_UPDATE_START_GOAL_ID}} );
+        }
+
+        if (document.readyState === "loading") {
+            document.addEventListener("DOMContentLoaded", function (e) {
+                addGoalEventListeners()
+            });
+        } else {
+            addGoalEventListeners()
+        }
+</script>


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/ROECCT-289

### Change description

Problems have been identified with Matomo not tracking some goals properly. This was caused by some Matomo scripts being blocked by the Content Security Policy. These changes should address these issues, allowing Matomo to track goals properly again.

### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
