### PR TITLE
ROECCT-230: Back button from 'date of update' for relevant period journey

### DIFF
--- a/src/controllers/update/update.filing.date.controller.ts
+++ b/src/controllers/update/update.filing.date.controller.ts
@@ -11,14 +11,14 @@ import { FilingDateKey, FilingDateKeys } from '../../model/date.model';
 import { ApplicationData } from "../../model/application.model";
 import { getConfirmationStatementNextMadeUpToDateAsIsoString } from "../../service/company.profile.service";
 import { convertIsoDateToInputDate } from "../../utils/date";
-import { checkRelevantPeriod } from "../../utils/relevant.period";
+import { checkAnyRPStatementsActionWasTaken } from "../../utils/relevant.period";
 
 export const get = async (req: Request, res: Response, next: NextFunction) => {
   try {
     logger.debugRequest(req, `${req.method} ${req.route.path}`);
 
     const appData = await getApplicationData(req.session);
-    const backLinkUrl = !checkRelevantPeriod(appData) ? config.RELEVANT_PERIOD_OWNED_LAND_FILTER_URL : config.RELEVANT_PERIOD_REVIEW_STATEMENTS_URL + config.RELEVANT_PERIOD_QUERY_PARAM;
+    const backLinkUrl = !checkAnyRPStatementsActionWasTaken(appData) ? config.RELEVANT_PERIOD_OWNED_LAND_FILTER_URL : config.RELEVANT_PERIOD_REVIEW_STATEMENTS_URL + config.RELEVANT_PERIOD_QUERY_PARAM;
 
     return res.render(config.UPDATE_FILING_DATE_PAGE, {
       backLinkUrl,

--- a/src/utils/relevant.period.ts
+++ b/src/utils/relevant.period.ts
@@ -9,3 +9,11 @@ export const checkRPStatementsExist = (appData: ApplicationData): boolean =>
   (!!appData.update?.change_bo_relevant_period && appData.update?.change_bo_relevant_period !== "NO_CHANGE_BO_RELEVANT_PERIOD") ||
   (!!appData.update?.trustee_involved_relevant_period && appData.update?.trustee_involved_relevant_period !== "NO_TRUSTEE_INVOLVED_RELEVANT_PERIOD") ||
   (!!appData.update?.change_beneficiary_relevant_period && appData.update?.change_beneficiary_relevant_period !== "NO_CHANGE_BENEFICIARY_RELEVANT_PERIOD");
+
+export const checkAnyRPStatementsActionWasTaken = (appData: ApplicationData): boolean =>
+  appData.update?.change_bo_relevant_period === "CHANGE_BO_RELEVANT_PERIOD" ||
+  appData.update?.change_bo_relevant_period === "NO_CHANGE_BO_RELEVANT_PERIOD" ||
+  appData.update?.trustee_involved_relevant_period === "TRUSTEE_INVOLVED_RELEVANT_PERIOD" ||
+  appData.update?.trustee_involved_relevant_period === "NO_TRUSTEE_INVOLVED_RELEVANT_PERIOD" ||
+  appData.update?.change_beneficiary_relevant_period === "CHANGE_BENEFICIARY_RELEVANT_PERIOD" ||
+  appData.update?.change_beneficiary_relevant_period === "NO_CHANGE_BENEFICIARY_RELEVANT_PERIOD";

--- a/test/controllers/update/update.filing.date.controller.spec.ts
+++ b/test/controllers/update/update.filing.date.controller.spec.ts
@@ -30,7 +30,7 @@ import { ErrorMessages } from "../../../src/validation/error.messages";
 import { getConfirmationStatementNextMadeUpToDateAsIsoString } from "../../../src/service/company.profile.service";
 import { isActiveFeature } from "../../../src/utils/feature.flag";
 import { hasOverseasEntity } from "../../../src/middleware/navigation/update/has.overseas.entity.middleware";
-import { checkRelevantPeriod } from "../../../src/utils/relevant.period";
+import { checkAnyRPStatementsActionWasTaken } from "../../../src/utils/relevant.period";
 import { FILING_DATE_REQ_BODY_MOCK } from '../../__mocks__/fields/date.mock';
 import { isRegistrationJourney } from "../../../src/utils/url";
 
@@ -106,7 +106,7 @@ mockServiceAvailabilityMiddleware.mockImplementation((req: Request, res: Respons
 const mockIsActiveFeature = isActiveFeature as jest.Mock;
 mockIsActiveFeature.mockReturnValue(true);
 
-const mockCheckRelevantPeriod = checkRelevantPeriod as jest.Mock;
+const mockCheckRelevantPeriodActionTaken = checkAnyRPStatementsActionWasTaken as jest.Mock;
 
 const mockIsRegistrationJourney = isRegistrationJourney as jest.Mock;
 mockIsRegistrationJourney.mockReturnValue(false);
@@ -125,7 +125,7 @@ describe("Update Filing Date controller", () => {
 
   describe("GET tests", () => {
     test('renders the update-filing-date page when FEATURE_FLAG_ENABLE_RELEVANT_PERIOD is not active,', async () => {
-      mockCheckRelevantPeriod.mockReturnValueOnce(false);
+      mockCheckRelevantPeriodActionTaken.mockReturnValueOnce(false);
       const resp = await request(app).get(config.UPDATE_FILING_DATE_URL);
 
       expect(resp.status).toEqual(200);
@@ -137,8 +137,16 @@ describe("Update Filing Date controller", () => {
       expect(resp.text).toContain('href="test"');
     });
 
+    test('renders the review-statements-for-the-pre-registration-period page when any action has been taken for relevant period is active,', async () => {
+      mockCheckRelevantPeriodActionTaken.mockReturnValueOnce(true);
+      const resp = await request(app).get(config.UPDATE_FILING_DATE_URL);
+
+      expect(resp.status).toEqual(200);
+      expect(resp.text).toContain("/update-an-overseas-entity/review-statements-for-the-pre-registration-period?relevant-period=true");
+    });
+
     test('renders the update-filing-date page when FEATURE_FLAG_ENABLE_RELEVANT_PERIOD is active,', async () => {
-      mockCheckRelevantPeriod.mockReturnValueOnce(true);
+      mockCheckRelevantPeriodActionTaken.mockReturnValueOnce(true);
       const resp = await request(app).get(config.UPDATE_FILING_DATE_URL);
 
       expect(resp.status).toEqual(200);
@@ -148,7 +156,7 @@ describe("Update Filing Date controller", () => {
     test('renders the update-filing-date page with no update session data', async () => {
       const mockData = { ...UPDATE_ENTITY_BODY_OBJECT_MOCK_WITH_ADDRESS, entity_number: 'OE111129' };
       mockGetApplicationData.mockReturnValueOnce(mockData);
-      mockCheckRelevantPeriod.mockReturnValueOnce(false);
+      mockCheckRelevantPeriodActionTaken.mockReturnValueOnce(false);
 
       const resp = await request(app).get(config.UPDATE_FILING_DATE_URL);
 
@@ -164,7 +172,7 @@ describe("Update Filing Date controller", () => {
     test('renders the update-filing-date page with update session data', async () => {
       const mockData = { ...APPLICATION_DATA_MOCK };
       mockGetApplicationData.mockReturnValueOnce(mockData);
-      mockCheckRelevantPeriod.mockReturnValueOnce(false);
+      mockCheckRelevantPeriodActionTaken.mockReturnValueOnce(false);
 
       const resp = await request(app).get(config.UPDATE_FILING_DATE_URL);
 
@@ -180,7 +188,7 @@ describe("Update Filing Date controller", () => {
     test('does not fetch private overseas entity data to app data if already exists', async () => {
       const mockData = { ...APPLICATION_DATA_MOCK };
       mockGetApplicationData.mockReturnValueOnce(mockData);
-      mockCheckRelevantPeriod.mockReturnValueOnce(false);
+      mockCheckRelevantPeriodActionTaken.mockReturnValueOnce(false);
 
       const resp = await request(app).get(config.UPDATE_FILING_DATE_URL);
 

--- a/test/utils/relevant.period.spec.ts
+++ b/test/utils/relevant.period.spec.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, test, jest } from '@jest/globals';
-import { checkRelevantPeriod, checkRPStatementsExist } from '../../src/utils/relevant.period';
+import { checkRelevantPeriod, checkRPStatementsExist, checkAnyRPStatementsActionWasTaken } from '../../src/utils/relevant.period';
 import {
   APPLICATION_DATA_UPDATE_BO_MOCK,
   UPDATE_OBJECT_MOCK_RELEVANT_PERIOD_CHANGE,
@@ -14,6 +14,7 @@ const appData = {
 
 const mockCheckRelevantPeriod = checkRelevantPeriod as jest.Mock;
 const mockCheckRPStatementsExist = checkRPStatementsExist as jest.Mock;
+const mockCheckAnyRPStatementsActionWasTaken = checkAnyRPStatementsActionWasTaken as jest.Mock;
 
 describe('relevant period test suite', () => {
   describe('check relevant period', () => {
@@ -177,6 +178,101 @@ describe('relevant period test suite', () => {
       expect(appData.update).toHaveProperty("change_bo_relevant_period", null);
       expect(appData.update).toHaveProperty("trustee_involved_relevant_period", null);
       expect(appData.update).toHaveProperty("change_beneficiary_relevant_period", null);
+    });
+  });
+  describe('check Any RP statements action was taken', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+
+      appData.update = {
+        change_bo_relevant_period: undefined,
+        trustee_involved_relevant_period: undefined,
+        change_beneficiary_relevant_period: undefined
+      };
+    });
+
+    test('should return true if change_bo_relevant_period is "CHANGE_BO_RELEVANT_PERIOD"', () => {
+      appData.update = { change_bo_relevant_period: "CHANGE_BO_RELEVANT_PERIOD" };
+
+      expect(mockCheckAnyRPStatementsActionWasTaken(appData)).toBeTruthy();
+
+      expect(appData.update).toHaveProperty("change_bo_relevant_period", "CHANGE_BO_RELEVANT_PERIOD");
+    });
+
+    test('should return true if change_bo_relevant_period is "NO_CHANGE_BO_RELEVANT_PERIOD"', () => {
+      appData.update = { change_bo_relevant_period: "NO_CHANGE_BO_RELEVANT_PERIOD" };
+
+      expect(mockCheckAnyRPStatementsActionWasTaken(appData)).toBeTruthy();
+
+      expect(appData.update).toHaveProperty("change_bo_relevant_period", "NO_CHANGE_BO_RELEVANT_PERIOD");
+    });
+
+    test('should return true if trustee_involved_relevant_period is "TRUSTEE_INVOLVED_RELEVANT_PERIOD"', () => {
+      appData.update = { trustee_involved_relevant_period: "TRUSTEE_INVOLVED_RELEVANT_PERIOD" };
+
+      expect(mockCheckAnyRPStatementsActionWasTaken(appData)).toBeTruthy();
+
+      expect(appData.update).toHaveProperty("trustee_involved_relevant_period", "TRUSTEE_INVOLVED_RELEVANT_PERIOD");
+    });
+
+    test('should return true if trustee_involved_relevant_period is "NO_TRUSTEE_INVOLVED_RELEVANT_PERIOD"', () => {
+      appData.update = { trustee_involved_relevant_period: "NO_TRUSTEE_INVOLVED_RELEVANT_PERIOD" };
+
+      expect(mockCheckAnyRPStatementsActionWasTaken(appData)).toBeTruthy();
+
+      expect(appData.update).toHaveProperty("trustee_involved_relevant_period", "NO_TRUSTEE_INVOLVED_RELEVANT_PERIOD");
+    });
+
+    test('should return true if change_beneficiary_relevant_period is "CHANGE_BENEFICIARY_RELEVANT_PERIOD"', () => {
+      appData.update = { change_beneficiary_relevant_period: "CHANGE_BENEFICIARY_RELEVANT_PERIOD" };
+
+      expect(mockCheckAnyRPStatementsActionWasTaken(appData)).toBeTruthy();
+
+      expect(appData.update).toHaveProperty("change_beneficiary_relevant_period", "CHANGE_BENEFICIARY_RELEVANT_PERIOD");
+    });
+
+    test('should return true if change_beneficiary_relevant_period is "NO_CHANGE_BENEFICIARY_RELEVANT_PERIOD"', () => {
+      appData.update = { change_beneficiary_relevant_period: "NO_CHANGE_BENEFICIARY_RELEVANT_PERIOD" };
+
+      expect(mockCheckAnyRPStatementsActionWasTaken(appData)).toBeTruthy();
+
+      expect(appData.update).toHaveProperty("change_beneficiary_relevant_period", "NO_CHANGE_BENEFICIARY_RELEVANT_PERIOD");
+    });
+
+    test('should return false if all relevant periods are undefined', () => {
+      expect(mockCheckAnyRPStatementsActionWasTaken(appData)).toBeFalsy();
+
+      expect(appData.update).toHaveProperty("change_bo_relevant_period", undefined);
+      expect(appData.update).toHaveProperty("trustee_involved_relevant_period", undefined);
+      expect(appData.update).toHaveProperty("change_beneficiary_relevant_period", undefined);
+    });
+
+    test('should return false if all relevant periods are null', () => {
+      appData.update = {
+        change_bo_relevant_period: null,
+        trustee_involved_relevant_period: null,
+        change_beneficiary_relevant_period: null
+      };
+
+      expect(mockCheckAnyRPStatementsActionWasTaken(appData)).toBeFalsy();
+
+      expect(appData.update).toHaveProperty("change_bo_relevant_period", null);
+      expect(appData.update).toHaveProperty("trustee_involved_relevant_period", null);
+      expect(appData.update).toHaveProperty("change_beneficiary_relevant_period", null);
+    });
+
+    test('should return false if relevant periods contain invalid values', () => {
+      appData.update = {
+        change_bo_relevant_period: "INVALID_VALUE",
+        trustee_involved_relevant_period: "INVALID_VALUE",
+        change_beneficiary_relevant_period: "INVALID_VALUE"
+      };
+
+      expect(mockCheckAnyRPStatementsActionWasTaken(appData)).toBeFalsy();
+
+      expect(appData.update).toHaveProperty("change_bo_relevant_period", "INVALID_VALUE");
+      expect(appData.update).toHaveProperty("trustee_involved_relevant_period", "INVALID_VALUE");
+      expect(appData.update).toHaveProperty("change_beneficiary_relevant_period", "INVALID_VALUE");
     });
   });
 });


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/ROECCT-230


### Change description

On the ‘date of your update’ page, when pressing the back button, the person should go back through the ‘review statements’ page and ‘select statements’ before going back to the filter page. This PR is fix of previous fix where we found one Scenario was not working when none of the above was selected.

### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
