### PR TITLE
defect/cc-3407: fix issue with edit links for trusts and trustees

### DIFF
--- a/src/utils/add.trust.ts
+++ b/src/utils/add.trust.ts
@@ -6,6 +6,7 @@ import { Trust } from '../model/trust.model';
 import { getRedirectUrl } from './url';
 import { generateTrustId } from './trust/details.mapper';
 import { ApplicationData } from 'model';
+import { hasTrustsToReview } from "./update/review_trusts";
 import { getApplicationData } from './application.data';
 import { checkRelevantPeriod } from './relevant.period';
 import { isAddTrustToBeValidated } from '../validation/add.trust.validation';
@@ -24,6 +25,7 @@ type TrustInvolvedPageProperties = {
   templateName: string;
   isUpdate: boolean,
   backLinkUrl?: string,
+  hasTrustsToReview?: boolean;
   pageParams: {
     title: string,
     subtitle: string
@@ -38,6 +40,7 @@ type TrustInvolvedPageProperties = {
   url: string,
 };
 
+// note: isUpdate covers both Update and Remove journeys, so when on Remove journey isUpdate will be true
 const getPageProperties = async (
   req: Request,
   isUpdate: boolean,
@@ -47,12 +50,12 @@ const getPageProperties = async (
 
   const appData: ApplicationData = await getApplicationData(req);
 
-  // note: isUpdate covers both Update and Remove journeys, so when on Remove journey isUpdate will be true.
   return {
     ...appData,
     errors,
     isUpdate,
     formData,
+    hasTrustsToReview: isUpdate && hasTrustsToReview(appData),
     url: getUrl(isUpdate),
     templateName: getPageTemplate(isUpdate),
     backLinkUrl: getBackLinkUrl(isUpdate, req, appData),

--- a/src/utils/check.your.answers.ts
+++ b/src/utils/check.your.answers.ts
@@ -10,6 +10,7 @@ import { RoleWithinTrustType } from "../model/role.within.trust.type.model";
 import { startPaymentsSession } from "../service/payment.service";
 import { checkRPStatementsExist } from "./relevant.period";
 import { relevantPeriodStatementsState } from "../controllers/update/confirm.overseas.entity.details.controller";
+import { mapTrustApiToWebWhenFlagsAreSet } from "./trust/api.to.web.mapper";
 import { fetchOverseasEntityEmailAddress } from "./update/fetch.overseas.entity.email";
 import { getRedirectUrl, isRemoveJourney } from "./url";
 import { fetchBeneficialOwnersPrivateData } from "./update/fetch.beneficial.owners.private.data";
@@ -45,6 +46,7 @@ export const getDataForReview = async (req: Request, res: Response, next: NextFu
   const session = req.session as Session;
   const isRemove: boolean = await isRemoveJourney(req);
   const appData: ApplicationData = await getApplicationData(req);
+  mapTrustApiToWebWhenFlagsAreSet(appData);
   const hasAnyBosWithTrusteeNocs = isNoChangeJourney ? checkEntityReviewRequiresTrusts(appData) : checkEntityRequiresTrusts(appData);
   const backLinkUrl = getBackLinkUrl(req, isNoChangeJourney, hasAnyBosWithTrusteeNocs, isRemove);
   const templateName = getTemplateName(isNoChangeJourney);

--- a/test/controllers/update/check.your.answers.controller.spec.ts
+++ b/test/controllers/update/check.your.answers.controller.spec.ts
@@ -12,6 +12,7 @@ jest.mock("../../../src/utils/feature.flag");
 jest.mock('../../../src/middleware/statement.validation.middleware');
 jest.mock("../../../src/utils/date");
 jest.mock("../../../src/utils/url");
+jest.mock("../../../src/utils/trust/api.to.web.mapper");
 
 import { NextFunction, Request, Response } from "express";
 import request from "supertest";
@@ -20,20 +21,21 @@ import mockCsrfProtectionMiddleware from "../../__mocks__/csrfProtectionMiddlewa
 import app from "../../../src/app";
 
 import { logger } from "../../../src/utils/logger";
-import { DUE_DILIGENCE_OBJECT_MOCK } from "../../__mocks__/due.diligence.mock";
-import { OVERSEAS_ENTITY_DUE_DILIGENCE_OBJECT_MOCK } from "../../__mocks__/overseas.entity.due.diligence.mock";
+import { ADDRESS } from "../../__mocks__/fields/address.mock";
+import { getTodaysDate } from "../../../src/utils/date";
 import { authentication } from "../../../src/middleware/authentication.middleware";
-import { companyAuthentication } from "../../../src/middleware/company.authentication.middleware";
-import { updateOverseasEntity } from "../../../src/service/overseas.entities.service";
-import { startPaymentsSession } from "../../../src/service/payment.service";
 import { isActiveFeature } from "../../../src/utils/feature.flag";
 import { hasBOsOrMOsUpdate } from "../../../src/middleware/navigation/update/has.beneficial.owners.or.managing.officers.update.middleware";
-import { BeneficialOwnerIndividualKey } from "../../../src/model/beneficial.owner.individual.model";
+import { updateOverseasEntity } from "../../../src/service/overseas.entities.service";
+import { startPaymentsSession } from "../../../src/service/payment.service";
+import { companyAuthentication } from "../../../src/middleware/company.authentication.middleware";
 import { BeneficialOwnerGovKey } from "../../../src/model/beneficial.owner.gov.model";
-import { ADDRESS } from "../../__mocks__/fields/address.mock";
 import { BeneficialOwnerOtherKey } from "../../../src/model/beneficial.owner.other.model";
-import { getTodaysDate } from "../../../src/utils/date";
+import { DUE_DILIGENCE_OBJECT_MOCK } from "../../__mocks__/due.diligence.mock";
+import { BeneficialOwnerIndividualKey } from "../../../src/model/beneficial.owner.individual.model";
 import { serviceAvailabilityMiddleware } from "../../../src/middleware/service.availability.middleware";
+import { mapTrustApiToWebWhenFlagsAreSet } from "../../../src/utils/trust/api.to.web.mapper";
+import { OVERSEAS_ENTITY_DUE_DILIGENCE_OBJECT_MOCK } from "../../__mocks__/overseas.entity.due.diligence.mock";
 
 import { postTransaction, closeTransaction } from "../../../src/service/transaction.service";
 import { validateStatements, summaryPagesGuard } from "../../../src/middleware/statement.validation.middleware";
@@ -245,6 +247,9 @@ mockPaymentsSession.mockReturnValue("CONFIRMATION_URL");
 
 const mockIsRegistrationJourney = isRegistrationJourney as jest.Mock;
 mockIsRegistrationJourney.mockReturnValue(false);
+
+const mockMapTrustApiToWebWhenFlagsAreSet = mapTrustApiToWebWhenFlagsAreSet as jest.Mock;
+mockMapTrustApiToWebWhenFlagsAreSet.mockReturnValue(true);
 
 describe("CHECK YOUR ANSWERS controller", () => {
 

--- a/test/controllers/update/update.review.statement.controller.spec.ts
+++ b/test/controllers/update/update.review.statement.controller.spec.ts
@@ -14,6 +14,7 @@ jest.mock("../../../src/service/private.overseas.entity.details");
 jest.mock("../../../src/service/overseas.entities.service");
 jest.mock("../../../src/utils/date");
 jest.mock('../../../src/utils/url');
+jest.mock("../../../src/utils/trust/api.to.web.mapper");
 
 import { NextFunction, Request, Response } from "express";
 import request from "supertest";
@@ -33,6 +34,7 @@ import { updateOverseasEntity } from "../../../src/service/overseas.entities.ser
 import { startPaymentsSession } from "../../../src/service/payment.service";
 import { companyAuthentication } from "../../../src/middleware/company.authentication.middleware";
 import { serviceAvailabilityMiddleware } from "../../../src/middleware/service.availability.middleware";
+import { mapTrustApiToWebWhenFlagsAreSet } from "../../../src/utils/trust/api.to.web.mapper";
 
 import { postTransaction, closeTransaction } from "../../../src/service/transaction.service";
 import { OverseasEntityKey, Transactionkey } from "../../../src/model/data.types.model";
@@ -109,6 +111,11 @@ const mockFetchApplicationData = fetchApplicationData as jest.Mock;
 const mockLoggerDebugRequest = logger.debugRequest as jest.Mock;
 const mockAuthenticationMiddleware = authentication as jest.Mock;
 const mockGetRedirectUrl = getRedirectUrl as jest.Mock;
+const mockIsRemoveJourney = isRemoveJourney as jest.Mock;
+const mockGetPrivateOeDetails = getPrivateOeDetails as jest.Mock;
+const mockGetBeneficialOwnersPrivateData = getBeneficialOwnersPrivateData as jest.Mock;
+const mockSetExtraData = setExtraData as jest.Mock;
+const mockUpdateOverseasEntity = updateOverseasEntity as jest.Mock;
 
 mockAuthenticationMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => next() );
 
@@ -120,11 +127,6 @@ mockServiceAvailabilityMiddleware.mockImplementation((req: Request, res: Respons
 
 const mockHasOverseasEntityMiddleware = hasOverseasEntity as jest.Mock;
 mockHasOverseasEntityMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => next() );
-
-const mockGetPrivateOeDetails = getPrivateOeDetails as jest.Mock;
-const mockGetBeneficialOwnersPrivateData = getBeneficialOwnersPrivateData as jest.Mock;
-const mockSetExtraData = setExtraData as jest.Mock;
-const mockUpdateOverseasEntity = updateOverseasEntity as jest.Mock;
 
 const mockTransactionService = postTransaction as jest.Mock;
 mockTransactionService.mockReturnValue( TRANSACTION_ID );
@@ -146,7 +148,8 @@ const mockCheckActiveBOExists = checkActiveBOExists as jest.Mock;
 const mockIsRegistrationJourney = isRegistrationJourney as jest.Mock;
 mockIsRegistrationJourney.mockReturnValue(false);
 
-const mockIsRemoveJourney = isRemoveJourney as jest.Mock;
+const mockMapTrustApiToWebWhenFlagsAreSet = mapTrustApiToWebWhenFlagsAreSet as jest.Mock;
+mockMapTrustApiToWebWhenFlagsAreSet.mockReturnValue(true);
 
 const appData = { ...APPLICATION_DATA_CH_REF_UPDATE_MOCK, };
 

--- a/views/includes/check-your-answers/historical-trustee.html
+++ b/views/includes/check-your-answers/historical-trustee.html
@@ -20,17 +20,13 @@
     {% set changeLinkUrl = CREATE_CHANGE_LINK_WITH_IDS(OE_CONFIGS.TRUST_ENTRY_WITH_PARAMS_URL, OE_TRANSACTION_ID, OE_SUBMISSION_ID) + "/" + trust.trust_id + "/" + OE_CONFIGS.TRUST_HISTORICAL_BENEFICIAL_OWNER_PAGE + "/" + formerTrustee.id %}
   {% endif %}
 {% else %}
-  {% if not IS_REDIS_REMOVAL_ENABLED %}
+  {% if IS_REDIS_REMOVAL_ENABLED %}
+    {% set changeLinkUrl = CREATE_CHANGE_LINK_WITH_IDS(OE_CONFIGS.UPDATE_TRUSTS_INDIVIDUALS_OR_ENTITIES_INVOLVED_WITH_PARAMS_URL, OE_TRANSACTION_ID, OE_SUBMISSION_ID) +  "/" + trust.trust_id + "/" + OE_CONFIGS.TRUST_HISTORICAL_BENEFICIAL_OWNER_PAGE + "/" + formerTrustee.id %}
+  {% else %}
     {% if manageTrusts %}
       {% set changeLinkUrl = OE_CONFIGS.UPDATE_MANAGE_TRUSTS_ORCHESTRATOR_CHANGE_HANDLER_URL +  "/" + trust.trust_id + "/historical/" + formerTrustee.id %}
     {% else %}
       {% set changeLinkUrl = OE_CONFIGS.UPDATE_TRUSTS_INDIVIDUALS_OR_ENTITIES_INVOLVED_URL +  "/" + trust.trust_id + "/" + OE_CONFIGS.TRUST_HISTORICAL_BENEFICIAL_OWNER_PAGE + "/" + formerTrustee.id %}
-    {% endif %}
-  {% else %}
-    {% if manageTrusts %}
-      {% set changeLinkUrl = CREATE_CHANGE_LINK_WITH_IDS(OE_CONFIGS.UPDATE_MANAGE_TRUSTS_ORCHESTRATOR_CHANGE_HANDLER_WITH_PARAMS_URL, OE_TRANSACTION_ID, OE_SUBMISSION_ID) +  "/" + trust.trust_id + "/historical/" + formerTrustee.id %}
-    {% else %}
-      {% set changeLinkUrl = CREATE_CHANGE_LINK_WITH_IDS(OE_CONFIGS.UPDATE_TRUSTS_INDIVIDUALS_OR_ENTITIES_INVOLVED_WITH_PARAMS_URL, OE_TRANSACTION_ID, OE_SUBMISSION_ID) +  "/" + trust.trust_id + "/" + OE_CONFIGS.TRUST_HISTORICAL_BENEFICIAL_OWNER_PAGE + "/" + formerTrustee.id %}
     {% endif %}
   {% endif %}
 {% endif %}

--- a/views/includes/check-your-answers/individual-trustee.html
+++ b/views/includes/check-your-answers/individual-trustee.html
@@ -51,18 +51,14 @@
   {% set stillInvolved = individualTrustee.still_involved %}
   {% set isNotStillInvolved = stillInvolved === "No" %}
   {% set trusteeCeasedDate = dateMacros.formatDate(individualTrustee.ceased_date_day, individualTrustee.ceased_date_month, individualTrustee.ceased_date_year) %}
-  {% if not IS_REDIS_REMOVAL_ENABLED %}
-    {% if manageTrusts %}
+  {% if IS_REDIS_REMOVAL_ENABLED %}
+    {% set changeLinkUrl = CREATE_CHANGE_LINK_WITH_IDS(OE_CONFIGS.UPDATE_TRUSTS_INDIVIDUALS_OR_ENTITIES_INVOLVED_WITH_PARAMS_URL, OE_TRANSACTION_ID, OE_SUBMISSION_ID) +  "/" + trust.trust_id + "/" + OE_CONFIGS.TRUST_INDIVIDUAL_BENEFICIAL_OWNER_PAGE + "/" + individualTrustee.id %}
+  {% else %}
+     {% if manageTrusts %}
       {% set changeLinkUrl = OE_CONFIGS.UPDATE_MANAGE_TRUSTS_ORCHESTRATOR_CHANGE_HANDLER_URL +  "/" + trust.trust_id + "/individual/" + individualTrustee.id %}
     {% else %}
       {% set changeLinkUrl = OE_CONFIGS.UPDATE_TRUSTS_INDIVIDUALS_OR_ENTITIES_INVOLVED_URL +  "/" + trust.trust_id + "/" + OE_CONFIGS.TRUST_INDIVIDUAL_BENEFICIAL_OWNER_PAGE + "/" + individualTrustee.id %}
-    {% endif %}
-  {% else %}
-    {% if manageTrusts %}
-      {% set changeLinkUrl = CREATE_CHANGE_LINK_WITH_IDS(OE_CONFIGS.UPDATE_MANAGE_TRUSTS_ORCHESTRATOR_CHANGE_HANDLER_WITH_PARAMS_URL, OE_TRANSACTION_ID, OE_SUBMISSION_ID) +  "/" + trust.trust_id + "/individual/" + individualTrustee.id %}
-    {% else %}
-      {% set changeLinkUrl = CREATE_CHANGE_LINK_WITH_IDS(OE_CONFIGS.UPDATE_TRUSTS_INDIVIDUALS_OR_ENTITIES_INVOLVED_WITH_PARAMS_URL, OE_TRANSACTION_ID, OE_SUBMISSION_ID) +  "/" + trust.trust_id + "/" + OE_CONFIGS.TRUST_INDIVIDUAL_BENEFICIAL_OWNER_PAGE + "/" + individualTrustee.id %}
-    {% endif %}
+    {% endif %} 
   {% endif %}
 {% endif %}
 

--- a/views/includes/check-your-answers/legal-entity-trustee.html
+++ b/views/includes/check-your-answers/legal-entity-trustee.html
@@ -61,18 +61,14 @@
   {% set stillInvolved = legalEntity.still_involved %}
   {% set isNotStillInvolved = stillInvolved === "No" %}
   {% set trusteeCeasedDate = dateMacros.formatDate(legalEntity.ceased_date_day, legalEntity.ceased_date_month, legalEntity.ceased_date_year) %}
-  {% if not IS_REDIS_REMOVAL_ENABLED %}
-    {% if manageTrusts %}
+  {% if IS_REDIS_REMOVAL_ENABLED %}
+    {% set changeLinkUrl = CREATE_CHANGE_LINK_WITH_IDS(OE_CONFIGS.UPDATE_TRUSTS_INDIVIDUALS_OR_ENTITIES_INVOLVED_WITH_PARAMS_URL, OE_TRANSACTION_ID, OE_SUBMISSION_ID) +  "/" + trust.trust_id + "/" + OE_CONFIGS.TRUST_LEGAL_ENTITY_BENEFICIAL_OWNER_PAGE + "/" + legalEntity.id %}
+  {% else %}
+     {% if manageTrusts %}
       {% set changeLinkUrl = OE_CONFIGS.UPDATE_MANAGE_TRUSTS_ORCHESTRATOR_CHANGE_HANDLER_URL + "/" + trust.trust_id + "/legalEntity/" + legalEntity.id %}
     {% else %}
       {% set changeLinkUrl = OE_CONFIGS.UPDATE_TRUSTS_INDIVIDUALS_OR_ENTITIES_INVOLVED_URL +  "/" + trust.trust_id + "/" + OE_CONFIGS.TRUST_LEGAL_ENTITY_BENEFICIAL_OWNER_PAGE + "/" + legalEntity.id %}
-    {% endif %}
-  {% else %}
-    {% if manageTrusts %}
-      {% set changeLinkUrl = CREATE_CHANGE_LINK_WITH_IDS(OE_CONFIGS.UPDATE_MANAGE_TRUSTS_ORCHESTRATOR_CHANGE_HANDLER_WITH_PARAMS_URL, OE_TRANSACTION_ID, OE_SUBMISSION_ID) + "/" + trust.trust_id + "/legalEntity/" + legalEntity.id %}
-    {% else %}
-      {% set changeLinkUrl = CREATE_CHANGE_LINK_WITH_IDS(OE_CONFIGS.UPDATE_TRUSTS_INDIVIDUALS_OR_ENTITIES_INVOLVED_WITH_PARAMS_URL, OE_TRANSACTION_ID, OE_SUBMISSION_ID) +  "/" + trust.trust_id + "/" + OE_CONFIGS.TRUST_LEGAL_ENTITY_BENEFICIAL_OWNER_PAGE + "/" + legalEntity.id %}
-    {% endif %}
+    {% endif %} 
   {% endif %}
 {% endif %}
 

--- a/views/includes/check-your-answers/managing-officer-corporate.html
+++ b/views/includes/check-your-answers/managing-officer-corporate.html
@@ -29,7 +29,7 @@
 {% if not IS_REDIS_REMOVAL_ENABLED %}
   {% set changeLinkUrl = OE_CONFIGS.MANAGING_OFFICER_CORPORATE_URL + "/" + moc.id %}
 {% else %}
-  {% set changeLinkUrl = CREATE_CHANGE_LINK_WITH_IDS(OE_CONFIGS.MANAGING_OFFICER_CORPORATE_WITH_PARAMS_URL, OE_TRANSACTION_ID, OE_SUBMISSION_ID) + "/" + moc.id %} %}
+  {% set changeLinkUrl = CREATE_CHANGE_LINK_WITH_IDS(OE_CONFIGS.MANAGING_OFFICER_CORPORATE_WITH_PARAMS_URL, OE_TRANSACTION_ID, OE_SUBMISSION_ID) + "/" + moc.id %}
 {% endif %}
 
 <h3 class="govuk-heading-m">Corporate managing officer</h3>

--- a/views/includes/check-your-answers/trusts.html
+++ b/views/includes/check-your-answers/trusts.html
@@ -26,18 +26,14 @@
     {% set isTrustStillInvolved = trustStillInvolved === "Yes" %}
     {% set isTrustNotStillInvolved = trustStillInvolved === "No" %}
     {% set trustCeasedDate = dateMacros.formatDate(trust.ceased_date_day, trust.ceased_date_month, trust.ceased_date_year) %}
-    {% if not IS_REDIS_REMOVAL_ENABLED %}
-      {% if manageTrusts %}
+    {% if IS_REDIS_REMOVAL_ENABLED %}
+      {% set changeLinkUrl = CREATE_CHANGE_LINK_WITH_IDS(OE_CONFIGS.UPDATE_TRUSTS_TELL_US_ABOUT_IT_WITH_PARAMS_URL, OE_TRANSACTION_ID, OE_SUBMISSION_ID) %}
+    {% else %}
+       {% if manageTrusts %}
         {% set changeLinkUrl = OE_CONFIGS.UPDATE_MANAGE_TRUSTS_ORCHESTRATOR_CHANGE_HANDLER_URL %}
       {% else %}
         {% set changeLinkUrl = OE_CONFIGS.UPDATE_TRUSTS_TELL_US_ABOUT_IT_URL %}
-      {% endif %}
-    {% else %}
-      {% if manageTrusts %}
-        {% set changeLinkUrl = CREATE_CHANGE_LINK_WITH_IDS(OE_CONFIGS.UPDATE_MANAGE_TRUSTS_ORCHESTRATOR_CHANGE_HANDLER_WITH_PARAMS_URL, OE_TRANSACTION_ID, OE_SUBMISSION_ID) %}
-      {% else %}
-        {% set changeLinkUrl = CREATE_CHANGE_LINK_WITH_IDS(OE_CONFIGS.UPDATE_TRUSTS_TELL_US_ABOUT_IT_WITH_PARAMS_URL, OE_TRANSACTION_ID, OE_SUBMISSION_ID) %}
-      {% endif %}
+      {% endif %} 
     {% endif %}
   {% endif %}
 

--- a/views/includes/page-templates/add-trust.html
+++ b/views/includes/page-templates/add-trust.html
@@ -20,10 +20,14 @@
         {% set addedTrusts = [] %}
 
         {% if not IS_REDIS_REMOVAL_ENABLED %}
-          {% set changeTrustsOrchestratorLink = OE_CONFIGS.UPDATE_MANAGE_TRUSTS_ORCHESTRATOR_CHANGE_HANDLER_URL %}
+          {% set changeTrustLink = OE_CONFIGS.UPDATE_MANAGE_TRUSTS_ORCHESTRATOR_CHANGE_HANDLER_URL %}
         {% else %}
-          {% set changeTrustsOrchestratorLink = CREATE_CHANGE_LINK_WITH_IDS(OE_CONFIGS.UPDATE_MANAGE_TRUSTS_ORCHESTRATOR_CHANGE_HANDLER_WITH_PARAMS_URL, OE_TRANSACTION_ID, OE_SUBMISSION_ID) %}
-        {% endif %}
+          {% if hasTrustsToReview %}
+            {% set changeTrustLink = CREATE_CHANGE_LINK_WITH_IDS(OE_CONFIGS.UPDATE_MANAGE_TRUSTS_ORCHESTRATOR_CHANGE_HANDLER_WITH_PARAMS_URL, OE_TRANSACTION_ID, OE_SUBMISSION_ID) %}
+          {% else %}
+            {% set changeTrustLink = CREATE_CHANGE_LINK_WITH_IDS(OE_CONFIGS.UPDATE_TRUSTS_TELL_US_ABOUT_IT_WITH_PARAMS_URL, OE_TRANSACTION_ID, OE_SUBMISSION_ID) %}
+          {% endif %}
+      {% endif %}
 
         {% for trust in pageData.trustData %}
             {% if trust.ch_reference.length %}
@@ -36,7 +40,7 @@
                 },
                 actions: {
                   items: [CREATE_CHANGE_LINK(
-                    changeTrustsOrchestratorLink + "/" + trust.trust_id,
+                    changeTrustLink + "/" + trust.trust_id,
                     "Trust " + trust.trust_name,
                     "change-trust-button"
                   )]


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/CC-3407

### Change description

- Fixes issue with edit link for trusts on the `update-manage-trusts-individuals-or-entities-involved` page when the Redis flag is set to `true`
- Fixes issue with edit link for trusts, historical trustees, individual trustees and legal entity trustees on the `/update/check-your-answers` page when the Redis flag is set to `true`
- Adds/updates unit tests to reflect updated functionality

### Work checklist

- [x] Tests added where applicable
- [x] UI changes meet accessibility criteria
