### PR TITLE
ROECCT-528: Bugfix - Incorrect Radio Button Selected

### DIFF
--- a/views/includes/page-templates/relevant-period-statements-add-radios.html
+++ b/views/includes/page-templates/relevant-period-statements-add-radios.html
@@ -6,7 +6,7 @@
 
 {{ govukRadios({
     errorMessage: errors.beneficial_owner_type if errors,
-    idPrefix: "beneficial_owner_type",
+    idPrefix: "beneficial_owner_type_relevant_period",
     name: "beneficial_owner_type",
     fieldset: {
     legend: {

--- a/views/includes/page-templates/trust-involved.html
+++ b/views/includes/page-templates/trust-involved.html
@@ -173,6 +173,7 @@
         {% include "includes/csrf_token.html" %}
 
         {% set fieldParam = {
+          id: "typeOfTrustee",
           name: 'typeOfTrustee',
           label: 'Which type of individual or entity do you want to add to this trust?',
           error: errors.typeOfTrustee,
@@ -220,6 +221,7 @@
           </div>
 
           {% set fieldParam = {
+            id: "typeOfTrusteeRelevantPeriod",
             name: 'typeOfTrustee',
             error: errors.typeOfTrustee,
             items: [


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/ROECCT-528

### Change description

Clicking on the text of radio buttons from the pre-registration period would make the user select a radio button that is not from the pre-registration period. This ticket should address these issues by assigning a unique ID for the two sets of radio buttons.

Please note that this is minor bugfix - users can click on the radio button circle to achieve their intended goal.

### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
