### PR TITLE
ROECCT-507: Fix Matomo problems caused by Content Security Policy

### DIFF
--- a/views/includes/piwik-goal.html
+++ b/views/includes/piwik-goal.html
@@ -8,7 +8,9 @@
   }
 
   function addGoalEventListeners() {
-    {% if (journey == "remove") %}
+    {% if (journey == "register") %}
+    trackGoal("continue", {{PIWIK_START_GOAL_ID}} );
+    {% elif (journey == "remove") %}
     trackGoal("submit", {{PIWIK_REMOVE_START_GOAL_ID}} );
     {% elif (update.owned_land_relevant_period == 1) %}
     trackGoal("submit", {{PIWIK_RELEVANT_PERIOD_START_GOAL_ID}} );

--- a/views/interrupt-card.html
+++ b/views/interrupt-card.html
@@ -33,9 +33,10 @@
 
         {% endif %}
 
-    <a href="{{pageParams.nextPageUrl}}" id="continue" onclick="_paq.push(['trackGoal', '{{PIWIK_START_GOAL_ID}}'])" role="button" draggable="false" class="govuk-button" data-module="govuk-button">
+    <a href="{{pageParams.nextPageUrl}}" id="continue" role="button" draggable="false" class="govuk-button" data-module="govuk-button">
       Continue
     </a>
+    {%  include "includes/piwik-goal.html" %}
 
       </div>
     </div>


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/ROECCT-507

### Change description

Problems have been identified with Matomo not tracking some goals properly. This was caused by some Matomo scripts being blocked by the Content Security Policy. These changes should address these issues, allowing Matomo to track goals properly again.

This is a continuation of the #1690 . The registration journey was identified to not be tracking goals. This ticket fixes this issue.

### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
