### PR TITLE
feat/cc-3241: get and save app data using DB for the `update-manage-trusts-tell-us-about-the-individual` page

### DIFF
--- a/src/controllers/update/update.manage.trusts.tell.us.about.the.individual.controller.ts
+++ b/src/controllers/update/update.manage.trusts.tell.us.about.the.individual.controller.ts
@@ -48,7 +48,7 @@ const getPageProperties = (trust, formData, trustee: TrustIndividual, req: Reque
     errors,
     formData,
     isUpdate: true,
-    uneditableDOB: trustee?.ch_references ? true : false,
+    uneditableDOB: !!trustee?.ch_references,
     backLinkUrl: getBackLink(req, trust.review_status.reviewed_individuals),
     templateName: req.url ? req.url.replace(UPDATE_AN_OVERSEAS_ENTITY_URL, "") : UPDATE_MANAGE_TRUSTS_TELL_US_ABOUT_THE_INDIVIDUAL_PAGE,
     pageParams: {

--- a/src/controllers/update/update.manage.trusts.tell.us.about.the.individual.controller.ts
+++ b/src/controllers/update/update.manage.trusts.tell.us.about.the.individual.controller.ts
@@ -1,35 +1,56 @@
 import { NextFunction, Request, Response } from 'express';
 import { ValidationError, validationResult } from 'express-validator';
-
 import { Session } from '@companieshouse/node-session-handler';
+
+import { logger } from '../../utils/logger';
+import { TrusteeType } from '../../model/trustee.type.model';
+import { isActiveFeature } from "../../utils/feature.flag";
+import { ApplicationData } from 'model';
+import { saveAndContinue } from '../../utils/save.and.continue';
+import { updateOverseasEntity } from "../../service/overseas.entities.service";
+import { RoleWithinTrustType } from '../../model/role.within.trust.type.model';
+import { checkTrusteeInterestedDate } from '../../validation/fields/date.validation';
+import { IndividualTrusteesFormCommon } from '../../model/trust.page.model';
+import { checkTrustIndividualCeasedDate } from '../../validation/async';
+import { checkTrustIndividualBeneficialOwnerStillInvolved } from '../../validation/stillInvolved.validation';
+
+import { getRedirectUrl, isRemoveJourney } from "../../utils/url";
+import { fetchApplicationData, setExtraData } from '../../utils/application.data';
+import { FormattedValidationErrors, formatValidationError } from '../../middleware/validation.middleware';
+import { mapIndividualTrusteeFromSessionToPage, mapIndividualTrusteeToSession } from '../../utils/trust/individual.trustee.mapper';
+
+import {
+  getTrustee,
+  getTrusteeIndex,
+  getTrustInReview,
+} from '../../utils/update/review_trusts';
+
+import {
+  Trust,
+  TrustIndividual,
+  IndividualTrustee,
+} from '../../model/trust.model';
 
 import {
   ROUTE_PARAM_TRUSTEE_ID,
   UPDATE_AN_OVERSEAS_ENTITY_URL,
-  UPDATE_MANAGE_TRUSTS_INDIVIDUALS_OR_ENTITIES_INVOLVED_URL,
+  FEATURE_FLAG_ENABLE_REDIS_REMOVAL,
   UPDATE_MANAGE_TRUSTS_ORCHESTRATOR_URL,
   UPDATE_MANAGE_TRUSTS_REVIEW_INDIVIDUALS_URL,
   UPDATE_MANAGE_TRUSTS_TELL_US_ABOUT_THE_INDIVIDUAL_PAGE,
+  UPDATE_MANAGE_TRUSTS_REVIEW_INDIVIDUALS_WITH_PARAMS_URL,
+  UPDATE_MANAGE_TRUSTS_INDIVIDUALS_OR_ENTITIES_INVOLVED_URL,
+  UPDATE_MANAGE_TRUSTS_INDIVIDUALS_OR_ENTITIES_INVOLVED_WITH_PARAMS_URL,
 } from '../../config';
-import { logger } from '../../utils/logger';
-import { getApplicationData, setExtraData } from '../../utils/application.data';
-import { mapIndividualTrusteeFromSessionToPage, mapIndividualTrusteeToSession } from '../../utils/trust/individual.trustee.mapper';
-import { getTrustInReview, getTrustee, getTrusteeIndex } from '../../utils/update/review_trusts';
-import { saveAndContinue } from '../../utils/save.and.continue';
-import { FormattedValidationErrors, formatValidationError } from '../../middleware/validation.middleware';
-import { TrusteeType } from '../../model/trustee.type.model';
-import { IndividualTrustee, Trust, TrustIndividual } from '../../model/trust.model';
-import { RoleWithinTrustType } from '../../model/role.within.trust.type.model';
-import { IndividualTrusteesFormCommon } from '../../model/trust.page.model';
-import { ApplicationData } from 'model';
-import { checkTrustIndividualCeasedDate } from '../../validation/async';
-import { checkTrustIndividualBeneficialOwnerStillInvolved } from '../../validation/stillInvolved.validation';
-import { checkTrusteeInterestedDate } from '../../validation/fields/date.validation';
 
-const getPageProperties = (trust, formData, trustee: TrustIndividual, url: string, errors?: FormattedValidationErrors) => {
+const getPageProperties = (trust, formData, trustee: TrustIndividual, req: Request, errors?: FormattedValidationErrors) => {
   return {
-    templateName: url ? url.replace(UPDATE_AN_OVERSEAS_ENTITY_URL, "") : UPDATE_MANAGE_TRUSTS_TELL_US_ABOUT_THE_INDIVIDUAL_PAGE,
-    backLinkUrl: getBackLink(trust.review_status.reviewed_individuals),
+    errors,
+    formData,
+    isUpdate: true,
+    uneditableDOB: trustee?.ch_references ? true : false,
+    backLinkUrl: getBackLink(req, trust.review_status.reviewed_individuals),
+    templateName: req.url ? req.url.replace(UPDATE_AN_OVERSEAS_ENTITY_URL, "") : UPDATE_MANAGE_TRUSTS_TELL_US_ABOUT_THE_INDIVIDUAL_PAGE,
     pageParams: {
       title: 'Tell us about the individual',
     },
@@ -40,30 +61,26 @@ const getPageProperties = (trust, formData, trustee: TrustIndividual, url: strin
       roleWithinTrustType: RoleWithinTrustType,
       entity_name: trust?.trust_name,
     },
-    formData,
-    errors,
-    uneditableDOB: trustee?.ch_references ? true : false,
-    isUpdate: true // this is an update controller so we are safe to say that isUpdate is true
   };
 };
 
 export const get = async (req: Request, res: Response, next: NextFunction) => {
+
   try {
+
     logger.debugRequest(req, `${req.method} ${req.route.path}`);
-
-    const appData: ApplicationData = await getApplicationData(req.session);
+    const isRemove: boolean = await isRemoveJourney(req);
+    const appData = await fetchApplicationData(req, !isRemove);
     const trusteeId = req.params[ROUTE_PARAM_TRUSTEE_ID];
-
     const trust = getTrustInReview(appData) as Trust;
     const trustee = getTrustee(trust, trusteeId, TrusteeType.INDIVIDUAL) as IndividualTrustee;
-
     const formData = trustee ? mapIndividualTrusteeFromSessionToPage(trustee) : {};
     const relevant_period = req.query['relevant-period'];
 
     if (relevant_period || (trustee && trustee.relevant_period)) {
-      return res.render(UPDATE_MANAGE_TRUSTS_TELL_US_ABOUT_THE_INDIVIDUAL_PAGE, getPagePropertiesRelevantPeriod(true, trust, formData, trustee, appData.entity_name, req.url));
+      return res.render(UPDATE_MANAGE_TRUSTS_TELL_US_ABOUT_THE_INDIVIDUAL_PAGE, getPagePropertiesRelevantPeriod(true, trust, formData, trustee, appData.entity_name, req));
     } else {
-      return res.render(UPDATE_MANAGE_TRUSTS_TELL_US_ABOUT_THE_INDIVIDUAL_PAGE, getPageProperties(trust, formData, trustee, req.url));
+      return res.render(UPDATE_MANAGE_TRUSTS_TELL_US_ABOUT_THE_INDIVIDUAL_PAGE, getPageProperties(trust, formData, trustee, req));
     }
 
   } catch (error) {
@@ -72,16 +89,18 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
 };
 
 export const post = async (req: Request, res: Response, next: NextFunction) => {
+
   try {
+
     logger.debugRequest(req, `${req.method} ${req.route.path}`);
-    const appData = await getApplicationData(req.session);
+    const session = req.session as Session;
+    const isRemove: boolean = await isRemoveJourney(req);
+    const appData = await fetchApplicationData(req, !isRemove);
     const trusteeId = req.params[ROUTE_PARAM_TRUSTEE_ID];
     const trust = getTrustInReview(appData) as Trust;
-
     const relevant_period = req.query['relevant-period'];
     const errorList = validationResult(req);
     const errors = await getValidationErrors(appData, req);
-
     const formData: IndividualTrusteesFormCommon = req.body;
 
     if (!errorList.isEmpty() || errors.length) {
@@ -91,12 +110,12 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
       if (relevant_period || (trustee && trustee.relevant_period)) {
         return res.render(
           UPDATE_MANAGE_TRUSTS_TELL_US_ABOUT_THE_INDIVIDUAL_PAGE,
-          getPagePropertiesRelevantPeriod(true, trust, formData, trustee, appData.entity_name, req.url, formatValidationError([...errorListArray, ...errors])),
+          getPagePropertiesRelevantPeriod(true, trust, formData, trustee, appData.entity_name, req, formatValidationError([...errorListArray, ...errors])),
         );
       } else {
         return res.render(
           UPDATE_MANAGE_TRUSTS_TELL_US_ABOUT_THE_INDIVIDUAL_PAGE,
-          getPageProperties(trust, formData, trustee, req.url, formatValidationError([...errorListArray, ...errors])),
+          getPageProperties(trust, formData, trustee, req, formatValidationError([...errorListArray, ...errors])),
         );
       }
     }
@@ -112,31 +131,43 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
       trust.INDIVIDUALS?.push(trustee);
     }
 
+    if (isActiveFeature(FEATURE_FLAG_ENABLE_REDIS_REMOVAL)) {
+      await updateOverseasEntity(req, session, appData);
+    } else {
+      await saveAndContinue(req, session);
+    }
     setExtraData(req.session, appData);
-    await saveAndContinue(req, req.session as Session);
 
     return res.redirect(UPDATE_MANAGE_TRUSTS_ORCHESTRATOR_URL);
+
   } catch (error) {
     next(error);
   }
 };
 
-const getBackLink = (individualsReviewed: boolean) => {
+const getBackLink = (req: Request, individualsReviewed: boolean) => {
   if (individualsReviewed) {
-    return UPDATE_MANAGE_TRUSTS_INDIVIDUALS_OR_ENTITIES_INVOLVED_URL;
+    return getRedirectUrl({
+      req,
+      urlWithEntityIds: UPDATE_MANAGE_TRUSTS_INDIVIDUALS_OR_ENTITIES_INVOLVED_WITH_PARAMS_URL,
+      urlWithoutEntityIds: UPDATE_MANAGE_TRUSTS_INDIVIDUALS_OR_ENTITIES_INVOLVED_URL,
+    });
   } else {
-    return UPDATE_MANAGE_TRUSTS_REVIEW_INDIVIDUALS_URL;
+    return getRedirectUrl({
+      req,
+      urlWithEntityIds: UPDATE_MANAGE_TRUSTS_REVIEW_INDIVIDUALS_WITH_PARAMS_URL,
+      urlWithoutEntityIds: UPDATE_MANAGE_TRUSTS_REVIEW_INDIVIDUALS_URL,
+    });
   }
 };
 
-const getPagePropertiesRelevantPeriod = (relevant_period, trust, formData, trustee: TrustIndividual, entityName, url: string, errors?: FormattedValidationErrors) => {
-  const pageProps = getPageProperties(trust, formData, trustee, url, errors);
+const getPagePropertiesRelevantPeriod = (relevant_period, trust, formData, trustee: TrustIndividual, entityName, req: Request, errors?: FormattedValidationErrors) => {
+  const pageProps = getPageProperties(trust, formData, trustee, req, errors);
   pageProps.formData.relevant_period = relevant_period;
   pageProps.pageData.entity_name = entityName;
   return pageProps;
 };
 
-// Get validation errors that depend on an asynchronous request
 const getValidationErrors = async (appData: ApplicationData, req: Request): Promise<ValidationError[]> => {
   const stillInvolvedErrors = checkTrustIndividualBeneficialOwnerStillInvolved(appData, req);
   const ceasedDateErrors = await checkTrustIndividualCeasedDate(appData, req);

--- a/test/controllers/update/update.manage.trusts.tell.us.about.the.individual.controller.spec.ts
+++ b/test/controllers/update/update.manage.trusts.tell.us.about.the.individual.controller.spec.ts
@@ -44,8 +44,9 @@ import {
 import {
   RELEVANT_PERIOD_QUERY_PARAM,
   UPDATE_MANAGE_TRUSTS_ORCHESTRATOR_URL,
-  UPDATE_MANAGE_TRUSTS_REVIEW_INDIVIDUALS_URL,
+  UPDATE_MANAGE_TRUSTS_REVIEW_INDIVIDUALS_URL, UPDATE_MANAGE_TRUSTS_REVIEW_INDIVIDUALS_WITH_PARAMS_URL,
   UPDATE_MANAGE_TRUSTS_TELL_US_ABOUT_THE_INDIVIDUAL_URL,
+  UPDATE_MANAGE_TRUSTS_TELL_US_ABOUT_THE_INDIVIDUAL_WITH_PARAMS_URL,
 } from '../../../src/config';
 
 import {
@@ -138,10 +139,11 @@ describe('Update - Manage Trusts - Review individuals', () => {
 
   describe('GET tests', () => {
 
-    test('when no trustee to display, still renders the page', async () => {
+    test('when no trustee to display, still renders the page and REDIS_flag is OFF', async () => {
       const appData = { entity_number: 'OE988669', entity_name: 'Tell us about the individual OE 1' };
       const trustInReview = { trust_id: 'trust-in-review-1', trust_name: 'Veggie Trust', review_status: { in_review: true } };
 
+      mockIsActiveFeature.mockReturnValue(false);
       mockFetchApplicationData.mockReturnValue(appData);
       mockGetTrustInReview.mockReturnValue(trustInReview);
       mockGetTrustee.mockReturnValue(undefined);
@@ -156,6 +158,29 @@ describe('Update - Manage Trusts - Review individuals', () => {
       expect(resp.text).toContain('Veggie Trust');
       expect(resp.text).toContain('Tell us about the individual');
       expect(resp.text).toContain(UPDATE_MANAGE_TRUSTS_REVIEW_INDIVIDUALS_URL);
+      expect(resp.text).toContain(SAVE_AND_CONTINUE_BUTTON_TEXT);
+      expect(resp.text).not.toContain(PAGE_TITLE_ERROR);
+    });
+
+    test('when no trustee to display, still renders the page and REDIS_flag is ON', async () => {
+      const appData = { entity_number: 'OE988669', entity_name: 'Tell us about the individual OE 1' };
+      const trustInReview = { trust_id: 'trust-in-review-1', trust_name: 'Veggie Trust', review_status: { in_review: true } };
+
+      mockIsActiveFeature.mockReturnValue(true);
+      mockFetchApplicationData.mockReturnValue(appData);
+      mockGetTrustInReview.mockReturnValue(trustInReview);
+      mockGetTrustee.mockReturnValue(undefined);
+
+      const resp = await request(app).get(`${UPDATE_MANAGE_TRUSTS_TELL_US_ABOUT_THE_INDIVIDUAL_WITH_PARAMS_URL}/trustee-individual-1`);
+
+      expect(resp.status).toEqual(200);
+      expect(mockGetTrustInReview).toHaveBeenCalledWith(appData);
+      expect(mockGetTrustInReview).toHaveBeenCalledTimes(1);
+      expect(mockGetTrustee).toHaveBeenCalledWith(trustInReview, 'trustee-individual-1', TrusteeType.INDIVIDUAL);
+      expect(mockGetTrustee).toHaveBeenCalledTimes(1);
+      expect(resp.text).toContain('Veggie Trust');
+      expect(resp.text).toContain('Tell us about the individual');
+      expect(resp.text).toContain(UPDATE_MANAGE_TRUSTS_REVIEW_INDIVIDUALS_WITH_PARAMS_URL);
       expect(resp.text).toContain(SAVE_AND_CONTINUE_BUTTON_TEXT);
       expect(resp.text).not.toContain(PAGE_TITLE_ERROR);
     });

--- a/test/controllers/update/update.manage.trusts.tell.us.about.the.individual.controller.spec.ts
+++ b/test/controllers/update/update.manage.trusts.tell.us.about.the.individual.controller.spec.ts
@@ -8,6 +8,7 @@ jest.mock('../../../src/middleware/company.authentication.middleware');
 jest.mock('../../../src/middleware/service.availability.middleware');
 jest.mock('../../../src/middleware/navigation/update/is.in.change.journey.middleware');
 jest.mock('../../../src/middleware/navigation/update/manage.trusts.middleware');
+jest.mock('../../../src/service/overseas.entities.service');
 jest.mock('../../../src/middleware/navigation/update/has.beneficial.owners.or.managing.officers.update.middleware');
 
 import mockCsrfProtectionMiddleware from "../../__mocks__/csrfProtectionMiddleware.mock";
@@ -16,29 +17,54 @@ import request from 'supertest';
 import { NextFunction } from 'express';
 
 import app from '../../../src/app';
+
+import { TrusteeType } from '../../../src/model/trustee.type.model';
+import { yesNoResponse } from '../../../src/model/data.types.model';
+import { ErrorMessages } from "../../../src/validation/error.messages";
+import { authentication } from '../../../src/middleware/authentication.middleware';
+import { isActiveFeature } from '../../../src/utils/feature.flag';
+import { saveAndContinue } from '../../../src/utils/save.and.continue';
+import { isInChangeJourney } from '../../../src/middleware/navigation/update/is.in.change.journey.middleware';
+import { hasBOsOrMOsUpdate } from '../../../src/middleware/navigation/update/has.beneficial.owners.or.managing.officers.update.middleware';
+import { OVERSEAS_ENTITY_ID } from "../../__mocks__/session.mock";
+import { RoleWithinTrustType } from '../../../src/model/role.within.trust.type.model';
+import { updateOverseasEntity } from "../../../src/service/overseas.entities.service";
+import { companyAuthentication } from '../../../src/middleware/company.authentication.middleware';
+import { serviceAvailabilityMiddleware } from '../../../src/middleware/service.availability.middleware';
+import { manageTrustsTellUsAboutIndividualsGuard } from '../../../src/middleware/navigation/update/manage.trusts.middleware';
+
+import { fetchApplicationData, setExtraData } from '../../../src/utils/application.data';
+
 import {
+  getTrustee,
+  getTrusteeIndex,
+  getTrustInReview,
+} from '../../../src/utils/update/review_trusts';
+
+import {
+  RELEVANT_PERIOD_QUERY_PARAM,
   UPDATE_MANAGE_TRUSTS_ORCHESTRATOR_URL,
   UPDATE_MANAGE_TRUSTS_REVIEW_INDIVIDUALS_URL,
   UPDATE_MANAGE_TRUSTS_TELL_US_ABOUT_THE_INDIVIDUAL_URL,
-  RELEVANT_PERIOD_QUERY_PARAM
 } from '../../../src/config';
-import { authentication } from '../../../src/middleware/authentication.middleware';
-import { companyAuthentication } from '../../../src/middleware/company.authentication.middleware';
-import { serviceAvailabilityMiddleware } from '../../../src/middleware/service.availability.middleware';
-import { isInChangeJourney } from '../../../src/middleware/navigation/update/is.in.change.journey.middleware';
-import { hasBOsOrMOsUpdate } from '../../../src/middleware/navigation/update/has.beneficial.owners.or.managing.officers.update.middleware';
-import { manageTrustsTellUsAboutIndividualsGuard } from '../../../src/middleware/navigation/update/manage.trusts.middleware';
-import { getApplicationData, setExtraData } from '../../../src/utils/application.data';
-import { getTrustInReview, getTrustee, getTrusteeIndex } from '../../../src/utils/update/review_trusts';
-import { isActiveFeature } from '../../../src/utils/feature.flag';
-import { PAGE_TITLE_ERROR, SAVE_AND_CONTINUE_BUTTON_TEXT, ERROR_LIST, RELEVANT_PERIOD, UPDATE_TELL_US_ABOUT_THE_INDIVIDUAL_BENEFICIARY_HEADING, UPDATE_WHAT_IS_THEIR_FIRST_NAME, UPDATE_ARE_THEY_STILL_INVOLVED_IN_THE_TRUST } from '../../__mocks__/text.mock';
-import { TrusteeType } from '../../../src/model/trustee.type.model';
-import { saveAndContinue } from '../../../src/utils/save.and.continue';
-import { yesNoResponse } from '../../../src/model/data.types.model';
-import { RoleWithinTrustType } from '../../../src/model/role.within.trust.type.model';
-import { ErrorMessages } from "../../../src/validation/error.messages";
+
+import {
+  PAGE_TITLE_ERROR,
+  ERROR_LIST, RELEVANT_PERIOD,
+  SAVE_AND_CONTINUE_BUTTON_TEXT,
+  UPDATE_WHAT_IS_THEIR_FIRST_NAME,
+  UPDATE_ARE_THEY_STILL_INVOLVED_IN_THE_TRUST,
+  UPDATE_TELL_US_ABOUT_THE_INDIVIDUAL_BENEFICIARY_HEADING,
+} from '../../__mocks__/text.mock';
 
 mockCsrfProtectionMiddleware.mockClear();
+const mockFetchApplicationData = fetchApplicationData as jest.Mock;
+const mockGetTrustInReview = getTrustInReview as jest.Mock;
+const mockGetTrustee = getTrustee as jest.Mock;
+const mockGetTrusteeIndex = getTrusteeIndex as jest.Mock;
+const mockSetExtraData = setExtraData as jest.Mock;
+const mockSaveAndContinue = saveAndContinue as jest.Mock;
+
 const mockAuthenticationMiddleware = authentication as jest.Mock;
 mockAuthenticationMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => next());
 
@@ -60,18 +86,16 @@ mockManageTrustsTellUsAboutIndividualsGuard.mockImplementation((req: Request, re
 const mockIsActiveFeature = isActiveFeature as jest.Mock;
 mockIsActiveFeature.mockReturnValue(true);
 
-const mockGetApplicationData = getApplicationData as jest.Mock;
-const mockGetTrustInReview = getTrustInReview as jest.Mock;
-const mockGetTrustee = getTrustee as jest.Mock;
-const mockGetTrusteeIndex = getTrusteeIndex as jest.Mock;
-const mockSetExtraData = setExtraData as jest.Mock;
-const mockSaveAndContinue = saveAndContinue as jest.Mock;
+const mockUpdateOverseasEntity = updateOverseasEntity as jest.Mock;
+mockUpdateOverseasEntity.mockReturnValue(OVERSEAS_ENTITY_ID);
 
 let DEFAULT_FORM_SUBMISSION;
 
 describe('Update - Manage Trusts - Review individuals', () => {
+
   beforeEach(() => {
     jest.clearAllMocks();
+    mockFetchApplicationData.mockReset();
 
     DEFAULT_FORM_SUBMISSION = {
       trusteeId: 'trustee-id-2',
@@ -113,27 +137,25 @@ describe('Update - Manage Trusts - Review individuals', () => {
   });
 
   describe('GET tests', () => {
+
     test('when no trustee to display, still renders the page', async () => {
       const appData = { entity_number: 'OE988669', entity_name: 'Tell us about the individual OE 1' };
       const trustInReview = { trust_id: 'trust-in-review-1', trust_name: 'Veggie Trust', review_status: { in_review: true } };
 
-      mockGetApplicationData.mockReturnValue(appData);
+      mockFetchApplicationData.mockReturnValue(appData);
       mockGetTrustInReview.mockReturnValue(trustInReview);
       mockGetTrustee.mockReturnValue(undefined);
 
       const resp = await request(app).get(`${UPDATE_MANAGE_TRUSTS_TELL_US_ABOUT_THE_INDIVIDUAL_URL}/trustee-individual-1`);
 
       expect(resp.status).toEqual(200);
-
       expect(mockGetTrustInReview).toHaveBeenCalledWith(appData);
       expect(mockGetTrustInReview).toHaveBeenCalledTimes(1);
       expect(mockGetTrustee).toHaveBeenCalledWith(trustInReview, 'trustee-individual-1', TrusteeType.INDIVIDUAL);
       expect(mockGetTrustee).toHaveBeenCalledTimes(1);
-
       expect(resp.text).toContain('Veggie Trust');
       expect(resp.text).toContain('Tell us about the individual');
       expect(resp.text).toContain(UPDATE_MANAGE_TRUSTS_REVIEW_INDIVIDUALS_URL);
-
       expect(resp.text).toContain(SAVE_AND_CONTINUE_BUTTON_TEXT);
       expect(resp.text).not.toContain(PAGE_TITLE_ERROR);
     });
@@ -181,18 +203,17 @@ describe('Update - Manage Trusts - Review individuals', () => {
         ceased_date_year: "2022"
       };
 
-      mockGetApplicationData.mockReturnValue(appData);
+      mockFetchApplicationData.mockReturnValue(appData);
       mockGetTrustInReview.mockReturnValue(trustInReview);
       mockGetTrustee.mockReturnValue(trustee);
 
       const resp = await request(app).get(`${UPDATE_MANAGE_TRUSTS_TELL_US_ABOUT_THE_INDIVIDUAL_URL}/trustee-individual-2`);
-      expect(resp.status).toEqual(200);
 
+      expect(resp.status).toEqual(200);
       expect(mockGetTrustInReview).toHaveBeenCalledWith(appData);
       expect(mockGetTrustInReview).toHaveBeenCalledTimes(1);
       expect(mockGetTrustee).toHaveBeenCalledWith(trustInReview, 'trustee-individual-2', TrusteeType.INDIVIDUAL);
       expect(mockGetTrustee).toHaveBeenCalledTimes(1);
-
       expect(resp.text).toContain('Veggie Trust');
       expect(resp.text).toContain('Tell us about the individual');
       expect(resp.text).toContain('Jack');
@@ -205,11 +226,8 @@ describe('Update - Manage Trusts - Review individuals', () => {
       expect(resp.text).toContain('name="ceasedDateDay" type="text" value="22"');
       expect(resp.text).toContain('name="ceasedDateMonth" type="text" value="03"');
       expect(resp.text).toContain('name="ceasedDateYear" type="text" value="2022"');
-
       expect(resp.text).toContain(UPDATE_MANAGE_TRUSTS_REVIEW_INDIVIDUALS_URL);
-
       expect(resp.text).not.toContain('id="dateOfBirthDay"');
-
       expect(resp.text).toContain(SAVE_AND_CONTINUE_BUTTON_TEXT);
       expect(resp.text).not.toContain(PAGE_TITLE_ERROR);
     });
@@ -218,7 +236,7 @@ describe('Update - Manage Trusts - Review individuals', () => {
       const appData = { entity_number: 'OE999999', entity_name: 'Overseas Entity Name' };
       const trustInReview = { trust_id: 'trust-in-review-1', trust_name: 'Overseas Entity Name', review_status: { in_review: true } };
       mockIsActiveFeature.mockReturnValue(true);
-      mockGetApplicationData.mockReturnValue(appData);
+      mockFetchApplicationData.mockReturnValue(appData);
       mockGetTrustInReview.mockReturnValue(trustInReview);
       const resp = await request(app).get(`${UPDATE_MANAGE_TRUSTS_TELL_US_ABOUT_THE_INDIVIDUAL_URL}${RELEVANT_PERIOD_QUERY_PARAM}`);
       expect(resp.status).toEqual(200);
@@ -238,7 +256,7 @@ describe('Update - Manage Trusts - Review individuals', () => {
         relevant_period: true
       };
       mockIsActiveFeature.mockReturnValue(true);
-      mockGetApplicationData.mockReturnValue(appData);
+      mockFetchApplicationData.mockReturnValue(appData);
       mockGetTrustInReview.mockReturnValue(trustInReview);
       mockGetTrustee.mockReturnValue(trustee);
       const resp = await request(app).get(`${UPDATE_MANAGE_TRUSTS_TELL_US_ABOUT_THE_INDIVIDUAL_URL}`);
@@ -253,6 +271,7 @@ describe('Update - Manage Trusts - Review individuals', () => {
   });
 
   describe('POST tests', () => {
+
     test('when a valid trust submission is provided, and the trust id is of an existing trust, the trust is updated in the model', async () => {
       const formSubmission = {
         ...DEFAULT_FORM_SUBMISSION
@@ -342,7 +361,7 @@ describe('Update - Manage Trusts - Review individuals', () => {
       };
 
       mockIsActiveFeature.mockReturnValue(true);
-      mockGetApplicationData.mockReturnValue(appData);
+      mockFetchApplicationData.mockReturnValue(appData);
       mockGetTrustInReview.mockReturnValue(trustInReview);
       mockGetTrusteeIndex.mockReturnValue(0);
 
@@ -354,11 +373,10 @@ describe('Update - Manage Trusts - Review individuals', () => {
 
       expect(resp.status).toBe(302);
       expect(resp.header.location).toBe(UPDATE_MANAGE_TRUSTS_ORCHESTRATOR_URL);
-
       expect(appData.update.review_trusts[0].INDIVIDUALS[0]).toEqual(expectedTrustee);
-
       expect(mockSetExtraData).toHaveBeenCalled();
-      expect(mockSaveAndContinue).toHaveBeenCalled();
+      expect(mockSaveAndContinue).not.toHaveBeenCalled();
+      expect(mockUpdateOverseasEntity).toHaveBeenCalledTimes(1);
     });
 
     test('when a valid trust submission is provided, and the trust id is not an existing trust, the trust is added to the model', async () => {
@@ -460,7 +478,7 @@ describe('Update - Manage Trusts - Review individuals', () => {
       };
 
       mockIsActiveFeature.mockReturnValue(true);
-      mockGetApplicationData.mockReturnValue(appData);
+      mockFetchApplicationData.mockReturnValue(appData);
       mockGetTrustInReview.mockReturnValue(trustInReview);
       mockGetTrusteeIndex.mockReturnValue(-1);
 
@@ -472,12 +490,11 @@ describe('Update - Manage Trusts - Review individuals', () => {
 
       expect(resp.status).toBe(302);
       expect(resp.header.location).toBe(UPDATE_MANAGE_TRUSTS_ORCHESTRATOR_URL);
-
       expect(appData.update.review_trusts[0].INDIVIDUALS[0]).toEqual(existingTrustee);
       expect(appData.update.review_trusts[0].INDIVIDUALS[1]).toEqual(expectedTrustee);
-
       expect(mockSetExtraData).toHaveBeenCalled();
-      expect(mockSaveAndContinue).toHaveBeenCalled();
+      expect(mockSaveAndContinue).not.toHaveBeenCalled();
+      expect(mockUpdateOverseasEntity).toHaveBeenCalledTimes(1);
     });
 
     test('when validation fails, page is re-rendered', async () => {
@@ -547,7 +564,7 @@ describe('Update - Manage Trusts - Review individuals', () => {
       };
 
       mockIsActiveFeature.mockReturnValue(true);
-      mockGetApplicationData.mockReturnValue(appData);
+      mockFetchApplicationData.mockReturnValue(appData);
       mockGetTrustInReview.mockReturnValue(trustInReview);
       mockGetTrustee.mockReturnValue(existingTrustee);
 
@@ -561,7 +578,6 @@ describe('Update - Manage Trusts - Review individuals', () => {
       expect(resp.text).toContain(ERROR_LIST);
       expect(resp.text).toContain('Tell us about the individual');
       expect(resp.text).toContain(UPDATE_MANAGE_TRUSTS_REVIEW_INDIVIDUALS_URL);
-
       expect(mockSetExtraData).not.toHaveBeenCalled();
       expect(mockSaveAndContinue).not.toHaveBeenCalled();
     });
@@ -680,7 +696,7 @@ describe('Update - Manage Trusts - Review individuals', () => {
       };
 
       mockIsActiveFeature.mockReturnValue(true);
-      mockGetApplicationData.mockReturnValue(appData);
+      mockFetchApplicationData.mockReturnValue(appData);
       mockGetTrustInReview.mockReturnValue(trustInReview);
 
       const resp = await request(app)
@@ -694,7 +710,6 @@ describe('Update - Manage Trusts - Review individuals', () => {
       expect(resp.text).toContain('Tell us about the individual');
       expect(resp.text).toContain(UPDATE_MANAGE_TRUSTS_REVIEW_INDIVIDUALS_URL);
       expect(resp.text).toContain(errorMessage);
-
       expect(mockSetExtraData).not.toHaveBeenCalled();
       expect(mockSaveAndContinue).not.toHaveBeenCalled();
     });


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/CC-3241

### Change description

- Gets and saves data to and from the API for the `update-manage-trusts-tell-us-about-the-individual` page
- Updates and adds unit test as required
- Adds formatting changes

### Work checklist

- [x] Tests added where applicable
- [x] UI changes meet accessibility criteria
