### PR TITLE
ROECCT-236: Fix- Correct relevant period validation check for PSC statements

### DIFF
--- a/src/controllers/update/confirm.overseas.entity.details.controller.ts
+++ b/src/controllers/update/confirm.overseas.entity.details.controller.ts
@@ -9,6 +9,7 @@ import { isRemoveJourney } from "../../utils/url";
 import { CompanyPersonsWithSignificantControlStatements } from "@companieshouse/api-sdk-node/dist/services/company-psc-statements/types";
 import { isActiveFeature } from "../../utils/feature.flag";
 import { getCompanyPscStatements } from "../../service/persons.with.signficant.control.statement.service";
+import { relevantPeriodPscStatements } from "../../utils/relevant.period";
 
 export const relevantPeriodStatementsState = {
   has_answered_relevant_period_question: false,
@@ -60,7 +61,7 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
 
     if (appData.entity && appData.entity_number) {
       const statements: CompanyPersonsWithSignificantControlStatements = await getCompanyPscStatements(req, appData.entity_number);
-      relevantPeriodStatementsState.has_answered_relevant_period_question = statements?.items?.length > 0;
+      relevantPeriodStatementsState.has_answered_relevant_period_question = statements?.items?.length > 0 && relevantPeriodPscStatements.has(statements.items?.[0].statement);
 
       if (isActiveFeature(config.FEATURE_FLAG_ENABLE_RELEVANT_PERIOD) && !relevantPeriodStatementsState.has_answered_relevant_period_question) {
         return res.redirect(config.RELEVANT_PERIOD_OWNED_LAND_FILTER_URL + config.RELEVANT_PERIOD_QUERY_PARAM);

--- a/src/utils/relevant.period.ts
+++ b/src/utils/relevant.period.ts
@@ -17,3 +17,12 @@ export const checkAnyRPStatementsActionWasTaken = (appData: ApplicationData): bo
   appData.update?.trustee_involved_relevant_period === "NO_TRUSTEE_INVOLVED_RELEVANT_PERIOD" ||
   appData.update?.change_beneficiary_relevant_period === "CHANGE_BENEFICIARY_RELEVANT_PERIOD" ||
   appData.update?.change_beneficiary_relevant_period === "NO_CHANGE_BENEFICIARY_RELEVANT_PERIOD";
+
+export const relevantPeriodPscStatements: Set<string> = new Set([
+  "change-beneficial-owner-relevant-period",
+  "no-change-beneficial-owner-relevant-period",
+  "trust-involved-relevant-period",
+  "no-trust-involved-relevant-period",
+  "change-beneficiary-relevant-period",
+  "no-change-beneficiary-relevant-period"
+]);


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/ROECCT-236

### Change description

Fix- Correct relevant period validation check for PSC statements.
This PR fixes the validation check for determining whether a company PSC statements contain any relevant statements before proceeding with a redirect to the relevant period owned land filter page.

### Work checklist

- [x] Tests added where applicable
- [x] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
