### PR TITLE
ROECCT-259: Update Trusts Associated with Entity Back Link

### DIFF
--- a/src/utils/add.trust.ts
+++ b/src/utils/add.trust.ts
@@ -166,13 +166,11 @@ const getPageTemplate = (isUpdate: boolean) => {
 };
 
 const getBackLinkUrl = (isUpdate: boolean, req: Request, appData: ApplicationData) => {
-  if (isUpdate) {
-    const trustId = getTrustArray(appData).length;
-    if (trustId > 0) {
-      return `${config.UPDATE_TRUSTS_INDIVIDUALS_OR_ENTITIES_INVOLVED_URL}/${trustId}${config.TRUST_INVOLVED_URL}`;
-    } else {
-      return config.UPDATE_BENEFICIAL_OWNER_TYPE_URL;
-    }
+  const trustId = getTrustArray(appData).length;
+  if (isUpdate && trustId > 0) {
+    return `${config.UPDATE_TRUSTS_INDIVIDUALS_OR_ENTITIES_INVOLVED_URL}/${trustId}${config.TRUST_INVOLVED_URL}`;
+  } else if (isUpdate) {
+    return config.UPDATE_BENEFICIAL_OWNER_TYPE_URL;
   } else {
     return isActiveFeature(config.FEATURE_FLAG_ENABLE_REDIS_REMOVAL)
       ? getUrlWithParamsToPath(config.BENEFICIAL_OWNER_TYPE_WITH_PARAMS_URL, req)

--- a/src/utils/add.trust.ts
+++ b/src/utils/add.trust.ts
@@ -52,7 +52,7 @@ const getPageProperties = async (
   // note: isUpdate covers both Update and Remove journeys, so when on Remove journey isUpdate will be true.
   return {
     templateName: getPageTemplate(isUpdate),
-    backLinkUrl: getBackLinkUrl(isUpdate, req),
+    backLinkUrl: getBackLinkUrl(isUpdate, req, appData),
     ...appData,
     pageData: {
       trustData: getTrustArray(appData),
@@ -165,9 +165,14 @@ const getPageTemplate = (isUpdate: boolean) => {
   }
 };
 
-const getBackLinkUrl = (isUpdate: boolean, req: Request) => {
+const getBackLinkUrl = (isUpdate: boolean, req: Request, appData: ApplicationData) => {
   if (isUpdate) {
-    return config.UPDATE_BENEFICIAL_OWNER_TYPE_URL;
+    const trustId = getTrustArray(appData).length;
+    if (trustId > 0) {
+      return `${config.UPDATE_TRUSTS_INDIVIDUALS_OR_ENTITIES_INVOLVED_URL}/${trustId}${config.TRUST_INVOLVED_URL}`;
+    } else {
+      return config.UPDATE_BENEFICIAL_OWNER_TYPE_URL;
+    }
   } else {
     return isActiveFeature(config.FEATURE_FLAG_ENABLE_REDIS_REMOVAL)
       ? getUrlWithParamsToPath(config.BENEFICIAL_OWNER_TYPE_WITH_PARAMS_URL, req)

--- a/src/utils/trust.details.ts
+++ b/src/utils/trust.details.ts
@@ -258,7 +258,7 @@ const getBackLinkUrl = (isUpdate: boolean, appData: ApplicationData, req: Reques
   if (isUpdate) {
     backLinkUrl = config.UPDATE_TRUSTS_SUBMISSION_INTERRUPT_URL;
     if (containsTrustData(getTrustArray(appData))) {
-      backLinkUrl = `${config.UPDATE_TRUSTS_ASSOCIATED_WITH_THE_OVERSEAS_ENTITY_URL}`;
+      backLinkUrl = `${config.UPDATE_BENEFICIAL_OWNER_TYPE_URL}`;
     }
   } else {
     backLinkUrl = isActiveFeature(config.FEATURE_FLAG_ENABLE_REDIS_REMOVAL)

--- a/test/controllers/update/update.trusts.associated.with.entity.controller.spec.ts
+++ b/test/controllers/update/update.trusts.associated.with.entity.controller.spec.ts
@@ -32,8 +32,8 @@ import {
 import {
   UPDATE_TRUSTS_ASSOCIATED_WITH_THE_OVERSEAS_ENTITY_URL,
   UPDATE_TRUSTS_TELL_US_ABOUT_IT_PAGE,
-  UPDATE_BENEFICIAL_OWNER_TYPE_URL,
   UPDATE_BENEFICIAL_OWNER_STATEMENTS_URL,
+  UPDATE_TRUSTS_INDIVIDUALS_OR_ENTITIES_INVOLVED_URL,
 } from '../../../src/config';
 
 import {
@@ -97,7 +97,7 @@ describe('Update - Trusts - Trusts associated with the overseas entity', () => {
 
       expect(resp.status).toEqual(200);
       expect(resp.text).toContain('Trusts associated with the overseas entity');
-      expect(resp.text).toContain(UPDATE_BENEFICIAL_OWNER_TYPE_URL);
+      expect(resp.text).toContain(UPDATE_TRUSTS_INDIVIDUALS_OR_ENTITIES_INVOLVED_URL);
       expect(resp.text).toContain(SAVE_AND_CONTINUE_BUTTON_TEXT);
       expect(resp.text).not.toContain(PAGE_TITLE_ERROR);
       if (isAddTrustsOptionToBeShown) {

--- a/test/controllers/update/update.trusts.tell.us.about.it.controller.spec.ts
+++ b/test/controllers/update/update.trusts.tell.us.about.it.controller.spec.ts
@@ -22,11 +22,11 @@ import { fetchApplicationData, getApplicationData } from '../../../src/utils/app
 
 import {
   TRUST_INVOLVED_URL,
-  UPDATE_TRUSTS_ASSOCIATED_WITH_THE_OVERSEAS_ENTITY_URL,
   UPDATE_TRUSTS_INDIVIDUALS_OR_ENTITIES_INVOLVED_URL,
   UPDATE_TRUSTS_SUBMISSION_INTERRUPT_URL,
   UPDATE_TRUSTS_TELL_US_ABOUT_IT_URL,
-  RELEVANT_PERIOD_QUERY_PARAM
+  RELEVANT_PERIOD_QUERY_PARAM,
+  UPDATE_BENEFICIAL_OWNER_TYPE_URL
 } from '../../../src/config';
 
 import {
@@ -82,7 +82,7 @@ describe('Update - Trusts - Tell us about the trust', () => {
       expect(resp.status).toEqual(200);
       expect(resp.text).toContain(UPDATE_TELL_US_ABOUT_TRUST_HEADING);
       expect(resp.text).toContain(UPDATE_TELL_US_ABOUT_TRUST_QUESTION);
-      expect(resp.text).toContain(UPDATE_TRUSTS_ASSOCIATED_WITH_THE_OVERSEAS_ENTITY_URL);
+      expect(resp.text).toContain(UPDATE_BENEFICIAL_OWNER_TYPE_URL);
       expect(resp.text).toContain(SAVE_AND_CONTINUE_BUTTON_TEXT);
       expect(resp.text).not.toContain(PAGE_TITLE_ERROR);
     });


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/ROECCT-259

### Change description

Update Trusts associated with entity back button link so users aren't redirected to the start of Update Beneficial Owner Type page after reviewing a trust.

### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
