### PR TITLE
feat/roe-2732: redirect to correct url from beneficial-owner-delete-warning page

### DIFF
--- a/src/controllers/beneficial.owner.delete.warning.controller.ts
+++ b/src/controllers/beneficial.owner.delete.warning.controller.ts
@@ -55,6 +55,7 @@ export const post = async (req: Request, res: Response, next: NextFunction): Pro
   try {
 
     logger.debugRequest(req, `POST ${config.BENEFICIAL_OWNER_DELETE_WARNING_PAGE}`);
+    let nextPageUrl: string;
 
     if (req.body["delete_beneficial_owners"] === '1') {
       const boStatement = req.body[BeneficialOwnerStatementKey];
@@ -77,14 +78,19 @@ export const post = async (req: Request, res: Response, next: NextFunction): Pro
         await updateOverseasEntity(req, req.session as Session, appData);
       }
       setExtraData(req.session, appData);
-      const nextPageUrl = isActiveFeature(config.FEATURE_FLAG_ENABLE_REDIS_REMOVAL)
+      nextPageUrl = isActiveFeature(config.FEATURE_FLAG_ENABLE_REDIS_REMOVAL)
         ? getUrlWithParamsToPath(config.BENEFICIAL_OWNER_TYPE_WITH_PARAMS_URL, req)
         : config.BENEFICIAL_OWNER_TYPE_URL;
 
       return res.redirect(nextPageUrl);
     }
 
-    return res.redirect(config.BENEFICIAL_OWNER_STATEMENTS_URL);
+    nextPageUrl = isActiveFeature(config.FEATURE_FLAG_ENABLE_REDIS_REMOVAL)
+      ? getUrlWithParamsToPath(config.BENEFICIAL_OWNER_STATEMENTS_WITH_PARAMS_URL, req)
+      : config.BENEFICIAL_OWNER_STATEMENTS_URL;
+
+    return res.redirect(nextPageUrl);
+
   } catch (error) {
     logger.errorRequest(req, error);
     next(error);

--- a/test/controllers/beneficial.owner.delete.warning.controller.spec.ts
+++ b/test/controllers/beneficial.owner.delete.warning.controller.spec.ts
@@ -144,7 +144,7 @@ describe("BENEFICIAL OWNER DELETE WARNING controller", () => {
   });
 
   describe("POST tests", () => {
-    test("redirects to the beneficial owner type page if No option has been selected", async () => {
+    test("redirects to the beneficial owner type page if No option has been selected and REDIS_removal flag is set to OFF", async () => {
       const resp = await request(app)
         .post(config.BENEFICIAL_OWNER_DELETE_WARNING_URL)
         .send({ delete_beneficial_owners: "0" });
@@ -157,7 +157,21 @@ describe("BENEFICIAL OWNER DELETE WARNING controller", () => {
       expect(mockUpdateOverseasEntity).not.toHaveBeenCalled();
     });
 
-    test(`redirects to the beneficial owner type page if Yes option has been selected and REDIS_removal flag is set to ON and
+    test("redirects to the beneficial owner type page if No option has been selected and REDIS_removal flag is set to ON", async () => {
+      const resp = await request(app)
+        .post(config.BENEFICIAL_OWNER_DELETE_WARNING_WITH_PARAMS_URL)
+        .send({ delete_beneficial_owners: "0" });
+      mockIsActiveFeature.mockReturnValueOnce(true);
+      mockIsActiveFeature.mockReturnValueOnce(true);
+      expect(resp.status).toEqual(302);
+      expect(resp.header.location).toEqual(config.BENEFICIAL_OWNER_STATEMENTS_URL);
+      expect(mockSetExtraData).not.toHaveBeenCalled();
+      expect(mockCheckBOsDetailsEntered).not.toHaveBeenCalled();
+      expect(mockCheckMOsDetailsEntered).not.toHaveBeenCalled();
+      expect(mockUpdateOverseasEntity).not.toHaveBeenCalled();
+    });
+
+    test(`redirects to the beneficial owner type page if Yes option has been selected when REDIS_removal flag is set to ON and
         ${BeneficialOwnersStatementType.SOME_IDENTIFIED_ALL_DETAILS} as statement type`, async () => {
 
       mockFetchApplicationData.mockReturnValueOnce(APPLICATION_DATA_MOCK);


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/ROE-2732

### Change description

Redirects to correct url from `beneficial-owner-delete-warning` page when REDIS_removal flag is set to `ON`

### Work checklist

- [x] Tests added where applicable
- [x] UI changes meet accessibility criteria
