### PR TITLE
ROECCT-515: Allow lowercase entity number for OE query

### DIFF
--- a/src/validation/overseas.entity.query.validation.ts
+++ b/src/validation/overseas.entity.query.validation.ts
@@ -5,6 +5,7 @@ import { VALID_OE_NUMBER_FORMAT } from "./regex/regex.validation";
 
 export const overseasEntityQuery = [
   body("entity_number")
+    .toUpperCase()
     .not().isEmpty({ ignore_whitespace: true })
     .withMessage(ErrorMessages.OE_QUERY_NUMBER)
     .trim()

--- a/test/controllers/update/overseas.entity.query.controller.spec.ts
+++ b/test/controllers/update/overseas.entity.query.controller.spec.ts
@@ -34,6 +34,7 @@ import { retrieveBoAndMoData } from "../../../src/utils/update/beneficial_owners
 import { ApplicationData } from "../../../src/model";
 
 const testOENumber = "OE123456";
+const testOENumberLowercase = "oe123456";
 const invalidOENUmberError = "OE number must be &quot;OE&quot; followed by 6 digits";
 const notFoundOENumberError = "Enter a correct Overseas Entity ID";
 
@@ -173,7 +174,7 @@ describe("OVERSEAS ENTITY QUERY controller", () => {
 
       const resp = await request(app)
         .post(config.OVERSEAS_ENTITY_QUERY_URL)
-        .send({ entity_number: 'oe111129' });
+        .send({ entity_number: testOENumberLowercase });
       expect(resp.status).toEqual(302);
       expect(mockRetrieveBoAndMoData).toHaveBeenCalledTimes(1);
       expect(mockSetExtraData).toHaveBeenCalledTimes(1);

--- a/test/controllers/update/overseas.entity.query.controller.spec.ts
+++ b/test/controllers/update/overseas.entity.query.controller.spec.ts
@@ -93,7 +93,7 @@ describe("OVERSEAS ENTITY QUERY controller", () => {
 
   describe("POST tests", () => {
 
-    const invalid_input_values = ['OE123', 'EO123456', 'OE123456789'];
+    const invalid_input_values = ['OE123', 'EO123456', 'OE123456789', 'eo123456'];
 
     test.each(invalid_input_values)(
       "given %p, renders OVERSEAS_ENTITY_QUERY_PAGE with validator failure", async (input_value) => {
@@ -166,6 +166,20 @@ describe("OVERSEAS ENTITY QUERY controller", () => {
       expect(resp.header.location).toEqual(config.UPDATE_AN_OVERSEAS_ENTITY_URL + config.CONFIRM_OVERSEAS_ENTITY_DETAILS_PAGE);
     });
 
+    test('redirects to confirm page for valid oe number with lowercase oe in update journey', async () => {
+      mockGetApplicationData.mockReturnValue({});
+      mockGetCompanyProfile.mockReturnValueOnce(companyProfileQueryMock);
+      mockMapCompanyProfileToOverseasEntity.mockReturnValueOnce({});
+
+      const resp = await request(app)
+        .post(config.OVERSEAS_ENTITY_QUERY_URL)
+        .send({ entity_number: 'oe111129' });
+      expect(resp.status).toEqual(302);
+      expect(mockRetrieveBoAndMoData).toHaveBeenCalledTimes(1);
+      expect(mockSetExtraData).toHaveBeenCalledTimes(1);
+      expect(resp.header.location).toEqual(config.UPDATE_AN_OVERSEAS_ENTITY_URL + config.CONFIRM_OVERSEAS_ENTITY_DETAILS_PAGE);
+    });
+
     test('redirects to confirm page for valid oe number in remove journey', async () => {
       mockGetApplicationData.mockReturnValue({});
       mockGetCompanyProfile.mockReturnValueOnce(companyProfileQueryMock);
@@ -190,7 +204,7 @@ describe("OVERSEAS ENTITY QUERY controller", () => {
       expect(resp.text).toContain(SERVICE_UNAVAILABLE);
     });
 
-    const values_without_trim = [' OE123456', 'OE123456 ', ' OE123456 '];
+    const values_without_trim = [' OE123456', 'OE123456 ', ' OE123456 ', '  oe123456  '];
 
     test.each(values_without_trim)(
       "trims the whitespaces and allows user to continue", async (input_value) => {


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/ROECCT-515

### Change description

Matomo errors that users are experiencing:

OE number must be "OE" followed by 6 digits.  This error seems to occur when the user has put in a lower case oe.

This change converts the OE ID during validation to uppercase, preventing the error when users input a lowercase `oe`.

### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
