### PR TITLE
feat/cc-3352: ensure transaction/entity creation is done after an entity number is supplied

### DIFF
--- a/src/controllers/update/overseas.entity.query.controller.ts
+++ b/src/controllers/update/overseas.entity.query.controller.ts
@@ -193,7 +193,7 @@ const saveEntityDetails = async (
 
 export const getNextPageUrl = (req: Request, appData: ApplicationData) => {
   if (!isActiveFeature(config.FEATURE_FLAG_ENABLE_REDIS_REMOVAL)) {
-    return config.UPDATE_INTERRUPT_CARD_URL;
+    return config.UPDATE_OVERSEAS_ENTITY_CONFIRM_URL;
   }
 
   if (appData[Transactionkey] && appData[OverseasEntityKey]) {

--- a/src/controllers/update/overseas.entity.query.controller.ts
+++ b/src/controllers/update/overseas.entity.query.controller.ts
@@ -7,14 +7,13 @@ import { mapInputDate } from "../../utils/update/mapper.utils";
 import { CompanyProfile } from "@companieshouse/api-sdk-node/dist/services/company-profile/types";
 import { isActiveFeature } from "../../utils/feature.flag";
 import { ApplicationData } from "../../model";
+import { postTransaction } from "../../service/transaction.service";
 import { resetEntityUpdate } from "../../utils/update/update.reset";
 import { getCompanyProfile } from "../../service/company.profile.service";
-import { updateTransaction } from "../../service/transaction.service";
 import { retrieveBoAndMoData } from "../../utils/update/beneficial_owners_managing_officers_data_fetch";
-import { updateOverseasEntity } from "../../service/overseas.entities.service";
-import { getRedirectUrl, isRemoveJourney } from "../../utils/url";
 import { mapCompanyProfileToOverseasEntity } from "../../utils/update/company.profile.mapper.to.overseas.entity";
 import { getDataFromEntityCookie, saveDataToCookie } from "../../utils/update/data.cookie";
+import { createOverseasEntity, updateOverseasEntity } from "../../service/overseas.entities.service";
 
 import {
   getRemove,
@@ -23,9 +22,17 @@ import {
 } from "../../utils/application.data";
 
 import {
+  getRedirectUrl,
+  isRemoveJourney,
+  getUrlWithTransactionIdAndSubmissionId,
+} from "../../utils/url";
+
+import {
   IsRemoveKey,
+  Transactionkey,
   EntityNumberKey,
-  EntityCookieCompanyNumberKey,
+  OverseasEntityKey,
+  IsSecureRegisterKey,
 } from "../../model/data.types.model";
 
 export const get = async (req: Request, res: Response, next: NextFunction) => {
@@ -34,7 +41,7 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
 
     logger.debugRequest(req, `${req.method} ${req.route.path}`);
     const isRemove: boolean = await isRemoveJourney(req);
-    const appData: ApplicationData = await getApplicationData(req);
+    const appData: ApplicationData = await getAppData(req, false);
 
     const backLinkUrl = getRedirectUrl({
       req,
@@ -72,22 +79,18 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
     logger.debugRequest(req, `${req.method} ${req.route.path}`);
     const entityNumber = req.body[EntityNumberKey];
     const isRemove: boolean = await isRemoveJourney(req);
-    const appData: ApplicationData = await getApplicationData(req);
+    const appData: ApplicationData = await getAppData(req);
 
-    if (appData.entity_number !== entityNumber) {
+    if (appData?.entity_number !== entityNumber) {
       const companyProfile = await getCompanyProfile(req, entityNumber);
       if (!companyProfile) {
         return await renderGetPageWithError(req, res, entityNumber);
       }
-      await addOeToApplicationData(req, appData, entityNumber, companyProfile, isRemove);
+      await addOeToApplicationData(req, res, appData, entityNumber, companyProfile, isRemove);
       saveToCookie(req, res, entityNumber);
     }
 
-    const nextPageUrl = getRedirectUrl({
-      req,
-      urlWithEntityIds: config.UPDATE_OVERSEAS_ENTITY_CONFIRM_WITH_PARAMS_URL,
-      urlWithoutEntityIds: config.UPDATE_OVERSEAS_ENTITY_CONFIRM_URL,
-    });
+    const nextPageUrl = getNextPageUrl(req, appData);
 
     if (isRemove) {
       return res.redirect(`${nextPageUrl}${config.JOURNEY_REMOVE_QUERY_PARAM}`);
@@ -135,19 +138,19 @@ const renderGetPageWithError = async (req: Request, res: Response, entityNumber:
   });
 };
 
-const addOeToApplicationData = async (req: Request, appData: ApplicationData, entityNumber: any, companyProfile: CompanyProfile, isRemove: boolean) => {
+const addOeToApplicationData = async (
+  req: Request,
+  res: Response,
+  appData: ApplicationData,
+  entityNumber: any,
+  companyProfile: CompanyProfile,
+  isRemove: boolean
+) => {
   resetEntityUpdate(appData);
   reloadOE(appData, entityNumber, companyProfile);
   await retrieveBoAndMoData(req, appData);
-  if (isActiveFeature(config.FEATURE_FLAG_ENABLE_REDIS_REMOVAL)) {
-    if (isRemove) {
-      appData[IsRemoveKey] = true;
-      appData[RemoveKey] = getRemove(await getDataFromEntityCookie(req, false));
-    }
-    await updateTransaction(req, req.session as Session, appData);
-    await updateOverseasEntity(req, req.session as Session, appData);
-  }
-  setExtraData(req.session, appData);
+  await saveEntityDetails(req, res, appData, isRemove);
+  setExtraData(req.session as Session, appData);
 };
 
 export const reloadOE = (appData: ApplicationData, entityNumber: string, companyProfile: CompanyProfile) => {
@@ -161,7 +164,58 @@ export const reloadOE = (appData: ApplicationData, entityNumber: string, company
 
 export const saveToCookie = (req: Request, res: Response, entityNumber: string) => {
   if (isActiveFeature(config.FEATURE_FLAG_ENABLE_REDIS_REMOVAL)) {
-    saveDataToCookie(req, res, EntityCookieCompanyNumberKey, entityNumber);
+    saveDataToCookie(req, res, EntityNumberKey, entityNumber);
   }
 };
 
+const saveEntityDetails = async (
+  req: Request,
+  res: Response,
+  appData: ApplicationData,
+  isRemove: boolean
+): Promise<void> => {
+  if (isActiveFeature(config.FEATURE_FLAG_ENABLE_REDIS_REMOVAL)) {
+    const session = req.session as Session;
+    if (!appData[Transactionkey]) {
+      const transactionID = await postTransaction(req, session);
+      appData[Transactionkey] = transactionID;
+      appData[OverseasEntityKey] = await createOverseasEntity(req, session, transactionID);
+    }
+    const cookieData = await getDataFromEntityCookie(req, false);
+    if (isRemove) {
+      appData[IsRemoveKey] = true;
+      appData[RemoveKey] = getRemove(cookieData);
+    }
+    appData[IsSecureRegisterKey] = cookieData[IsSecureRegisterKey];
+    await updateOverseasEntity(req, req.session as Session, appData);
+  }
+};
+
+export const getNextPageUrl = (req: Request, appData: ApplicationData) => {
+  if (!isActiveFeature(config.FEATURE_FLAG_ENABLE_REDIS_REMOVAL)) {
+    return config.UPDATE_INTERRUPT_CARD_URL;
+  }
+
+  if (appData[Transactionkey] && appData[OverseasEntityKey]) {
+    return getUrlWithTransactionIdAndSubmissionId(
+      config.UPDATE_OVERSEAS_ENTITY_CONFIRM_WITH_PARAMS_URL,
+        appData[Transactionkey] as string,
+        appData[OverseasEntityKey] as string
+    );
+  }
+
+  return getRedirectUrl({
+    req,
+    urlWithEntityIds: config.UPDATE_OVERSEAS_ENTITY_CONFIRM_WITH_PARAMS_URL,
+    urlWithoutEntityIds: config.UPDATE_OVERSEAS_ENTITY_CONFIRM_URL,
+  });
+
+};
+
+const getAppData = async (req: Request, getCompany: boolean = true): Promise<ApplicationData> => {
+  let appData: ApplicationData = await getApplicationData(req);
+  if (!Object.keys(appData).length) {
+    appData = await getDataFromEntityCookie(req, getCompany);
+  }
+  return appData;
+};

--- a/src/controllers/update/update.continue.saved.filing.controller.ts
+++ b/src/controllers/update/update.continue.saved.filing.controller.ts
@@ -2,6 +2,7 @@ import { NextFunction, Request, Response } from "express";
 import * as config from "../../config";
 import { logger } from "../../utils/logger";
 import { isRemoveJourney } from "../../utils/url";
+import { removeEntityCookie } from "../../utils/update/data.cookie";
 
 export const get = async (req: Request, res: Response, _: NextFunction) => {
   logger.debugRequest(req, `GET ${config.UPDATE_CONTINUE_WITH_SAVED_FILING_PAGE}`);
@@ -27,6 +28,8 @@ export const post = async (req: Request, res: Response, _: NextFunction) => {
   if (req.body["continue_saved_filing"] === 'yes') {
     return res.redirect(config.YOUR_FILINGS_PATH);
   }
+
+  removeEntityCookie(req, res);
 
   if (isRemove) {
     return res.redirect(`${config.REMOVE_SOLD_ALL_LAND_FILTER_URL}${config.JOURNEY_REMOVE_QUERY_PARAM}`);

--- a/src/controllers/update/update.interrupt.card.controller.ts
+++ b/src/controllers/update/update.interrupt.card.controller.ts
@@ -41,11 +41,18 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
 
     logger.debugRequest(req, `${req.method} ${req.route.path}`);
     const isRemove: boolean = await isRemoveJourney(req);
+    const nextPageUrl = getRedirectUrl({
+      req,
+      urlWithEntityIds: config.OVERSEAS_ENTITY_QUERY_WITH_PARAMS_URL,
+      urlWithoutEntityIds: config.OVERSEAS_ENTITY_QUERY_URL,
+    });
 
     if (isRemove){
-      return res.redirect(`${config.OVERSEAS_ENTITY_QUERY_PAGE}${config.JOURNEY_REMOVE_QUERY_PARAM}`);
+      return res.redirect(`${nextPageUrl}${config.JOURNEY_REMOVE_QUERY_PARAM}`);
     }
-    return res.redirect(config.OVERSEAS_ENTITY_QUERY_PAGE);
+
+    return res.redirect(nextPageUrl);
+
   } catch (error) {
     logger.errorRequest(req, error);
     next(error);

--- a/src/model/data.types.model.ts
+++ b/src/model/data.types.model.ts
@@ -102,4 +102,4 @@ export const IsNotProprietorOfLandKey = "is_not_proprietor_of_land";
 
 // Cookie names
 export const EntityCookieKey = "_roe";
-export const EntityCookieCompanyNumberKey = "e_number";
+

--- a/src/utils/secure.filter.ts
+++ b/src/utils/secure.filter.ts
@@ -1,15 +1,18 @@
 import { NextFunction, Request, Response } from "express";
 import { Session } from "@companieshouse/node-session-handler";
-
 import * as config from "../config";
 import { logger } from "./logger";
 import { ApplicationData } from "../model";
 import { isActiveFeature } from "./feature.flag";
-import { postTransaction } from "../service/transaction.service";
-
+import { updateOverseasEntity } from "../service/overseas.entities.service";
 import { getApplicationData, setExtraData } from "./application.data";
-import { createOverseasEntity, updateOverseasEntity } from "../service/overseas.entities.service";
-import { IsSecureRegisterKey, OverseasEntityKey, Transactionkey } from "../model/data.types.model";
+import { getDataFromEntityCookie, saveDataToCookie } from "./update/data.cookie";
+
+import {
+  Transactionkey,
+  OverseasEntityKey,
+  IsSecureRegisterKey,
+} from "../model/data.types.model";
 
 import {
   getRedirectUrl,
@@ -24,7 +27,8 @@ export const getFilterPage = async (req: Request, res: Response, next: NextFunct
 
     logger.debugRequest(req, `${req.method} ${req.route.path}`);
     const isRemove = await isRemoveJourney(req);
-    const appData: ApplicationData = await getApplicationData(req);
+    const isUpdate: boolean = await isUpdateJourney(req);
+    const appData: ApplicationData = await getAppData(req, isUpdate, isRemove);
 
     if (isRemove) {
       return res.render(templateName, {
@@ -66,7 +70,7 @@ export const postFilterPage = async (
     const isRedisRemovalFlag = isActiveFeature(config.FEATURE_FLAG_ENABLE_REDIS_REMOVAL);
     const isUpdate: boolean = await isUpdateJourney(req);
     const isRemove: boolean = await isRemoveJourney(req);
-    const appData: ApplicationData = await getApplicationData(req);
+    const appData: ApplicationData = await getAppData(req, isUpdate, isRemove);
     const isSecureRegister = (req.body[IsSecureRegisterKey]).toString();
     appData[IsSecureRegisterKey] = isSecureRegister;
 
@@ -79,8 +83,8 @@ export const postFilterPage = async (
     if (isSecureRegister === "0") {
       nextPageUrl = isSecureRegisterNoUrl;
       if (isRedisRemovalFlag) {
-        await createOrUpdateEntityDetails(req, appData, isUpdate, isRemove);
-        nextPageUrl = getNextPageUrl(appData, isSecureRegisterNoUrl, isRedisRemovalFlag);
+        await updateEntityDetails(req, res, appData, isUpdate, isRemove, isSecureRegister);
+        nextPageUrl = getNextPageUrl(req, appData, isSecureRegisterNoUrl, isRedisRemovalFlag);
       }
     }
 
@@ -97,31 +101,54 @@ export const postFilterPage = async (
   }
 };
 
-const createOrUpdateEntityDetails = async (req: Request, appData: ApplicationData, isUpdate: boolean, isRemove: boolean): Promise<void> => {
+const updateEntityDetails = async (
+  req: Request,
+  res: Response,
+  appData: ApplicationData,
+  isUpdate: boolean,
+  isRemove: boolean,
+  isSecureRegister: string
+): Promise<void> => {
 
   const session = req.session as Session;
 
-  if ((isUpdate || isRemove) && !appData[Transactionkey]) {
-    const transactionID = await postTransaction(req, session);
-    appData[Transactionkey] = transactionID;
-    appData[OverseasEntityKey] = await createOverseasEntity(req, session, transactionID);
-  }
-
-  if (appData[Transactionkey] && appData[OverseasEntityKey]) {
-    await updateOverseasEntity(req, session, appData, true);
+  if (isUpdate || isRemove) {
+    saveDataToCookie(req, res, IsSecureRegisterKey, isSecureRegister);
   } else {
-    throw new Error("Error: is_secure_register filter cannot be updated - transaction_id or overseas_entity_id is missing");
+    if (appData[Transactionkey] && appData[OverseasEntityKey]) {
+      await updateOverseasEntity(req, session, appData, true);
+    } else {
+      throw new Error("Error: is_secure_register filter cannot be updated - transaction_id or overseas_entity_id is missing");
+    }
   }
 };
 
-const getNextPageUrl = (appData: ApplicationData, fallbackUrl: string, isRedisRemovalFlag: boolean): string => {
+const getNextPageUrl = (req, appData: ApplicationData, fallbackUrl: string, isRedisRemovalFlag: boolean): string => {
   try {
     if (isRedisRemovalFlag) {
-      return getUrlWithTransactionIdAndSubmissionId(fallbackUrl, appData[Transactionkey] as string, appData[OverseasEntityKey] as string);
+      if (appData[Transactionkey] && appData[OverseasEntityKey]) {
+        return getUrlWithTransactionIdAndSubmissionId(fallbackUrl, appData[Transactionkey] as string, appData[OverseasEntityKey] as string);
+      } else {
+        return getRedirectUrl({
+          req,
+          urlWithEntityIds: config.UPDATE_INTERRUPT_CARD_WITH_PARAMS_URL,
+          urlWithoutEntityIds: config.UPDATE_INTERRUPT_CARD_URL,
+        });
+      }
     }
     return fallbackUrl;
   } catch (error) {
     logger.error(`Error generating nextPageUrl with transactionId and submissionId: ${error}`);
     return fallbackUrl;
   }
+};
+
+const getAppData = async (req: Request, isUpdate: boolean, isRemove: boolean): Promise<ApplicationData> => {
+  let appData: ApplicationData = await getApplicationData(req);
+  if (isUpdate || isRemove) {
+    if (!Object.keys(appData).length) {
+      appData = await getDataFromEntityCookie(req, false);
+    }
+  }
+  return appData;
 };

--- a/src/utils/update/data.cookie.ts
+++ b/src/utils/update/data.cookie.ts
@@ -4,15 +4,15 @@ import { logger } from "../logger";
 import { mapInputDate } from "./mapper.utils";
 import { ApplicationData } from "../../model/application.model";
 import { getCompanyProfile } from "../../service/company.profile.service";
+import { EntityNumberKey, EntityCookieKey } from "../../model/data.types.model";
 import { mapCompanyProfileToOverseasEntity } from "./company.profile.mapper.to.overseas.entity";
-import { EntityCookieCompanyNumberKey, EntityCookieKey } from "../../model/data.types.model";
 
 export const getDataFromEntityCookie = async (req: Request, getCompany: boolean = true): Promise<ApplicationData> => {
 
   try {
 
     const cookieData = req.cookies[EntityCookieKey] ? JSON.parse(req.cookies[EntityCookieKey]) : {};
-    const entityNumber = cookieData?.[EntityCookieCompanyNumberKey];
+    const entityNumber = cookieData?.[EntityNumberKey];
 
     if (!entityNumber || !getCompany) {
       return cookieData;

--- a/test/controllers/update/overseas.entity.query.controller.spec.ts
+++ b/test/controllers/update/overseas.entity.query.controller.spec.ts
@@ -164,7 +164,7 @@ describe("OVERSEAS ENTITY QUERY controller", () => {
     });
 
     test('renders not found error for non existing oe number', async () => {
-      mockGetApplicationData.mockReturnValueOnce({});
+      mockGetApplicationData.mockReturnValue({});
       mockGetCompanyProfile.mockReturnValueOnce(undefined);
       const resp = await request(app)
         .post(config.OVERSEAS_ENTITY_QUERY_URL)
@@ -217,27 +217,6 @@ describe("OVERSEAS ENTITY QUERY controller", () => {
       expect(resp.header.location).toEqual(config.UPDATE_AN_OVERSEAS_ENTITY_URL + config.CONFIRM_OVERSEAS_ENTITY_DETAILS_PAGE);
     });
 
-    // @todo: test passes individually, but fails as part of the suite. needs to be fixed so it passes as part of the suite
-    test.skip('redirects to confirm page for valid oe number with lowercase oe in update journey when REDIS_flag is set to ON', async () => {
-      mockGetApplicationData.mockReturnValue({});
-      mockIsActiveFeature.mockReturnValue(true);
-      mockGetCompanyProfile.mockReturnValue(companyProfileQueryMock);
-      mockMapCompanyProfileToOverseasEntity.mockReturnValue({});
-      mockCreateOverseasEntity.mockReturnValue(OVERSEAS_ENTITY_ID);
-      mockRetrieveBoAndMoData.mockReturnValueOnce(Promise.resolve(true));
-      const resp = await request(app)
-        .post(config.OVERSEAS_ENTITY_QUERY_URL)
-        .send({ entity_number: testOENumberLowercase });
-      expect(resp.status).toEqual(302);
-      expect(mockRetrieveBoAndMoData).toHaveBeenCalledTimes(1);
-      expect(mockPostTransactionService).toHaveBeenCalledTimes(1);
-      expect(mockCreateOverseasEntity).toHaveBeenCalledTimes(1);
-      expect(mockUpdateOverseasEntity).toHaveBeenCalledTimes(1);
-      expect(mockSetExtraData).toHaveBeenCalledTimes(1);
-      expect(mockSaveDataToCookie).toHaveBeenCalledTimes(1);
-      expect(resp.header.location).toEqual(`${config.UPDATE_AN_OVERSEAS_ENTITY_URL}transaction/${TRANSACTION_ID}/submission/${OVERSEAS_ENTITY_ID}/${config.CONFIRM_OVERSEAS_ENTITY_DETAILS_PAGE}`);
-    });
-
     test('redirects to confirm page for valid oe number in remove journey', async () => {
       mockGetApplicationData.mockReturnValue({});
       mockGetCompanyProfile.mockReturnValueOnce(companyProfileQueryMock);
@@ -281,6 +260,27 @@ describe("OVERSEAS ENTITY QUERY controller", () => {
         expect(resp.status).toEqual(200);
         expect(resp.text).not.toContain(invalidOENUmberError);
       });
+
+    test('redirects to confirm page for valid oe number with lowercase oe in update journey when REDIS_flag is set to ON', async () => {
+      mockGetApplicationData.mockReturnValue({});
+      mockIsActiveFeature.mockReturnValue(true);
+      mockGetCompanyProfile.mockReturnValue(companyProfileQueryMock);
+      mockMapCompanyProfileToOverseasEntity.mockReturnValue({});
+      mockCreateOverseasEntity.mockReturnValue(OVERSEAS_ENTITY_ID);
+      mockRetrieveBoAndMoData.mockReturnValueOnce(Promise.resolve(true));
+      const resp = await request(app)
+        .post(config.OVERSEAS_ENTITY_QUERY_URL)
+        .send({ entity_number: testOENumberLowercase });
+      expect(resp.status).toEqual(302);
+      expect(mockRetrieveBoAndMoData).toHaveBeenCalledTimes(1);
+      expect(mockPostTransactionService).toHaveBeenCalledTimes(1);
+      expect(mockCreateOverseasEntity).toHaveBeenCalledTimes(1);
+      expect(mockUpdateOverseasEntity).toHaveBeenCalledTimes(1);
+      expect(mockSetExtraData).toHaveBeenCalledTimes(1);
+      expect(mockSaveDataToCookie).toHaveBeenCalledTimes(1);
+      expect(resp.header.location).toEqual(`${config.UPDATE_AN_OVERSEAS_ENTITY_URL}transaction/${TRANSACTION_ID}/submission/${OVERSEAS_ENTITY_ID}/${config.CONFIRM_OVERSEAS_ENTITY_DETAILS_PAGE}`);
+    });
+
   });
 
 });

--- a/test/controllers/update/overseas.entity.query.controller.spec.ts
+++ b/test/controllers/update/overseas.entity.query.controller.spec.ts
@@ -1,4 +1,3 @@
-
 jest.mock("ioredis");
 jest.mock("../../../src/utils/logger");
 jest.mock('../../../src/middleware/authentication.middleware');
@@ -6,12 +5,17 @@ jest.mock('../../../src/middleware/service.availability.middleware');
 jest.mock('../../../src/utils/application.data');
 jest.mock("../../../src/service/company.profile.service");
 jest.mock("../../../src/utils/update/company.profile.mapper.to.overseas.entity");
+jest.mock('../../../src/service/transaction.service');
+jest.mock('../../../src/service/overseas.entities.service');
 jest.mock("../../../src/utils/update/beneficial_owners_managing_officers_data_fetch");
 jest.mock("../../../src/utils/update/data.cookie");
+jest.mock("../../../src/utils/feature.flag" );
 
 // import remove journey middleware mock before app to prevent real function being used instead of mock
 import mockJourneyDetectionMiddleware from "../../__mocks__/journey.detection.middleware.mock";
 import mockCsrfProtectionMiddleware from "../../__mocks__/csrfProtectionMiddleware.mock";
+
+import { NextFunction } from "express";
 
 import * as config from "../../../src/config";
 import app from "../../../src/app";
@@ -20,17 +24,21 @@ import request from "supertest";
 import { beforeEach, jest, test, describe } from "@jest/globals";
 
 import { logger } from "../../../src/utils/logger";
-import { authentication } from "../../../src/middleware/authentication.middleware";
 import { ErrorMessages } from "../../../src/validation/error.messages";
-import { NextFunction } from "express";
+import { authentication } from "../../../src/middleware/authentication.middleware";
+import { isActiveFeature } from "../../../src/utils/feature.flag";
+import { ApplicationData } from "../../../src/model";
+import { postTransaction } from "../../../src/service/transaction.service";
 import { getCompanyProfile } from "../../../src/service/company.profile.service";
 import { retrieveBoAndMoData } from "../../../src/utils/update/beneficial_owners_managing_officers_data_fetch";
-import { ApplicationData } from "../../../src/model";
 import { companyProfileQueryMock } from "../../__mocks__/update.entity.mocks";
 import { serviceAvailabilityMiddleware } from "../../../src/middleware/service.availability.middleware";
 import { getApplicationData, setExtraData } from "../../../src/utils/application.data";
 import { mapCompanyProfileToOverseasEntity } from "../../../src/utils/update/company.profile.mapper.to.overseas.entity";
 import { getDataFromEntityCookie, saveDataToCookie } from "../../../src/utils/update/data.cookie";
+
+import { TRANSACTION_ID, OVERSEAS_ENTITY_ID } from "../../__mocks__/session.mock";
+import { createOverseasEntity, updateOverseasEntity } from "../../../src/service/overseas.entities.service";
 
 import {
   PAGE_TITLE_ERROR,
@@ -52,6 +60,8 @@ const mockGetApplicationData = getApplicationData as jest.Mock;
 const mockSetExtraData = setExtraData as jest.Mock;
 const mockGetCompanyProfile = getCompanyProfile as jest.Mock;
 const mockMapCompanyProfileToOverseasEntity = mapCompanyProfileToOverseasEntity as jest.Mock;
+const mockIsActiveFeature = isActiveFeature as jest.Mock;
+const mockCreateOverseasEntity = createOverseasEntity as jest.Mock;
 
 const mockGetDataFromEntityCookie = getDataFromEntityCookie as jest.Mock;
 mockGetDataFromEntityCookie.mockReturnValue(companyProfileQueryMock);
@@ -60,18 +70,28 @@ const mockSaveDataToCookie = saveDataToCookie as jest.Mock;
 mockSaveDataToCookie.mockReturnValue(true);
 
 const mockAuthenticationMiddleware = authentication as jest.Mock;
-mockAuthenticationMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => next() );
+mockAuthenticationMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => next());
 
 const mockServiceAvailabilityMiddleware = serviceAvailabilityMiddleware as jest.Mock;
-mockServiceAvailabilityMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => next() );
+mockServiceAvailabilityMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => next());
 
 const mockRetrieveBoAndMoData = retrieveBoAndMoData as jest.Mock;
-mockRetrieveBoAndMoData.mockImplementation((req: Request, appData: ApplicationData) => appData.update = { bo_mo_data_fetched: true } );
+mockRetrieveBoAndMoData.mockImplementation((req: Request, appData: ApplicationData) => appData.update = { bo_mo_data_fetched: true });
+
+const mockPostTransactionService = postTransaction as jest.Mock;
+mockPostTransactionService.mockReturnValue(TRANSACTION_ID);
+
+const mockUpdateOverseasEntity = updateOverseasEntity as jest.Mock;
+mockUpdateOverseasEntity.mockReturnValue(true);
 
 describe("OVERSEAS ENTITY QUERY controller", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockIsActiveFeature.mockReset();
+    mockCreateOverseasEntity.mockReset();
+    mockUpdateOverseasEntity.mockReset();
+    mockUpdateOverseasEntity.mockReset();
   });
 
   describe("GET tests", () => {
@@ -100,7 +120,7 @@ describe("OVERSEAS ENTITY QUERY controller", () => {
     });
 
     test('catch error when rendering the page', async () => {
-      mockLoggerDebugRequest.mockImplementationOnce( () => { throw new Error(ANY_MESSAGE_ERROR); });
+      mockLoggerDebugRequest.mockImplementationOnce(() => { throw new Error(ANY_MESSAGE_ERROR); });
       const resp = await request(app).get(config.OVERSEAS_ENTITY_QUERY_URL);
       expect(resp.status).toEqual(500);
       expect(resp.text).toContain(SERVICE_UNAVAILABLE);
@@ -182,8 +202,9 @@ describe("OVERSEAS ENTITY QUERY controller", () => {
       expect(resp.header.location).toEqual(config.UPDATE_AN_OVERSEAS_ENTITY_URL + config.CONFIRM_OVERSEAS_ENTITY_DETAILS_PAGE);
     });
 
-    test('redirects to confirm page for valid oe number with lowercase oe in update journey', async () => {
+    test('redirects to confirm page for valid oe number with lowercase oe in update journey when REDIS_flag is set to OFF', async () => {
       mockGetApplicationData.mockReturnValue({});
+      mockIsActiveFeature.mockReturnValue(false);
       mockGetCompanyProfile.mockReturnValueOnce(companyProfileQueryMock);
       mockMapCompanyProfileToOverseasEntity.mockReturnValueOnce({});
 
@@ -194,6 +215,27 @@ describe("OVERSEAS ENTITY QUERY controller", () => {
       expect(mockRetrieveBoAndMoData).toHaveBeenCalledTimes(1);
       expect(mockSetExtraData).toHaveBeenCalledTimes(1);
       expect(resp.header.location).toEqual(config.UPDATE_AN_OVERSEAS_ENTITY_URL + config.CONFIRM_OVERSEAS_ENTITY_DETAILS_PAGE);
+    });
+
+    // @todo: test passes individually, but fails as part of the suite. needs to be fixed so it passes as part of the suite
+    test.skip('redirects to confirm page for valid oe number with lowercase oe in update journey when REDIS_flag is set to ON', async () => {
+      mockGetApplicationData.mockReturnValue({});
+      mockIsActiveFeature.mockReturnValue(true);
+      mockGetCompanyProfile.mockReturnValue(companyProfileQueryMock);
+      mockMapCompanyProfileToOverseasEntity.mockReturnValue({});
+      mockCreateOverseasEntity.mockReturnValue(OVERSEAS_ENTITY_ID);
+      mockRetrieveBoAndMoData.mockReturnValueOnce(Promise.resolve(true));
+      const resp = await request(app)
+        .post(config.OVERSEAS_ENTITY_QUERY_URL)
+        .send({ entity_number: testOENumberLowercase });
+      expect(resp.status).toEqual(302);
+      expect(mockRetrieveBoAndMoData).toHaveBeenCalledTimes(1);
+      expect(mockPostTransactionService).toHaveBeenCalledTimes(1);
+      expect(mockCreateOverseasEntity).toHaveBeenCalledTimes(1);
+      expect(mockUpdateOverseasEntity).toHaveBeenCalledTimes(1);
+      expect(mockSetExtraData).toHaveBeenCalledTimes(1);
+      expect(mockSaveDataToCookie).toHaveBeenCalledTimes(1);
+      expect(resp.header.location).toEqual(`${config.UPDATE_AN_OVERSEAS_ENTITY_URL}transaction/${TRANSACTION_ID}/submission/${OVERSEAS_ENTITY_ID}/${config.CONFIRM_OVERSEAS_ENTITY_DETAILS_PAGE}`);
     });
 
     test('redirects to confirm page for valid oe number in remove journey', async () => {
@@ -211,7 +253,7 @@ describe("OVERSEAS ENTITY QUERY controller", () => {
     });
 
     test("catch error when posting data", async () => {
-      mockLoggerDebugRequest.mockImplementationOnce( () => { throw new Error(ANY_MESSAGE_ERROR); });
+      mockLoggerDebugRequest.mockImplementationOnce(() => { throw new Error(ANY_MESSAGE_ERROR); });
       const resp = await request(app)
         .post(config.OVERSEAS_ENTITY_QUERY_URL)
         .send({ entity_number: testOENumber });

--- a/test/controllers/update/secure.update.filter.controller.spec.ts
+++ b/test/controllers/update/secure.update.filter.controller.spec.ts
@@ -3,7 +3,6 @@ jest.mock("../../../src/utils/logger");
 jest.mock('../../../src/middleware/authentication.middleware');
 jest.mock('../../../src/middleware/service.availability.middleware');
 jest.mock('../../../src/utils/application.data');
-jest.mock('../../../src/service/transaction.service');
 jest.mock('../../../src/service/overseas.entities.service');
 jest.mock("../../../src/utils/feature.flag" );
 jest.mock("../../../src/utils/url");
@@ -21,22 +20,19 @@ import { logger } from "../../../src/utils/logger";
 import { ErrorMessages } from "../../../src/validation/error.messages";
 import { authentication } from "../../../src/middleware/authentication.middleware";
 import { isActiveFeature } from "../../../src/utils/feature.flag";
-import { postTransaction } from "../../../src/service/transaction.service";
 import { serviceAvailabilityMiddleware } from "../../../src/middleware/service.availability.middleware";
 
-import { setExtraData, fetchApplicationData, getApplicationData } from "../../../src/utils/application.data";
-import { createOverseasEntity, updateOverseasEntity } from "../../../src/service/overseas.entities.service";
+import { setExtraData, getApplicationData } from "../../../src/utils/application.data";
+import { updateOverseasEntity } from "../../../src/service/overseas.entities.service";
 
 import {
   isRemoveJourney,
   isUpdateJourney,
-  isRegistrationJourney,
   getUrlWithTransactionIdAndSubmissionId,
   getRedirectUrl,
 } from "../../../src/utils/url";
 
 import {
-  TRANSACTION_ID,
   APPLICATION_DATA_MOCK,
 } from "../../__mocks__/session.mock";
 
@@ -69,9 +65,6 @@ const mockIsRemoveJourney = isRemoveJourney as jest.Mock;
 const mockGetRedirectUrl = getRedirectUrl as jest.Mock;
 const MOCKED_PAGE_URL = "/MOCKED_PAGE";
 
-const mockIsRegistrationJourney = isRegistrationJourney as jest.Mock;
-mockIsRegistrationJourney.mockReturnValue(false);
-
 const mockIsUpdateJourney = isUpdateJourney as jest.Mock;
 mockIsUpdateJourney.mockReturnValue(true);
 
@@ -84,19 +77,12 @@ mockServiceAvailabilityMiddleware.mockImplementation((req: Request, res: Respons
 const mockGetUrlWithTransactionIdAndSubmissionId = getUrlWithTransactionIdAndSubmissionId as jest.Mock;
 mockGetUrlWithTransactionIdAndSubmissionId.mockReturnValue(MOCKED_PAGE_URL);
 
-const mockPostTransactionService = postTransaction as jest.Mock;
-mockPostTransactionService.mockReturnValue(TRANSACTION_ID);
-
 const mockGetApplicationData = getApplicationData as jest.Mock;
 mockGetApplicationData.mockReturnValue(APPLICATION_DATA_MOCK);
-
-const mockFetchApplicationData = fetchApplicationData as jest.Mock;
-mockFetchApplicationData.mockReturnValue(APPLICATION_DATA_MOCK);
 
 const mockLoggerDebugRequest = logger.debugRequest as jest.Mock;
 const mockSetExtraData = setExtraData as jest.Mock;
 const mockUpdateOverseasEntity = updateOverseasEntity as jest.Mock;
-const mockCreateOverseasEntity = createOverseasEntity as jest.Mock;
 
 describe("SECURE UPDATE FILTER controller", () => {
 
@@ -137,7 +123,6 @@ describe("SECURE UPDATE FILTER controller", () => {
 
     test(`renders the ${SECURE_UPDATE_FILTER_PAGE} page for remove`, async () => {
       mockIsActiveFeature.mockReturnValue(false);
-      mockFetchApplicationData.mockReturnValue({});
       mockGetApplicationData.mockReturnValue({});
       mockGetRedirectUrl.mockReturnValue(REMOVE_IS_ENTITY_REGISTERED_OWNER_URL);
       mockIsRemoveJourney.mockReturnValueOnce(true);
@@ -196,7 +181,6 @@ describe("SECURE UPDATE FILTER controller", () => {
       mockGetApplicationData.mockReturnValueOnce(APPLICATION_DATA_MOCK);
       mockIsRemoveJourney.mockReturnValueOnce(false);
       mockUpdateOverseasEntity.mockReturnValueOnce(true);
-      mockCreateOverseasEntity.mockReturnValueOnce(false);
 
       const resp = await request(app)
         .post(SECURE_UPDATE_FILTER_WITH_PARAMS_URL)
@@ -204,7 +188,6 @@ describe("SECURE UPDATE FILTER controller", () => {
 
       expect(resp.status).toEqual(302);
       expect(resp.header.location).toEqual(MOCKED_PAGE_URL);
-      expect(mockCreateOverseasEntity).not.toHaveBeenCalled();
       expect(mockGetUrlWithTransactionIdAndSubmissionId).toHaveBeenCalledTimes(1);
       expect(mockSetExtraData).toHaveBeenCalledTimes(1);
     });

--- a/test/utils/update/data.cookie.spec.ts
+++ b/test/utils/update/data.cookie.spec.ts
@@ -1,4 +1,3 @@
-
 jest.mock("../../../src/utils/logger");
 jest.mock("../../../src/service/company.profile.service");
 jest.mock("../../../src/utils/update/mapper.utils");
@@ -6,16 +5,17 @@ jest.mock("../../../src/utils/update/company.profile.mapper.to.overseas.entity")
 
 import { Request, Response } from "express";
 import { beforeEach, jest, describe, test, expect } from "@jest/globals";
+
 import { logger } from "../../../src/utils/logger";
-import { EntityNumberKey, EntityCookieKey } from "../../../src/model/data.types.model";
-import { getCompanyProfile } from "../../../src/service/company.profile.service";
 import { mapInputDate } from "../../../src/utils/update/mapper.utils";
+import { getCompanyProfile } from "../../../src/service/company.profile.service";
+import { EntityNumberKey, EntityCookieKey } from "../../../src/model/data.types.model";
 import { mapCompanyProfileToOverseasEntity } from "../../../src/utils/update/company.profile.mapper.to.overseas.entity";
 
 import {
-  getDataFromEntityCookie,
   saveDataToCookie,
   removeEntityCookie,
+  getDataFromEntityCookie,
 } from "../../../src/utils/update/data.cookie";
 
 import {

--- a/test/utils/update/data.cookie.spec.ts
+++ b/test/utils/update/data.cookie.spec.ts
@@ -1,9 +1,11 @@
+
 jest.mock("../../../src/utils/logger");
 jest.mock("../../../src/service/company.profile.service");
 
 import { Request, Response } from "express";
 import { beforeEach, jest, describe } from "@jest/globals";
 import { logger } from "../../../src/utils/logger";
+import { EntityNumberKey } from "../../../src/model/data.types.model";
 import { getCompanyProfile } from "../../../src/service/company.profile.service";
 
 import {
@@ -30,7 +32,7 @@ describe("Test suite for data cookie in update/remove journey", () => {
 
   const mockReq = {
     cookies: {
-      _roe: JSON.stringify({ e_number: testEntityNumber }),
+      _roe: JSON.stringify({ entity_number: testEntityNumber }),
     }
   } as Request;
 
@@ -46,7 +48,7 @@ describe("Test suite for data cookie in update/remove journey", () => {
     test("returns data object with only the entity number if company details are not found", async () => {
       mockGetCompanyProfile.mockReturnValue(false);
       const resp = await getDataFromEntityCookie(mockReq);
-      expect(resp).toEqual({ e_number: testEntityNumber });
+      expect(resp).toEqual({ [EntityNumberKey]: testEntityNumber });
     });
   });
 

--- a/test/utils/update/data.cookie.spec.ts
+++ b/test/utils/update/data.cookie.spec.ts
@@ -1,16 +1,21 @@
 
 jest.mock("../../../src/utils/logger");
 jest.mock("../../../src/service/company.profile.service");
+jest.mock("../../../src/utils/update/mapper.utils");
+jest.mock("../../../src/utils/update/company.profile.mapper.to.overseas.entity");
 
 import { Request, Response } from "express";
-import { beforeEach, jest, describe } from "@jest/globals";
+import { beforeEach, jest, describe, test, expect } from "@jest/globals";
 import { logger } from "../../../src/utils/logger";
-import { EntityNumberKey } from "../../../src/model/data.types.model";
+import { EntityNumberKey, EntityCookieKey } from "../../../src/model/data.types.model";
 import { getCompanyProfile } from "../../../src/service/company.profile.service";
+import { mapInputDate } from "../../../src/utils/update/mapper.utils";
+import { mapCompanyProfileToOverseasEntity } from "../../../src/utils/update/company.profile.mapper.to.overseas.entity";
 
 import {
   getDataFromEntityCookie,
   saveDataToCookie,
+  removeEntityCookie,
 } from "../../../src/utils/update/data.cookie";
 
 import {
@@ -21,6 +26,11 @@ import {
 
 const mockLoggerErrorRequest = logger.errorRequest as jest.Mock;
 const mockGetCompanyProfile = getCompanyProfile as jest.Mock;
+const mockMapInputDate = mapInputDate as jest.Mock;
+const mockMapCompanyProfileToOverseasEntity = mapCompanyProfileToOverseasEntity as jest.Mock;
+
+const MOCK_ENTITY_OBJECT = { incorporation_country: "Ireland" };
+const MOCK_DATE = { day: "01", month: "01", year: "2000" };
 
 describe("Test suite for data cookie in update/remove journey", () => {
 
@@ -28,12 +38,18 @@ describe("Test suite for data cookie in update/remove journey", () => {
     jest.clearAllMocks();
     mockGetCompanyProfile.mockReset();
     mockLoggerErrorRequest.mockReset();
+    mockMapInputDate.mockReturnValue(MOCK_DATE);
+    mockMapCompanyProfileToOverseasEntity.mockReturnValue(MOCK_ENTITY_OBJECT);
   });
 
   const mockReq = {
     cookies: {
-      _roe: JSON.stringify({ entity_number: testEntityNumber }),
+      [EntityCookieKey]: JSON.stringify({ [EntityNumberKey]: testEntityNumber }),
     }
+  } as Request;
+
+  const mockReqNoCookie = {
+    cookies: {}
   } as Request;
 
   describe("getDataFromEntityCookie", () => {
@@ -45,21 +61,152 @@ describe("Test suite for data cookie in update/remove journey", () => {
       expect(resp.entity_name).toBe(testEntityName);
     });
 
+    test("returns entity object and update date from mapped company profile", async () => {
+      mockGetCompanyProfile.mockReturnValue(companyProfileQueryMock);
+      const resp = await getDataFromEntityCookie(mockReq);
+      expect(resp.entity).toEqual(MOCK_ENTITY_OBJECT);
+      expect(resp.update).toEqual({ date_of_creation: MOCK_DATE });
+      expect(mockMapCompanyProfileToOverseasEntity).toHaveBeenCalledWith(companyProfileQueryMock);
+      expect(mockMapInputDate).toHaveBeenCalledWith(companyProfileQueryMock.dateOfCreation);
+    });
+
     test("returns data object with only the entity number if company details are not found", async () => {
       mockGetCompanyProfile.mockReturnValue(false);
       const resp = await getDataFromEntityCookie(mockReq);
       expect(resp).toEqual({ [EntityNumberKey]: testEntityNumber });
+      expect(mockLoggerErrorRequest).toHaveBeenCalledTimes(1);
+    });
+
+    test("returns empty cookie data when no entity_number is present in cookie", async () => {
+      const reqWithoutEntityNumber = {
+        cookies: {
+          [EntityCookieKey]: JSON.stringify({ some_other_key: "value" }),
+        }
+      } as Request;
+      const resp = await getDataFromEntityCookie(reqWithoutEntityNumber);
+      expect(resp).toEqual({ some_other_key: "value" });
+      expect(mockGetCompanyProfile).not.toHaveBeenCalled();
+    });
+
+    test("returns empty object when cookie is not present", async () => {
+      const resp = await getDataFromEntityCookie(mockReqNoCookie);
+      expect(resp).toEqual({});
+      expect(mockGetCompanyProfile).not.toHaveBeenCalled();
+    });
+
+    test("skips company profile fetch when getCompany is false", async () => {
+      const resp = await getDataFromEntityCookie(mockReq, false);
+      expect(resp).toEqual({ [EntityNumberKey]: testEntityNumber });
+      expect(mockGetCompanyProfile).not.toHaveBeenCalled();
+    });
+
+    test("returns empty object and logs error when an exception is thrown", async () => {
+      mockGetCompanyProfile.mockRejectedValue(new Error("service error"));
+      const resp = await getDataFromEntityCookie(mockReq);
+      expect(resp).toEqual({});
+      expect(mockLoggerErrorRequest).toHaveBeenCalledTimes(1);
     });
   });
 
   describe("saveDataToCookie", () => {
 
-    test("correctly saves entity number to data cookie", async () => {
+    test("correctly saves a key/value pair to the data cookie", () => {
       const mockRes = {
         cookie: jest.fn() as any,
       } as Response;
-      await saveDataToCookie(mockReq, mockRes, 'e_number', testEntityNumber);
-      expect(mockRes.cookie).toHaveBeenCalled();
+      saveDataToCookie(mockReq, mockRes, "e_number", testEntityNumber);
+      expect(mockRes.cookie).toHaveBeenCalledTimes(1);
+      expect(mockRes.cookie).toHaveBeenCalledWith(
+        EntityCookieKey,
+        expect.stringContaining(testEntityNumber),
+        expect.objectContaining({ httpOnly: true })
+      );
+    });
+
+    test("merges new key/value into existing cookie data", () => {
+      const mockRes = {
+        cookie: jest.fn() as any,
+      } as Response;
+      saveDataToCookie(mockReq, mockRes, "new_key", "new_value");
+      const calledWith = (mockRes.cookie as jest.Mock).mock.calls[0][1] as string;
+      const parsed = JSON.parse(calledWith);
+      expect(parsed[EntityNumberKey]).toBe(testEntityNumber);
+      expect(parsed["new_key"]).toBe("new_value");
+    });
+
+    test("starts with empty object when no existing cookie is present", () => {
+      const mockRes = {
+        cookie: jest.fn() as any,
+      } as Response;
+      saveDataToCookie(mockReqNoCookie, mockRes, "e_number", testEntityNumber);
+      const calledWith = (mockRes.cookie as jest.Mock).mock.calls[0][1] as string;
+      const parsed = JSON.parse(calledWith);
+      expect(parsed).toEqual({ e_number: testEntityNumber });
+    });
+
+    test("sets correct cookie options including httpOnly, path and domain", () => {
+      const mockRes = {
+        cookie: jest.fn() as any,
+      } as Response;
+      saveDataToCookie(mockReq, mockRes, "e_number", testEntityNumber);
+      const options = (mockRes.cookie as jest.Mock).mock.calls[0][2] as Record<string, unknown>;
+      expect(options.httpOnly).toBe(true);
+      expect(options).toHaveProperty("domain");
+      expect(options).toHaveProperty("path");
+      expect(options).toHaveProperty("secure");
+    });
+
+    test("logs error and rethrows when res.cookie throws", () => {
+      const mockRes = {
+        cookie: jest.fn().mockImplementation(() => { throw new Error("cookie error"); }) as any,
+      } as Response;
+      expect(() => saveDataToCookie(mockReq, mockRes, "e_number", testEntityNumber)).toThrow("cookie error");
+      expect(mockLoggerErrorRequest).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("removeEntityCookie", () => {
+
+    test("sets cookie with maxAge 0 and empty body when cookie exists", () => {
+      const mockRes = {
+        cookie: jest.fn() as any,
+      } as Response;
+      removeEntityCookie(mockReq, mockRes);
+      expect(mockRes.cookie).toHaveBeenCalledTimes(1);
+      expect(mockRes.cookie).toHaveBeenCalledWith(
+        EntityCookieKey,
+        "{}",
+        expect.objectContaining({ maxAge: 0, httpOnly: true })
+      );
+    });
+
+    test("does not set cookie when no entity cookie is present", () => {
+      const mockRes = {
+        cookie: jest.fn() as any,
+      } as Response;
+      removeEntityCookie(mockReqNoCookie, mockRes);
+      expect(mockRes.cookie).not.toHaveBeenCalled();
+    });
+
+    test("logs error when res.cookie throws during removal", () => {
+      const mockRes = {
+        cookie: jest.fn().mockImplementation(() => { throw new Error("removal error"); }) as any,
+      } as Response;
+      expect(() => removeEntityCookie(mockReq, mockRes)).not.toThrow();
+      expect(mockLoggerErrorRequest).toHaveBeenCalledTimes(1);
+    });
+
+    test("sets correct cookie options for removal including path and domain", () => {
+      const mockRes = {
+        cookie: jest.fn() as any,
+      } as Response;
+      removeEntityCookie(mockReq, mockRes);
+      const options = (mockRes.cookie as jest.Mock).mock.calls[0][2] as Record<string, unknown>;
+      expect(options.httpOnly).toBe(true);
+      expect(options.maxAge).toBe(0);
+      expect(options).toHaveProperty("domain");
+      expect(options).toHaveProperty("path");
+      expect(options).toHaveProperty("secure");
     });
   });
 });


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/CC-3352

### Change description

- Refactor to ensure transaction/entity creation is done after an entity number is supplied
- Preserves entity IDs in URL after transaction/entity creation
- Boost test coverage for data cookie spec

### Work checklist

- [x] Tests added where applicable
- [x] UI changes meet accessibility criteria