### PR TITLE
ROECCT-514: Remove personal information shown in Overseas Entity ID validation message

### DIFF
--- a/src/controllers/update/overseas.entity.query.controller.ts
+++ b/src/controllers/update/overseas.entity.query.controller.ts
@@ -70,8 +70,8 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
   }
 };
 
-function createEntityNumberError(entityNumber: string): any {
-  const msg = `An Overseas Entity with OE number "${entityNumber}" was not found.`;
+function createEntityNumberError(): any {
+  const msg = `Enter a correct Overseas Entity ID.`;
   const errors = { errorList: [] } as any;
   errors.errorList.push({ href: "#entity_number", text: msg });
   errors.entity_number = { text: msg };
@@ -79,7 +79,7 @@ function createEntityNumberError(entityNumber: string): any {
 }
 
 const renderGetPageWithError = async (req: Request, res: Response, entityNumber: any) => {
-  const errors = createEntityNumberError(entityNumber);
+  const errors = createEntityNumberError();
   const isRemove: boolean = await isRemoveJourney(req);
 
   if (isRemove) {

--- a/test/controllers/update/overseas.entity.query.controller.spec.ts
+++ b/test/controllers/update/overseas.entity.query.controller.spec.ts
@@ -35,7 +35,7 @@ import { ApplicationData } from "../../../src/model";
 
 const testOENumber = "OE123456";
 const invalidOENUmberError = "OE number must be &quot;OE&quot; followed by 6 digits";
-const notFoundOENumberError = "An Overseas Entity with OE number &quot;" + testOENumber + "&quot; was not found";
+const notFoundOENumberError = "Enter a correct Overseas Entity ID";
 
 mockJourneyDetectionMiddleware.mockClear();
 mockCsrfProtectionMiddleware.mockClear();


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/ROECCT-514

### Change description

Personal info is being sent to Matomo via the Overseas Entity ID validation message. This PR changes the validation message to prevent further info from being sent.

### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
