### PR TITLE
defect/cc-3413, defect/cc-3407: ensure `is_newly_added` flag is correctly added to trustees during review

### DIFF
--- a/src/utils/add.trust.ts
+++ b/src/utils/add.trust.ts
@@ -6,7 +6,6 @@ import { Trust } from '../model/trust.model';
 import { getRedirectUrl } from './url';
 import { generateTrustId } from './trust/details.mapper';
 import { ApplicationData } from 'model';
-import { hasTrustsToReview } from "./update/review_trusts";
 import { getApplicationData } from './application.data';
 import { checkRelevantPeriod } from './relevant.period';
 import { isAddTrustToBeValidated } from '../validation/add.trust.validation';
@@ -25,7 +24,6 @@ type TrustInvolvedPageProperties = {
   templateName: string;
   isUpdate: boolean,
   backLinkUrl?: string,
-  hasTrustsToReview?: boolean;
   pageParams: {
     title: string,
     subtitle: string
@@ -40,7 +38,6 @@ type TrustInvolvedPageProperties = {
   url: string,
 };
 
-// note: isUpdate covers both Update and Remove journeys, so when on Remove journey isUpdate will be true
 const getPageProperties = async (
   req: Request,
   isUpdate: boolean,
@@ -50,12 +47,12 @@ const getPageProperties = async (
 
   const appData: ApplicationData = await getApplicationData(req);
 
+  // note: isUpdate covers both Update and Remove journeys, so when on Remove journey isUpdate will be true.
   return {
     ...appData,
     errors,
     isUpdate,
     formData,
-    hasTrustsToReview: isUpdate && hasTrustsToReview(appData),
     url: getUrl(isUpdate),
     templateName: getPageTemplate(isUpdate),
     backLinkUrl: getBackLinkUrl(isUpdate, req, appData),

--- a/src/utils/check.your.answers.ts
+++ b/src/utils/check.your.answers.ts
@@ -10,7 +10,6 @@ import { RoleWithinTrustType } from "../model/role.within.trust.type.model";
 import { startPaymentsSession } from "../service/payment.service";
 import { checkRPStatementsExist } from "./relevant.period";
 import { relevantPeriodStatementsState } from "../controllers/update/confirm.overseas.entity.details.controller";
-import { mapTrustApiToWebWhenFlagsAreSet } from "./trust/api.to.web.mapper";
 import { fetchOverseasEntityEmailAddress } from "./update/fetch.overseas.entity.email";
 import { getRedirectUrl, isRemoveJourney } from "./url";
 import { fetchBeneficialOwnersPrivateData } from "./update/fetch.beneficial.owners.private.data";
@@ -46,7 +45,6 @@ export const getDataForReview = async (req: Request, res: Response, next: NextFu
   const session = req.session as Session;
   const isRemove: boolean = await isRemoveJourney(req);
   const appData: ApplicationData = await getApplicationData(req);
-  mapTrustApiToWebWhenFlagsAreSet(appData);
   const hasAnyBosWithTrusteeNocs = isNoChangeJourney ? checkEntityReviewRequiresTrusts(appData) : checkEntityRequiresTrusts(appData);
   const backLinkUrl = getBackLinkUrl(req, isNoChangeJourney, hasAnyBosWithTrusteeNocs, isRemove);
   const templateName = getTemplateName(isNoChangeJourney);

--- a/src/utils/trust/historical.beneficial.owner.mapper.ts
+++ b/src/utils/trust/historical.beneficial.owner.mapper.ts
@@ -1,10 +1,10 @@
 import { v4 as uuidv4 } from 'uuid';
-import { TrusteeType } from '../../model/trustee.type.model';
 import * as Trust from '../../model/trust.model';
 import * as Page from '../../model/trust.page.model';
+import { TrusteeType } from '../../model/trustee.type.model';
 import { yesNoResponse } from '../../model/data.types.model';
-import { getFormerTrustee } from '../../utils/trusts';
 import { ApplicationData } from 'model';
+import { getFormerTrustee } from '../../utils/trusts';
 
 const mapBeneficialOwnerToSession = (
   formData: Page.TrustHistoricalBeneficialOwnerForm,
@@ -57,7 +57,7 @@ const mapFormerTrusteeFromSessionToPage = (
     endDateDay: trustee.ceased_date_day,
     endDateMonth: trustee.ceased_date_month,
     endDateYear: trustee.ceased_date_year,
-    is_newly_added: trustee.ch_references ? false : true
+    is_newly_added: trustee.ch_references ? false : Number(String(trustee.id)) ? false : true,
   };
 
   if (trustee.corporate_indicator && 'corporate_name' in trustee) {

--- a/src/utils/trust/historical.beneficial.owner.mapper.ts
+++ b/src/utils/trust/historical.beneficial.owner.mapper.ts
@@ -57,7 +57,7 @@ const mapFormerTrusteeFromSessionToPage = (
     endDateDay: trustee.ceased_date_day,
     endDateMonth: trustee.ceased_date_month,
     endDateYear: trustee.ceased_date_year,
-    is_newly_added: trustee.ch_references ? false : Number(String(trustee.id)) ? false : true,
+    is_newly_added: trustee.ch_references ? false : Number(trustee.id) ? false : true,
   };
 
   if (trustee.corporate_indicator && 'corporate_name' in trustee) {

--- a/src/utils/trust/individual.trustee.mapper.ts
+++ b/src/utils/trust/individual.trustee.mapper.ts
@@ -111,7 +111,7 @@ export const mapIndividualTrusteeFromSessionToPage = (
 
   const data = {
     trusteeId: trustee.id,
-    is_newly_added: trustee.ch_references ? false : Number(String(trustee.id)) ? false : true,
+    is_newly_added: trustee.ch_references ? false : Number(trustee.id) ? false : true,
     roleWithinTrust: trustee.type,
     forename: trustee.forename,
     surname: trustee.surname,

--- a/src/utils/trust/individual.trustee.mapper.ts
+++ b/src/utils/trust/individual.trustee.mapper.ts
@@ -1,9 +1,9 @@
+import { v4 as uuidv4 } from 'uuid';
 import * as Trust from '../../model/trust.model';
 import * as Page from '../../model/trust.page.model';
-import { v4 as uuidv4 } from 'uuid';
+import { ApplicationData } from 'model';
 import { RoleWithinTrustType } from '../../model/role.within.trust.type.model';
 import { getIndividualTrustee } from '../../utils/trusts';
-import { ApplicationData } from 'model';
 
 enum YesOrNo {
   No = "0",
@@ -111,7 +111,7 @@ export const mapIndividualTrusteeFromSessionToPage = (
 
   const data = {
     trusteeId: trustee.id,
-    is_newly_added: trustee.ch_references ? false : true,
+    is_newly_added: trustee.ch_references ? false : Number(String(trustee.id)) ? false : true,
     roleWithinTrust: trustee.type,
     forename: trustee.forename,
     surname: trustee.surname,

--- a/src/utils/trust/legal.entity.beneficial.owner.mapper.ts
+++ b/src/utils/trust/legal.entity.beneficial.owner.mapper.ts
@@ -177,7 +177,7 @@ const mapLegalEntityItemToPage = (
     id: legalEntity.id,
     name: legalEntity.name,
     trusteeItemType: TrusteeType.LEGAL_ENTITY,
-    is_newly_added: legalEntity.ch_references ? false : Number(String(legalEntity.id)) ? false : true,
+    is_newly_added: legalEntity.ch_references ? false : Number(legalEntity.id) ? false : true,
   };
 };
 

--- a/src/utils/trust/legal.entity.beneficial.owner.mapper.ts
+++ b/src/utils/trust/legal.entity.beneficial.owner.mapper.ts
@@ -2,9 +2,9 @@ import { v4 as uuidv4 } from "uuid";
 import * as Trust from "../../model/trust.model";
 import * as Page from "../../model/trust.page.model";
 import { TrusteeType } from '../../model/trustee.type.model';
+import { ApplicationData } from 'model';
 import { RoleWithinTrustType } from '../../model/role.within.trust.type.model';
 import { getLegalEntityTrustee } from '../../utils/trusts';
-import { ApplicationData } from 'model';
 
 enum YesOrNo {
   No = "0",
@@ -52,6 +52,7 @@ const mapLegalEntityToSession = (
   };
 
   let publicRegisterData = {};
+
   if (formData.is_on_register_in_country_formed_in?.toString() === "1") {
     publicRegisterData = {
       identification_place_registered: formData.public_register_name,
@@ -176,11 +177,11 @@ const mapLegalEntityItemToPage = (
     id: legalEntity.id,
     name: legalEntity.name,
     trusteeItemType: TrusteeType.LEGAL_ENTITY,
-    is_newly_added: legalEntity.ch_references ? false : true
+    is_newly_added: legalEntity.ch_references ? false : Number(String(legalEntity.id)) ? false : true,
   };
 };
 
-//  other
+// other
 const generateId = (): string => {
   return uuidv4();
 };

--- a/src/utils/update/review_trusts.ts
+++ b/src/utils/update/review_trusts.ts
@@ -128,18 +128,11 @@ export const putTrustInChangeScenario = (appData: ApplicationData, trustId: stri
   const trustForChangeScenario = appData.trusts?.splice(appData.trusts.findIndex(trust => trust.trust_id === trustId), 1)[0];
 
   if (!isActiveFeature(FEATURE_FLAG_ENABLE_REDIS_REMOVAL)) {
-
     appData.update?.review_trusts?.push(trustForChangeScenario as Trust);
     const trustInChangeScenario = (appData.update?.review_trusts ?? [])[0];
 
     if (trustInChangeScenario) {
-      trustInChangeScenario.review_status = {
-        in_review: true,
-        reviewed_former_bos: (trusteeType ? trusteeType !== TrusteeType.HISTORICAL : true),
-        reviewed_individuals: (trusteeType ? trusteeType !== TrusteeType.INDIVIDUAL : true),
-        reviewed_legal_entities: (trusteeType ? trusteeType !== TrusteeType.LEGAL_ENTITY : true),
-        reviewed_trust_details: (trusteeType !== undefined)
-      };
+      trustInChangeScenario.review_status = resetTrustInChangeReviewStatus(trusteeType);
     }
 
   } else {
@@ -152,13 +145,7 @@ export const putTrustInChangeScenario = (appData: ApplicationData, trustId: stri
     }
 
     if (trustForChangeScenario) {
-      trustForChangeScenario.review_status = {
-        in_review: true,
-        reviewed_former_bos: false,
-        reviewed_individuals: false,
-        reviewed_legal_entities: false,
-        reviewed_trust_details: false,
-      };
+      trustForChangeScenario.review_status = resetTrustInChangeReviewStatus(trusteeType);
     }
     appData.update?.review_trusts?.push(trustForChangeScenario as Trust);
   }
@@ -205,4 +192,14 @@ const resetTrustReviewStatus = (trust: Trust) => {
       reviewed_legal_entities: false
     };
   }
+};
+
+const resetTrustInChangeReviewStatus = (trusteeType) => {
+  return {
+    in_review: true,
+    reviewed_former_bos: (trusteeType ? trusteeType !== TrusteeType.HISTORICAL : true),
+    reviewed_individuals: (trusteeType ? trusteeType !== TrusteeType.INDIVIDUAL : true),
+    reviewed_legal_entities: (trusteeType ? trusteeType !== TrusteeType.LEGAL_ENTITY : true),
+    reviewed_trust_details: (trusteeType !== undefined)
+  };
 };

--- a/src/utils/update/review_trusts.ts
+++ b/src/utils/update/review_trusts.ts
@@ -1,6 +1,8 @@
 import { Trust } from '../../model/trust.model';
-import { ApplicationData } from '../../model';
 import { TrusteeType } from '../../model/trustee.type.model';
+import { ApplicationData } from '../../model';
+import { isActiveFeature } from "../feature.flag";
+import { FEATURE_FLAG_ENABLE_REDIS_REMOVAL } from "../../config";
 
 export const hasTrustsToReview = (appData: ApplicationData) =>
   (appData.update?.review_trusts ?? []).length > 0;
@@ -122,20 +124,43 @@ export const moveTrustOutOfReview = (appData: ApplicationData) => {
 };
 
 export const putTrustInChangeScenario = (appData: ApplicationData, trustId: string, trusteeType?: string) => {
+
   const trustForChangeScenario = appData.trusts?.splice(appData.trusts.findIndex(trust => trust.trust_id === trustId), 1)[0];
 
-  appData.update?.review_trusts?.push(trustForChangeScenario as Trust);
+  if (!isActiveFeature(FEATURE_FLAG_ENABLE_REDIS_REMOVAL)) {
 
-  const trustInChangeScenario = (appData.update?.review_trusts ?? [])[0];
+    appData.update?.review_trusts?.push(trustForChangeScenario as Trust);
+    const trustInChangeScenario = (appData.update?.review_trusts ?? [])[0];
 
-  if (trustInChangeScenario) {
-    trustInChangeScenario.review_status = {
-      in_review: true,
-      reviewed_former_bos: (trusteeType ? trusteeType !== TrusteeType.HISTORICAL : true),
-      reviewed_individuals: (trusteeType ? trusteeType !== TrusteeType.INDIVIDUAL : true),
-      reviewed_legal_entities: (trusteeType ? trusteeType !== TrusteeType.LEGAL_ENTITY : true),
-      reviewed_trust_details: (trusteeType !== undefined)
-    };
+    if (trustInChangeScenario) {
+      trustInChangeScenario.review_status = {
+        in_review: true,
+        reviewed_former_bos: (trusteeType ? trusteeType !== TrusteeType.HISTORICAL : true),
+        reviewed_individuals: (trusteeType ? trusteeType !== TrusteeType.INDIVIDUAL : true),
+        reviewed_legal_entities: (trusteeType ? trusteeType !== TrusteeType.LEGAL_ENTITY : true),
+        reviewed_trust_details: (trusteeType !== undefined)
+      };
+    }
+
+  } else {
+
+    if (!appData.update?.review_trusts) {
+      appData.update = {
+        ...appData.update,
+        review_trusts: [],
+      };
+    }
+
+    if (trustForChangeScenario) {
+      trustForChangeScenario.review_status = {
+        in_review: true,
+        reviewed_former_bos: false,
+        reviewed_individuals: false,
+        reviewed_legal_entities: false,
+        reviewed_trust_details: false,
+      };
+    }
+    appData.update?.review_trusts?.push(trustForChangeScenario as Trust);
   }
 };
 

--- a/test/controllers/update/check.your.answers.controller.spec.ts
+++ b/test/controllers/update/check.your.answers.controller.spec.ts
@@ -12,7 +12,6 @@ jest.mock("../../../src/utils/feature.flag");
 jest.mock('../../../src/middleware/statement.validation.middleware');
 jest.mock("../../../src/utils/date");
 jest.mock("../../../src/utils/url");
-jest.mock("../../../src/utils/trust/api.to.web.mapper");
 
 import { NextFunction, Request, Response } from "express";
 import request from "supertest";
@@ -21,21 +20,20 @@ import mockCsrfProtectionMiddleware from "../../__mocks__/csrfProtectionMiddlewa
 import app from "../../../src/app";
 
 import { logger } from "../../../src/utils/logger";
-import { ADDRESS } from "../../__mocks__/fields/address.mock";
-import { getTodaysDate } from "../../../src/utils/date";
+import { DUE_DILIGENCE_OBJECT_MOCK } from "../../__mocks__/due.diligence.mock";
+import { OVERSEAS_ENTITY_DUE_DILIGENCE_OBJECT_MOCK } from "../../__mocks__/overseas.entity.due.diligence.mock";
 import { authentication } from "../../../src/middleware/authentication.middleware";
-import { isActiveFeature } from "../../../src/utils/feature.flag";
-import { hasBOsOrMOsUpdate } from "../../../src/middleware/navigation/update/has.beneficial.owners.or.managing.officers.update.middleware";
+import { companyAuthentication } from "../../../src/middleware/company.authentication.middleware";
 import { updateOverseasEntity } from "../../../src/service/overseas.entities.service";
 import { startPaymentsSession } from "../../../src/service/payment.service";
-import { companyAuthentication } from "../../../src/middleware/company.authentication.middleware";
-import { BeneficialOwnerGovKey } from "../../../src/model/beneficial.owner.gov.model";
-import { BeneficialOwnerOtherKey } from "../../../src/model/beneficial.owner.other.model";
-import { DUE_DILIGENCE_OBJECT_MOCK } from "../../__mocks__/due.diligence.mock";
+import { isActiveFeature } from "../../../src/utils/feature.flag";
+import { hasBOsOrMOsUpdate } from "../../../src/middleware/navigation/update/has.beneficial.owners.or.managing.officers.update.middleware";
 import { BeneficialOwnerIndividualKey } from "../../../src/model/beneficial.owner.individual.model";
+import { BeneficialOwnerGovKey } from "../../../src/model/beneficial.owner.gov.model";
+import { ADDRESS } from "../../__mocks__/fields/address.mock";
+import { BeneficialOwnerOtherKey } from "../../../src/model/beneficial.owner.other.model";
+import { getTodaysDate } from "../../../src/utils/date";
 import { serviceAvailabilityMiddleware } from "../../../src/middleware/service.availability.middleware";
-import { mapTrustApiToWebWhenFlagsAreSet } from "../../../src/utils/trust/api.to.web.mapper";
-import { OVERSEAS_ENTITY_DUE_DILIGENCE_OBJECT_MOCK } from "../../__mocks__/overseas.entity.due.diligence.mock";
 
 import { postTransaction, closeTransaction } from "../../../src/service/transaction.service";
 import { validateStatements, summaryPagesGuard } from "../../../src/middleware/statement.validation.middleware";
@@ -247,9 +245,6 @@ mockPaymentsSession.mockReturnValue("CONFIRMATION_URL");
 
 const mockIsRegistrationJourney = isRegistrationJourney as jest.Mock;
 mockIsRegistrationJourney.mockReturnValue(false);
-
-const mockMapTrustApiToWebWhenFlagsAreSet = mapTrustApiToWebWhenFlagsAreSet as jest.Mock;
-mockMapTrustApiToWebWhenFlagsAreSet.mockReturnValue(true);
 
 describe("CHECK YOUR ANSWERS controller", () => {
 

--- a/test/controllers/update/update.review.statement.controller.spec.ts
+++ b/test/controllers/update/update.review.statement.controller.spec.ts
@@ -14,7 +14,6 @@ jest.mock("../../../src/service/private.overseas.entity.details");
 jest.mock("../../../src/service/overseas.entities.service");
 jest.mock("../../../src/utils/date");
 jest.mock('../../../src/utils/url');
-jest.mock("../../../src/utils/trust/api.to.web.mapper");
 
 import { NextFunction, Request, Response } from "express";
 import request from "supertest";
@@ -34,7 +33,6 @@ import { updateOverseasEntity } from "../../../src/service/overseas.entities.ser
 import { startPaymentsSession } from "../../../src/service/payment.service";
 import { companyAuthentication } from "../../../src/middleware/company.authentication.middleware";
 import { serviceAvailabilityMiddleware } from "../../../src/middleware/service.availability.middleware";
-import { mapTrustApiToWebWhenFlagsAreSet } from "../../../src/utils/trust/api.to.web.mapper";
 
 import { postTransaction, closeTransaction } from "../../../src/service/transaction.service";
 import { OverseasEntityKey, Transactionkey } from "../../../src/model/data.types.model";
@@ -111,11 +109,6 @@ const mockFetchApplicationData = fetchApplicationData as jest.Mock;
 const mockLoggerDebugRequest = logger.debugRequest as jest.Mock;
 const mockAuthenticationMiddleware = authentication as jest.Mock;
 const mockGetRedirectUrl = getRedirectUrl as jest.Mock;
-const mockIsRemoveJourney = isRemoveJourney as jest.Mock;
-const mockGetPrivateOeDetails = getPrivateOeDetails as jest.Mock;
-const mockGetBeneficialOwnersPrivateData = getBeneficialOwnersPrivateData as jest.Mock;
-const mockSetExtraData = setExtraData as jest.Mock;
-const mockUpdateOverseasEntity = updateOverseasEntity as jest.Mock;
 
 mockAuthenticationMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => next() );
 
@@ -127,6 +120,11 @@ mockServiceAvailabilityMiddleware.mockImplementation((req: Request, res: Respons
 
 const mockHasOverseasEntityMiddleware = hasOverseasEntity as jest.Mock;
 mockHasOverseasEntityMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => next() );
+
+const mockGetPrivateOeDetails = getPrivateOeDetails as jest.Mock;
+const mockGetBeneficialOwnersPrivateData = getBeneficialOwnersPrivateData as jest.Mock;
+const mockSetExtraData = setExtraData as jest.Mock;
+const mockUpdateOverseasEntity = updateOverseasEntity as jest.Mock;
 
 const mockTransactionService = postTransaction as jest.Mock;
 mockTransactionService.mockReturnValue( TRANSACTION_ID );
@@ -148,8 +146,7 @@ const mockCheckActiveBOExists = checkActiveBOExists as jest.Mock;
 const mockIsRegistrationJourney = isRegistrationJourney as jest.Mock;
 mockIsRegistrationJourney.mockReturnValue(false);
 
-const mockMapTrustApiToWebWhenFlagsAreSet = mapTrustApiToWebWhenFlagsAreSet as jest.Mock;
-mockMapTrustApiToWebWhenFlagsAreSet.mockReturnValue(true);
+const mockIsRemoveJourney = isRemoveJourney as jest.Mock;
 
 const appData = { ...APPLICATION_DATA_CH_REF_UPDATE_MOCK, };
 

--- a/test/utils/trust/historical.beneficial.owner.mapper.spec.ts
+++ b/test/utils/trust/historical.beneficial.owner.mapper.spec.ts
@@ -1,25 +1,33 @@
 jest.mock('uuid');
 
 import { beforeEach, describe, expect, jest, test } from "@jest/globals";
-import { ApplicationData } from "../../../src/model";
 import * as uuid from 'uuid';
 import * as Page from '../../../src/model/trust.page.model';
+import { ApplicationData } from "../../../src/model";
+import { TrusteeType } from "../../../src/model/trustee.type.model";
+import { yesNoResponse } from "../../../src/model/data.types.model";
+
+import {
+  TrustKey,
+  TrustHistoricalBeneficialOwner,
+} from "../../../src/model/trust.model";
+
 import {
   generateBoId,
   mapBeneficialOwnerToSession,
   mapFormerTrusteeByIdFromSessionToPage,
 } from '../../../src/utils/trust/historical.beneficial.owner.mapper';
-import { TrusteeType } from "../../../src/model/trustee.type.model";
-import { yesNoResponse } from "../../../src/model/data.types.model";
-import { TrustHistoricalBeneficialOwner, TrustKey } from "../../../src/model/trust.model";
 
 describe('Historical Beneficial Owner page Mapper Service', () => {
+
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
   describe('To Session mapper methods test', () => {
+
     describe('History Beneficial owner mapper', () => {
+
       const mockFormDataBasic = {
         startDateDay: '99',
         startDateMonth: '98',
@@ -79,11 +87,11 @@ describe('Historical Beneficial Owner page Mapper Service', () => {
   });
 
   describe('From session to page mapper method tests', () => {
+
     describe('Map historical/former trustee from session to page Beneficial owner mapper', () => {
 
       const trustId = '987';
       const trusteeId = '9998';
-
       const mockSessionDataBasic = {
         id: trusteeId,
         notified_date_day: "01",
@@ -120,8 +128,7 @@ describe('Historical Beneficial Owner page Mapper Service', () => {
           endDateDay: mockSessionData.ceased_date_day,
           endDateMonth: mockSessionData.ceased_date_month,
           endDateYear: mockSessionData.ceased_date_year,
-          is_newly_added: true,
-
+          is_newly_added: false,
         });
       });
 
@@ -140,7 +147,6 @@ describe('Historical Beneficial Owner page Mapper Service', () => {
         } as ApplicationData;
 
         expect(mapFormerTrusteeByIdFromSessionToPage( appData, trustId, trusteeId )).toEqual({
-
           boId: mockSessionData.id,
           type: TrusteeType.LEGAL_ENTITY,
           corporate_name: mockSessionData.corporate_name,
@@ -150,7 +156,7 @@ describe('Historical Beneficial Owner page Mapper Service', () => {
           endDateDay: mockSessionData.ceased_date_day,
           endDateMonth: mockSessionData.ceased_date_month,
           endDateYear: mockSessionData.ceased_date_year,
-          is_newly_added: true,
+          is_newly_added: false,
         });
       });
     });
@@ -159,7 +165,6 @@ describe('Historical Beneficial Owner page Mapper Service', () => {
   test('test generateBoId', () => {
     const expectNewId = '9999';
     jest.spyOn(uuid, 'v4').mockReturnValue(expectNewId);
-
     expect(generateBoId()).toBe(expectNewId);
   });
 });

--- a/test/utils/trust/individual.trustee.mapper.spec.ts
+++ b/test/utils/trust/individual.trustee.mapper.spec.ts
@@ -1,18 +1,20 @@
 jest.mock('uuid');
 
-import { TrustIndividual, yesNoResponse } from "@companieshouse/api-sdk-node/dist/services/overseas-entities";
 import { beforeEach, describe, expect, jest, test } from "@jest/globals";
+import * as Page from '../../../src/model/trust.page.model';
 import { ApplicationData } from "../../../src/model";
 import { RoleWithinTrustType } from "../../../src/model/role.within.trust.type.model";
 import { IndividualTrustee, TrustKey } from "../../../src/model/trust.model";
-import * as Page from '../../../src/model/trust.page.model';
+import { TrustIndividual, yesNoResponse } from "@companieshouse/api-sdk-node/dist/services/overseas-entities";
+
 import {
-  mapIndividualTrusteeByIdFromSessionToPage,
-  mapIndividualTrusteeFromSessionToPage,
   mapIndividualTrusteeToSession,
+  mapIndividualTrusteeFromSessionToPage,
+  mapIndividualTrusteeByIdFromSessionToPage,
 } from '../../../src/utils/trust/individual.trustee.mapper';
 
 describe('Individual Beneficial Owner page Mapper Service', () => {
+
   beforeEach(() => {
     jest.clearAllMocks();
   });
@@ -22,6 +24,7 @@ describe('Individual Beneficial Owner page Mapper Service', () => {
     ['10000', RoleWithinTrustType.GRANTOR],
     ['10001', RoleWithinTrustType.SETTLOR]
   ];
+
   describe('To Session mapper methods test', () => {
 
     describe('Individual Beneficial Owner mapper', () => {
@@ -420,10 +423,11 @@ describe('Individual Beneficial Owner page Mapper Service', () => {
       });
     });
   });
+
   describe('To Session mapper methods test', () => {
 
     const test_trust_id = '342';
-    const test_trustee_id = '999';
+    const test_trustee_id = 'abc123';
 
     const mockSessionDataBasic = {
       id: test_trustee_id,

--- a/test/utils/trust/legal.entity.beneficial.owner.mapper.spec.ts
+++ b/test/utils/trust/legal.entity.beneficial.owner.mapper.spec.ts
@@ -1,27 +1,35 @@
 jest.mock('uuid');
 
-import { beforeEach, describe, expect, jest, test } from "@jest/globals";
-import { ApplicationData } from "../../../src/model";
 import * as uuid from 'uuid';
-import { TrustLegalEntityForm } from '../../../src/model/trust.page.model';
-import { TrustCorporate, TrustKey } from "../../../src/model/trust.model";
+import { beforeEach, describe, expect, jest, test } from "@jest/globals";
 import { TrusteeType } from "../../../src/model/trustee.type.model";
+import { yesNoResponse } from "@companieshouse/api-sdk-node/dist/services/overseas-entities";
+import { ApplicationData } from "../../../src/model";
 import { RoleWithinTrustType } from "../../../src/model/role.within.trust.type.model";
+import { TrustLegalEntityForm } from '../../../src/model/trust.page.model';
+
+import {
+  TrustKey,
+  TrustCorporate,
+} from "../../../src/model/trust.model";
+
 import {
   generateId,
   mapLegalEntityItemToPage,
   mapLegalEntityToSession,
   mapLegalEntityTrusteeByIdFromSessionToPage,
 } from '../../../src/utils/trust/legal.entity.beneficial.owner.mapper';
-import { yesNoResponse } from "@companieshouse/api-sdk-node/dist/services/overseas-entities";
 
 describe('Trust Legal Entity Beneficial Owner Page Mapper Service', () => {
+
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
   describe('Test session mapper methods', () => {
+
     describe('Test trust legal entity form to session mapping', () => {
+
       const mockFormDataBasic = {
         legalEntityId: "9999",
         legalEntityName: "My Legal Entity",
@@ -148,7 +156,9 @@ describe('Trust Legal Entity Beneficial Owner Page Mapper Service', () => {
           still_involved: "No",
         });
       });
+
       test('Map start_date to session when relevant_period is true', () => {
+
         const mockFormData = {
           ...mockFormDataBasic,
           roleWithinTrust: RoleWithinTrustType.INTERESTED_PERSON,
@@ -203,10 +213,10 @@ describe('Trust Legal Entity Beneficial Owner Page Mapper Service', () => {
           still_involved: "No",
         });
       });
+
       test('test generateId', () => {
         const expectNewId = '9999';
         jest.spyOn(uuid, 'v4').mockReturnValue(expectNewId);
-
         expect(generateId()).toBe(expectNewId);
       });
     });
@@ -246,6 +256,7 @@ describe('Trust Legal Entity Beneficial Owner Page Mapper Service', () => {
         ceased_date_year: "2020",
         still_involved: "No"
       };
+
       test("Map legal entity trustee session data to page", () => {
 
         const trustId = '987';
@@ -254,13 +265,13 @@ describe('Trust Legal Entity Beneficial Owner Page Mapper Service', () => {
           ...mockSessionDataBasic,
           type: RoleWithinTrustType.BENEFICIARY
         };
-
         const appData = {
           [TrustKey]: [{
             'trust_id': trustId,
             'CORPORATES': [ mockSessionData ] as TrustCorporate[],
           }]
         } as ApplicationData;
+
         expect(
           mapLegalEntityTrusteeByIdFromSessionToPage(appData, trustId, trusteeId)
         ).toEqual({
@@ -300,7 +311,6 @@ describe('Trust Legal Entity Beneficial Owner Page Mapper Service', () => {
 
         const trustId = '987';
         const trusteeId = '9998';
-
         const mockSessionData = {
           ...mockSessionDataBasic,
           type: RoleWithinTrustType.INTERESTED_PERSON,
@@ -308,13 +318,13 @@ describe('Trust Legal Entity Beneficial Owner Page Mapper Service', () => {
           date_became_interested_person_month: "01",
           date_became_interested_person_year: "2020",
         };
-
         const appData = {
           [TrustKey]: [{
             'trust_id': trustId,
             'CORPORATES': [ mockSessionData ] as TrustCorporate[],
           }]
         } as ApplicationData;
+
         expect(
           mapLegalEntityTrusteeByIdFromSessionToPage(appData, trustId, trusteeId)
         ).toEqual({
@@ -352,14 +362,16 @@ describe('Trust Legal Entity Beneficial Owner Page Mapper Service', () => {
           stillInvolved: "0"
         });
       });
+
       test("Map legal entity trustee session data to page trustee item", () => {
+
         expect(
           mapLegalEntityItemToPage(mockSessionDataBasic as TrustCorporate)
         ).toEqual({
           id: mockSessionDataBasic.id,
           name: mockSessionDataBasic.name,
           trusteeItemType: TrusteeType.LEGAL_ENTITY,
-          is_newly_added: true,
+          is_newly_added: false,
         });
       });
 
@@ -367,18 +379,17 @@ describe('Trust Legal Entity Beneficial Owner Page Mapper Service', () => {
 
         const trustId = '987';
         const trusteeId = '9998';
-
         const mockSessionData = {
           ...mockSessionDataBasic,
           still_involved: "Yes",
         };
-
         const appData = {
           [TrustKey]: [{
             'trust_id': trustId,
             'CORPORATES': [ mockSessionData ] as TrustCorporate[],
           }]
         } as ApplicationData;
+
         expect(
           mapLegalEntityTrusteeByIdFromSessionToPage(appData, trustId, trusteeId)
         ).toEqual({
@@ -417,7 +428,6 @@ describe('Trust Legal Entity Beneficial Owner Page Mapper Service', () => {
 
         const trustId = '987';
         const trusteeId = '9998';
-
         const mockSessionData = {
           ...mockSessionDataBasic,
           still_involved: "No",
@@ -429,6 +439,7 @@ describe('Trust Legal Entity Beneficial Owner Page Mapper Service', () => {
             'CORPORATES': [ mockSessionData ] as TrustCorporate[],
           }]
         } as ApplicationData;
+
         expect(
           mapLegalEntityTrusteeByIdFromSessionToPage(appData, trustId, trusteeId)
         ).toEqual({
@@ -467,7 +478,6 @@ describe('Trust Legal Entity Beneficial Owner Page Mapper Service', () => {
 
         const trustId = '987';
         const trusteeId = '9998';
-
         const mockSessionData = {
           ...mockSessionDataBasic,
           still_involved: undefined,
@@ -479,6 +489,7 @@ describe('Trust Legal Entity Beneficial Owner Page Mapper Service', () => {
             'CORPORATES': [ mockSessionData ] as TrustCorporate[],
           }]
         } as ApplicationData;
+
         expect(
           mapLegalEntityTrusteeByIdFromSessionToPage(appData, trustId, trusteeId)
         ).toEqual({
@@ -562,7 +573,6 @@ describe('Trust Legal Entity Beneficial Owner Page Mapper Service', () => {
           stillInvolved: ""
         });
       });
-
     });
   });
 });

--- a/test/utils/update/review_trusts.spec.ts
+++ b/test/utils/update/review_trusts.spec.ts
@@ -1,48 +1,60 @@
-import { ApplicationData } from '../../../src/model';
-import { Trust, TrustCorporate, TrustHistoricalBeneficialOwner, TrustIndividual } from '../../../src/model/trust.model';
-import { TrusteeType } from '../../../src/model/trustee.type.model';
+jest.mock("../../../src/utils/feature.flag");
+
+import { jest } from "@jest/globals";
 import { UpdateKey } from '../../../src/model/update.type.model';
+import { TrusteeType } from '../../../src/model/trustee.type.model';
+import { ApplicationData } from '../../../src/model';
+import { isActiveFeature } from "../../../src/utils/feature.flag";
+
 import {
-  hasTrustsToReview,
-  getTrustInReview,
-  hasTrusteesToReview,
-  getTrusteeIndex,
+  Trust,
+  TrustCorporate,
+  TrustIndividual,
+  TrustHistoricalBeneficialOwner,
+} from '../../../src/model/trust.model';
+
+import {
   getTrustee,
+  getTrusteeIndex,
+  getTrustInReview,
+  hasTrustsToReview,
+  getReviewTrustById,
+  hasTrusteesToReview,
+  moveTrustOutOfReview,
+  putNextTrustInReview,
   setTrusteesAsReviewed,
   updateTrustInReviewList,
-  getReviewTrustById,
-  putNextTrustInReview,
-  setTrustDetailsAsReviewed,
-  moveTrustOutOfReview,
   putTrustInChangeScenario,
+  setTrustDetailsAsReviewed,
   moveReviewableTrustsIntoReview,
   resetReviewStatusOnAllTrustsToBeReviewed,
 } from '../../../src/utils/update/review_trusts';
 
+const mockIsActiveFeature = isActiveFeature as jest.Mock;
+
 describe('Manage trusts - review trusts utils tests', () => {
+
   describe('hasTrustsToReview', () => {
+
     test.each([
       [ 'no update in model', undefined ],
       [ 'no review trusts', { review_trusts: undefined } ],
       [ 'review trusts is empty', { review_trusts: [] } ],
     ])('will return false when there is %s', (_, update) => {
       const appData = { update };
-
       const result = hasTrustsToReview(appData);
-
       expect(result).toBe(false);
     });
 
     test('will return true when there are some trusts to review', () => {
       const appData = { update: { review_trusts: [{} as Trust] } };
-
       const result = hasTrustsToReview(appData);
-
       expect(result).toBe(true);
     });
   });
 
   describe('getTrustInReview', () => {
+
     test.each([
       [ 'no update in model', undefined ],
       [ 'no review trusts', { review_trusts: undefined } ],
@@ -50,32 +62,27 @@ describe('Manage trusts - review trusts utils tests', () => {
       [ 'review trusts has no trust in review', { review_trusts: [{ review_status: { in_review: false } } as Trust] }],
     ])('will return undefined when there is %s', (_, update) => {
       const appData = { update };
-
       const result = getTrustInReview(appData);
-
       expect(result).toBe(undefined);
     });
 
     test('will return true when there is a trust in review', () => {
       const trust = { review_status: { in_review: true } } as Trust;
       const appData = { update: { review_trusts: [trust] } };
-
       const result = getTrustInReview(appData);
-
       expect(result).toBe(trust);
     });
   });
 
   describe('putNextTrustInReview', () => {
+
     test.each([
       [ 'there is no update in model', undefined ],
       [ 'there is no review trusts in model', { review_trusts: undefined } ],
       [ 'review trusts is empty', { review_trusts: [] } ],
     ])('will return undefined when %s', (_, update) => {
       const appData = { update };
-
       const result = putNextTrustInReview(appData);
-
       expect(result).toBe(undefined);
     });
 
@@ -93,9 +100,7 @@ describe('Manage trusts - review trusts utils tests', () => {
       };
 
       const appData = { update: { review_trusts: [trust] } };
-
       const result = putNextTrustInReview(appData);
-
       expect(result).toEqual(expectedTrust);
     });
   });
@@ -108,9 +113,7 @@ describe('Manage trusts - review trusts utils tests', () => {
       [ 'there is no review_status in trust', { review_trusts: [{ trust_name: 'Trust 1' }] } ],
     ])('will return false when %s', (_, update) => {
       const appData = { update } as ApplicationData;
-
       const result = setTrustDetailsAsReviewed(appData);
-
       expect(result).toBe(false);
     });
 
@@ -123,7 +126,6 @@ describe('Manage trusts - review trusts utils tests', () => {
         reviewed_legal_entities: false,
       } } as Trust;
       const appData = { update: { review_trusts: [trust] } };
-
       const result = setTrustDetailsAsReviewed(appData);
 
       expect(result).toBe(true);
@@ -138,15 +140,14 @@ describe('Manage trusts - review trusts utils tests', () => {
   });
 
   describe('hasTrusteesToReview', () => {
+
     test('when checking former bos, and former bos are reviewed, with no former bos, returns false', () => {
       const trusteeType = TrusteeType.HISTORICAL;
       const trust = {
         review_status: { reviewed_former_bos: true },
         HISTORICAL_BO: [] as TrustHistoricalBeneficialOwner[],
       } as Trust;
-
       const result = hasTrusteesToReview(trust, trusteeType);
-
       expect(result).toBe(false);
     });
 
@@ -156,9 +157,7 @@ describe('Manage trusts - review trusts utils tests', () => {
         review_status: { reviewed_former_bos: true },
         HISTORICAL_BO: [{}],
       } as Trust;
-
       const result = hasTrusteesToReview(trust, trusteeType);
-
       expect(result).toBe(false);
     });
 
@@ -168,9 +167,7 @@ describe('Manage trusts - review trusts utils tests', () => {
         review_status: { reviewed_former_bos: false },
         HISTORICAL_BO: [] as TrustHistoricalBeneficialOwner[],
       } as Trust;
-
       const result = hasTrusteesToReview(trust, trusteeType);
-
       expect(result).toBe(false);
     });
 
@@ -180,9 +177,7 @@ describe('Manage trusts - review trusts utils tests', () => {
         review_status: { reviewed_former_bos: false },
         HISTORICAL_BO: [{}],
       } as Trust;
-
       const result = hasTrusteesToReview(trust, trusteeType);
-
       expect(result).toBe(true);
     });
 
@@ -192,9 +187,7 @@ describe('Manage trusts - review trusts utils tests', () => {
         review_status: { reviewed_individuals: true },
         INDIVIDUALS: [] as TrustIndividual[],
       } as Trust;
-
       const result = hasTrusteesToReview(trust, trusteeType);
-
       expect(result).toBe(false);
     });
 
@@ -204,9 +197,7 @@ describe('Manage trusts - review trusts utils tests', () => {
         review_status: { reviewed_individuals: true },
         INDIVIDUALS: [{}],
       } as Trust;
-
       const result = hasTrusteesToReview(trust, trusteeType);
-
       expect(result).toBe(false);
     });
 
@@ -216,9 +207,7 @@ describe('Manage trusts - review trusts utils tests', () => {
         review_status: { reviewed_individuals: false },
         INDIVIDUALS: [] as TrustIndividual[],
       } as Trust;
-
       const result = hasTrusteesToReview(trust, trusteeType);
-
       expect(result).toBe(false);
     });
 
@@ -228,9 +217,7 @@ describe('Manage trusts - review trusts utils tests', () => {
         review_status: { reviewed_individuals: false },
         INDIVIDUALS: [{}],
       } as Trust;
-
       const result = hasTrusteesToReview(trust, trusteeType);
-
       expect(result).toBe(true);
     });
 
@@ -240,9 +227,7 @@ describe('Manage trusts - review trusts utils tests', () => {
         review_status: { reviewed_legal_entities: true },
         CORPORATES: [] as TrustCorporate[],
       } as Trust;
-
       const result = hasTrusteesToReview(trust, trusteeType);
-
       expect(result).toBe(false);
     });
 
@@ -252,9 +237,7 @@ describe('Manage trusts - review trusts utils tests', () => {
         review_status: { reviewed_legal_entities: true },
         CORPORATES: [{}],
       } as Trust;
-
       const result = hasTrusteesToReview(trust, trusteeType);
-
       expect(result).toBe(false);
     });
 
@@ -264,9 +247,7 @@ describe('Manage trusts - review trusts utils tests', () => {
         review_status: { reviewed_legal_entities: false },
         CORPORATES: [] as TrustCorporate[],
       };
-
       const result = hasTrusteesToReview(trust as Trust, trusteeType);
-
       expect(result).toBe(false);
     });
 
@@ -276,9 +257,7 @@ describe('Manage trusts - review trusts utils tests', () => {
         review_status: { reviewed_legal_entities: false },
         CORPORATES: [{}],
       } as any;
-
       const result = hasTrusteesToReview(trust, trusteeType);
-
       expect(result).toBe(true);
     });
 
@@ -288,12 +267,12 @@ describe('Manage trusts - review trusts utils tests', () => {
       ['legal entities', { review_status: { reviewed_legal_entities: false }, CORPORATES: [{}] }],
     ])('when trustee type is invalid, with %s to review, returns false', (_, trust) => {
       const result = hasTrusteesToReview(trust as Trust, 'carrot' as any);
-
       expect(result).toBe(false);
     });
   });
 
   describe('getTrusteeIndex', () => {
+
     test.each([
       ['former bo', TrusteeType.HISTORICAL],
       ['individual', TrusteeType.INDIVIDUAL],
@@ -320,7 +299,6 @@ describe('Manage trusts - review trusts utils tests', () => {
       ['legal entities', { CORPORATES: [{ id: 'onions' }] }, TrusteeType.LEGAL_ENTITY],
     ])('when there are %s, searching for an id that does not exist returns -1', (_, trust, trusteeType) => {
       const result = getTrusteeIndex(trust as Trust, 'parsnip', trusteeType);
-
       expect(result).toBe(-1);
     });
 
@@ -330,19 +308,18 @@ describe('Manage trusts - review trusts utils tests', () => {
       ['legal entities', { CORPORATES: [{ id: 'onions' }, { id: 'bananas' }, { id: 'tomatoes' }] }, 2, TrusteeType.LEGAL_ENTITY],
     ])('when there are %s, searching for an id that does exist returns the index', (_, trust, expectedIndex, trusteeType) => {
       const result = getTrusteeIndex(trust as Trust, 'tomatoes', trusteeType);
-
       expect(result).toBe(expectedIndex);
     });
   });
 
   describe('getTrustee', () => {
+
     test.each([
       [' former bo', TrusteeType.HISTORICAL],
       ['n individual', TrusteeType.INDIVIDUAL],
       [' legal entity', TrusteeType.LEGAL_ENTITY],
     ])('when trust is undefined, getting a%s, returns undefined', (_, trusteeType) => {
       const result = getTrustee(undefined, '', trusteeType);
-
       expect(result).toBe(undefined);
     });
 
@@ -352,7 +329,6 @@ describe('Manage trusts - review trusts utils tests', () => {
       ['legal entities', { CORPORATES: [] as TrustCorporate[] }, TrusteeType.LEGAL_ENTITY],
     ])('when there are no %s, searching for one returns undefined', (_, trust, trusteeType) => {
       const result = getTrustee(trust as Trust, '', trusteeType);
-
       expect(result).toBe(undefined);
     });
 
@@ -362,39 +338,33 @@ describe('Manage trusts - review trusts utils tests', () => {
       ['legal entities', { CORPORATES: [{ id: 'onions' }] }, TrusteeType.LEGAL_ENTITY],
     ])('when there are %s, searching for an id that does not exist returns undefined', (_, trust, trusteeType) => {
       const result = getTrustee(trust as Trust, 'parsnip', trusteeType);
-
       expect(result).toBe(undefined);
     });
 
     test('when there are former bo trustees, searching for an id of one that exists, returns the trustee', () => {
       const expectedTrustee = { id: 'expected-former-bo' };
       const trust = { HISTORICAL_BO: [{ id: 'unexpected-former-bo' }, expectedTrustee] };
-
       const result = getTrustee(trust as Trust, 'expected-former-bo', TrusteeType.HISTORICAL);
-
       expect(result).toBe(expectedTrustee);
     });
 
     test('when there are individual trustees, searching for an id of one that exists, returns the trustee', () => {
       const expectedTrustee = { id: 'expected-individual' };
       const trust = { INDIVIDUALS: [{ id: 'unexpected-individual' }, expectedTrustee, { id: 'unexpected-individual-1' }] };
-
       const result = getTrustee(trust as Trust, 'expected-individual', TrusteeType.INDIVIDUAL);
-
       expect(result).toBe(expectedTrustee);
     });
 
     test('when there are legal entity trustees, searching for an id of one that exists, returns the trustee', () => {
       const expectedTrustee = { id: 'expected-legal-entity' };
       const trust = { CORPORATES: [{ id: 'unexpected-legal-entity' }, { id: 'unexpected-legal-entity-1' }, expectedTrustee] };
-
       const result = getTrustee(trust as Trust, 'expected-legal-entity', TrusteeType.LEGAL_ENTITY);
-
       expect(result).toBe(expectedTrustee);
     });
   });
 
   describe('setTrusteesAsReviewed', () => {
+
     test('when no trust is in review, returns false, and trust remains unchanged', () => {
       const review_status = {
         in_review: false,
@@ -404,7 +374,6 @@ describe('Manage trusts - review trusts utils tests', () => {
         reviewed_legal_entities: false,
       };
       const appData = { update: { review_trusts: [{ review_status }] } } as ApplicationData;
-
       const result = setTrusteesAsReviewed(appData, '' as any);
 
       expect(result).toBe(false);
@@ -426,7 +395,6 @@ describe('Manage trusts - review trusts utils tests', () => {
         reviewed_legal_entities: false,
       };
       const appData = { update: { review_trusts: [{ review_status }] } } as ApplicationData;
-
       const result = setTrusteesAsReviewed(appData, '' as any);
 
       expect(result).toBe(false);
@@ -448,7 +416,6 @@ describe('Manage trusts - review trusts utils tests', () => {
         reviewed_legal_entities: false,
       };
       const appData = { update: { review_trusts: [{ review_status }] } } as ApplicationData;
-
       const result = setTrusteesAsReviewed(appData, TrusteeType.HISTORICAL);
 
       expect(result).toBe(true);
@@ -470,7 +437,6 @@ describe('Manage trusts - review trusts utils tests', () => {
         reviewed_legal_entities: false,
       };
       const appData = { update: { review_trusts: [{ review_status }] } } as ApplicationData;
-
       const result = setTrusteesAsReviewed(appData, TrusteeType.INDIVIDUAL);
 
       expect(result).toBe(true);
@@ -492,7 +458,6 @@ describe('Manage trusts - review trusts utils tests', () => {
         reviewed_legal_entities: false,
       };
       const appData = { update: { review_trusts: [{ review_status }] } } as ApplicationData;
-
       const result = setTrusteesAsReviewed(appData, TrusteeType.LEGAL_ENTITY);
 
       expect(result).toBe(true);
@@ -507,6 +472,7 @@ describe('Manage trusts - review trusts utils tests', () => {
   });
 
   describe('updateTrustInReviewList', () => {
+
     test ('that new trust data is saved to application data', () => {
       const trustData = {
         trust_id: '1',
@@ -528,7 +494,6 @@ describe('Manage trusts - review trusts utils tests', () => {
 
       const appData = { update: { no_change: false, review_trusts: [trustData] } };
       const expectedAppData = { update: { no_change: false, review_trusts: [reviewedTrustData] } };
-
       updateTrustInReviewList(appData, reviewedTrustData);
 
       expect(appData).toEqual(expectedAppData);
@@ -536,6 +501,7 @@ describe('Manage trusts - review trusts utils tests', () => {
   });
 
   describe('getReviewTrustById', () => {
+
     test ('test that correct trust is returned', () => {
       const reviewTrustData = {
         trust_id: '1',
@@ -545,9 +511,7 @@ describe('Manage trusts - review trusts utils tests', () => {
         creation_date_year: '2023',
         unable_to_obtain_all_trust_info: 'No',
       } as Trust;
-
       const appData = { update: { review_trusts: [reviewTrustData] } };
-
       expect(getReviewTrustById(appData, reviewTrustData.trust_id)).toEqual(reviewTrustData);
     });
   });
@@ -563,11 +527,8 @@ describe('moveTrustOutOfReview', () => {
       reviewed_individuals: false,
       reviewed_legal_entities: false,
     };
-
     const appData = { update: { review_trusts: [{ review_status }] } } as ApplicationData;
-
     moveTrustOutOfReview(appData);
-
     // trust.review_status set to undefined, trust added to trusts list in app data
     expect(appData.trusts).toEqual( [{ review_status: undefined }] );
   });
@@ -581,9 +542,7 @@ describe('moveTrustOutOfReview', () => {
       reviewed_individuals: false,
       reviewed_legal_entities: false,
     };
-
     const appData = { update: { review_trusts: [{ review_status }] } } as ApplicationData;
-
     moveTrustOutOfReview(appData);
 
     // appData set to [] if undefined
@@ -592,19 +551,56 @@ describe('moveTrustOutOfReview', () => {
 });
 
 describe('putTrustInChangeScenario', () => {
-  test('moves trust from main model to review_trusts', () => {
+
+  beforeEach(() => {
+    mockIsActiveFeature.mockReset();
+  });
+
+  test('moves trust from main model to review_trusts when the Redis_flag is OFF', () => {
+    mockIsActiveFeature.mockReturnValue(false);
     const appData = {
       trusts: [{ trust_id: '1', trust_name: 'trust name' } as Trust],
       [UpdateKey]: {
         review_trusts: []
       }
     };
-
     putTrustInChangeScenario(appData, '1');
+    console.log(appData[UpdateKey].review_trusts);
+    expect(appData[UpdateKey].review_trusts.length).toEqual(1);
+    expect(appData[UpdateKey].review_trusts[0].trust_id).toEqual("1");
+    expect(appData[UpdateKey].review_trusts[0].review_status).toEqual({
+      in_review: true,
+      reviewed_former_bos: true,
+      reviewed_individuals: true,
+      reviewed_legal_entities: true,
+      reviewed_trust_details: false
+    });
+  });
+
+  test('moves trust from main model to review_trusts when the Redis_flag is ON', () => {
+    mockIsActiveFeature.mockReturnValue(true);
+    const appData = {
+      trusts: [{ trust_id: '1', trust_name: 'trust name' } as Trust],
+      [UpdateKey]: {
+        review_trusts: []
+      }
+    };
+    putTrustInChangeScenario(appData, '1');
+    console.log(appData[UpdateKey].review_trusts);
+    expect(appData[UpdateKey].review_trusts.length).toEqual(1);
+    expect(appData[UpdateKey].review_trusts[0].trust_id).toEqual("1");
+    expect(appData[UpdateKey].review_trusts[0].review_status).toEqual({
+      in_review: true,
+      reviewed_former_bos: false,
+      reviewed_individuals: false,
+      reviewed_legal_entities: false,
+      reviewed_trust_details: false
+    });
   });
 });
 
 describe('moveReviewableTrustsIntoReview', () => {
+
   test('moves trusts with ch_reference attribute from appData.trusts to appData.update.review_trusts', () => {
     const trust1 = {
       trust_id: "1",
@@ -642,10 +638,8 @@ describe('moveReviewableTrustsIntoReview', () => {
 
     expect(appData.trusts?.length).toEqual(2);
     expect(appData.update?.review_trusts?.length).toEqual(2);
-
     expect(appData.update?.review_trusts).toContain(trust1);
     expect(appData.update?.review_trusts).toContain(trust3);
-
     expect(appData.trusts).toContain(trust2);
     expect(appData.trusts).toContain(trust4);
 
@@ -708,10 +702,8 @@ describe('moveReviewableTrustsIntoReview', () => {
 
     expect(appData.trusts?.length).toEqual(2);
     expect(appData.update?.review_trusts?.length).toEqual(2);
-
     expect(appData.update?.review_trusts).toContain(trust3);
     expect(appData.update?.review_trusts).toContain(trust4);
-
     expect(appData.trusts).toContain(trust1);
     expect(appData.trusts).toContain(trust2);
   });
@@ -720,12 +712,12 @@ describe('moveReviewableTrustsIntoReview', () => {
     const appData = {
       trusts: []
     } as ApplicationData;
-
     expect(() => moveReviewableTrustsIntoReview(appData)).toThrowError("No update object exists on appData when trying to move trusts back into review");
   });
 });
 
 describe('resetReviewStatusOnAllTrustsToBeReviewed', () => {
+
   test('should rest review_status object on all trusts in review_trusts', () => {
     const appData: ApplicationData = {
       update: {
@@ -773,9 +765,7 @@ describe('resetReviewStatusOnAllTrustsToBeReviewed', () => {
         review_trusts: []
       }
     } as ApplicationData;
-
     resetReviewStatusOnAllTrustsToBeReviewed(appData);
-
     expect(appData.update?.review_trusts?.length).toEqual(0);
   });
 
@@ -783,9 +773,7 @@ describe('resetReviewStatusOnAllTrustsToBeReviewed', () => {
     const appData: ApplicationData = {
       update: { }
     } as ApplicationData;
-
     resetReviewStatusOnAllTrustsToBeReviewed(appData);
-
     expect(appData.update?.review_trusts).toBeUndefined();
   });
 });

--- a/test/utils/update/review_trusts.spec.ts
+++ b/test/utils/update/review_trusts.spec.ts
@@ -591,9 +591,9 @@ describe('putTrustInChangeScenario', () => {
     expect(appData[UpdateKey].review_trusts[0].trust_id).toEqual("1");
     expect(appData[UpdateKey].review_trusts[0].review_status).toEqual({
       in_review: true,
-      reviewed_former_bos: false,
-      reviewed_individuals: false,
-      reviewed_legal_entities: false,
+      reviewed_former_bos: true,
+      reviewed_individuals: true,
+      reviewed_legal_entities: true,
       reviewed_trust_details: false
     });
   });

--- a/views/includes/check-your-answers/historical-trustee.html
+++ b/views/includes/check-your-answers/historical-trustee.html
@@ -20,13 +20,17 @@
     {% set changeLinkUrl = CREATE_CHANGE_LINK_WITH_IDS(OE_CONFIGS.TRUST_ENTRY_WITH_PARAMS_URL, OE_TRANSACTION_ID, OE_SUBMISSION_ID) + "/" + trust.trust_id + "/" + OE_CONFIGS.TRUST_HISTORICAL_BENEFICIAL_OWNER_PAGE + "/" + formerTrustee.id %}
   {% endif %}
 {% else %}
-  {% if IS_REDIS_REMOVAL_ENABLED %}
-    {% set changeLinkUrl = CREATE_CHANGE_LINK_WITH_IDS(OE_CONFIGS.UPDATE_TRUSTS_INDIVIDUALS_OR_ENTITIES_INVOLVED_WITH_PARAMS_URL, OE_TRANSACTION_ID, OE_SUBMISSION_ID) +  "/" + trust.trust_id + "/" + OE_CONFIGS.TRUST_HISTORICAL_BENEFICIAL_OWNER_PAGE + "/" + formerTrustee.id %}
-  {% else %}
+  {% if not IS_REDIS_REMOVAL_ENABLED %}
     {% if manageTrusts %}
       {% set changeLinkUrl = OE_CONFIGS.UPDATE_MANAGE_TRUSTS_ORCHESTRATOR_CHANGE_HANDLER_URL +  "/" + trust.trust_id + "/historical/" + formerTrustee.id %}
     {% else %}
       {% set changeLinkUrl = OE_CONFIGS.UPDATE_TRUSTS_INDIVIDUALS_OR_ENTITIES_INVOLVED_URL +  "/" + trust.trust_id + "/" + OE_CONFIGS.TRUST_HISTORICAL_BENEFICIAL_OWNER_PAGE + "/" + formerTrustee.id %}
+    {% endif %}
+  {% else %}
+    {% if manageTrusts %}
+      {% set changeLinkUrl = CREATE_CHANGE_LINK_WITH_IDS(OE_CONFIGS.UPDATE_MANAGE_TRUSTS_ORCHESTRATOR_CHANGE_HANDLER_WITH_PARAMS_URL, OE_TRANSACTION_ID, OE_SUBMISSION_ID) +  "/" + trust.trust_id + "/historical/" + formerTrustee.id %}
+    {% else %}
+      {% set changeLinkUrl = CREATE_CHANGE_LINK_WITH_IDS(OE_CONFIGS.UPDATE_TRUSTS_INDIVIDUALS_OR_ENTITIES_INVOLVED_WITH_PARAMS_URL, OE_TRANSACTION_ID, OE_SUBMISSION_ID) +  "/" + trust.trust_id + "/" + OE_CONFIGS.TRUST_HISTORICAL_BENEFICIAL_OWNER_PAGE + "/" + formerTrustee.id %}
     {% endif %}
   {% endif %}
 {% endif %}

--- a/views/includes/check-your-answers/individual-trustee.html
+++ b/views/includes/check-your-answers/individual-trustee.html
@@ -51,14 +51,18 @@
   {% set stillInvolved = individualTrustee.still_involved %}
   {% set isNotStillInvolved = stillInvolved === "No" %}
   {% set trusteeCeasedDate = dateMacros.formatDate(individualTrustee.ceased_date_day, individualTrustee.ceased_date_month, individualTrustee.ceased_date_year) %}
-  {% if IS_REDIS_REMOVAL_ENABLED %}
-    {% set changeLinkUrl = CREATE_CHANGE_LINK_WITH_IDS(OE_CONFIGS.UPDATE_TRUSTS_INDIVIDUALS_OR_ENTITIES_INVOLVED_WITH_PARAMS_URL, OE_TRANSACTION_ID, OE_SUBMISSION_ID) +  "/" + trust.trust_id + "/" + OE_CONFIGS.TRUST_INDIVIDUAL_BENEFICIAL_OWNER_PAGE + "/" + individualTrustee.id %}
-  {% else %}
-     {% if manageTrusts %}
+  {% if not IS_REDIS_REMOVAL_ENABLED %}
+    {% if manageTrusts %}
       {% set changeLinkUrl = OE_CONFIGS.UPDATE_MANAGE_TRUSTS_ORCHESTRATOR_CHANGE_HANDLER_URL +  "/" + trust.trust_id + "/individual/" + individualTrustee.id %}
     {% else %}
       {% set changeLinkUrl = OE_CONFIGS.UPDATE_TRUSTS_INDIVIDUALS_OR_ENTITIES_INVOLVED_URL +  "/" + trust.trust_id + "/" + OE_CONFIGS.TRUST_INDIVIDUAL_BENEFICIAL_OWNER_PAGE + "/" + individualTrustee.id %}
-    {% endif %} 
+    {% endif %}
+  {% else %}
+    {% if manageTrusts %}
+      {% set changeLinkUrl = CREATE_CHANGE_LINK_WITH_IDS(OE_CONFIGS.UPDATE_MANAGE_TRUSTS_ORCHESTRATOR_CHANGE_HANDLER_WITH_PARAMS_URL, OE_TRANSACTION_ID, OE_SUBMISSION_ID) +  "/" + trust.trust_id + "/individual/" + individualTrustee.id %}
+    {% else %}
+      {% set changeLinkUrl = CREATE_CHANGE_LINK_WITH_IDS(OE_CONFIGS.UPDATE_TRUSTS_INDIVIDUALS_OR_ENTITIES_INVOLVED_WITH_PARAMS_URL, OE_TRANSACTION_ID, OE_SUBMISSION_ID) +  "/" + trust.trust_id + "/" + OE_CONFIGS.TRUST_INDIVIDUAL_BENEFICIAL_OWNER_PAGE + "/" + individualTrustee.id %}
+    {% endif %}
   {% endif %}
 {% endif %}
 

--- a/views/includes/check-your-answers/legal-entity-trustee.html
+++ b/views/includes/check-your-answers/legal-entity-trustee.html
@@ -61,14 +61,18 @@
   {% set stillInvolved = legalEntity.still_involved %}
   {% set isNotStillInvolved = stillInvolved === "No" %}
   {% set trusteeCeasedDate = dateMacros.formatDate(legalEntity.ceased_date_day, legalEntity.ceased_date_month, legalEntity.ceased_date_year) %}
-  {% if IS_REDIS_REMOVAL_ENABLED %}
-    {% set changeLinkUrl = CREATE_CHANGE_LINK_WITH_IDS(OE_CONFIGS.UPDATE_TRUSTS_INDIVIDUALS_OR_ENTITIES_INVOLVED_WITH_PARAMS_URL, OE_TRANSACTION_ID, OE_SUBMISSION_ID) +  "/" + trust.trust_id + "/" + OE_CONFIGS.TRUST_LEGAL_ENTITY_BENEFICIAL_OWNER_PAGE + "/" + legalEntity.id %}
-  {% else %}
-     {% if manageTrusts %}
+  {% if not IS_REDIS_REMOVAL_ENABLED %}
+    {% if manageTrusts %}
       {% set changeLinkUrl = OE_CONFIGS.UPDATE_MANAGE_TRUSTS_ORCHESTRATOR_CHANGE_HANDLER_URL + "/" + trust.trust_id + "/legalEntity/" + legalEntity.id %}
     {% else %}
       {% set changeLinkUrl = OE_CONFIGS.UPDATE_TRUSTS_INDIVIDUALS_OR_ENTITIES_INVOLVED_URL +  "/" + trust.trust_id + "/" + OE_CONFIGS.TRUST_LEGAL_ENTITY_BENEFICIAL_OWNER_PAGE + "/" + legalEntity.id %}
-    {% endif %} 
+    {% endif %}
+  {% else %}
+    {% if manageTrusts %}
+      {% set changeLinkUrl = CREATE_CHANGE_LINK_WITH_IDS(OE_CONFIGS.UPDATE_MANAGE_TRUSTS_ORCHESTRATOR_CHANGE_HANDLER_WITH_PARAMS_URL, OE_TRANSACTION_ID, OE_SUBMISSION_ID) + "/" + trust.trust_id + "/legalEntity/" + legalEntity.id %}
+    {% else %}
+      {% set changeLinkUrl = CREATE_CHANGE_LINK_WITH_IDS(OE_CONFIGS.UPDATE_TRUSTS_INDIVIDUALS_OR_ENTITIES_INVOLVED_WITH_PARAMS_URL, OE_TRANSACTION_ID, OE_SUBMISSION_ID) +  "/" + trust.trust_id + "/" + OE_CONFIGS.TRUST_LEGAL_ENTITY_BENEFICIAL_OWNER_PAGE + "/" + legalEntity.id %}
+    {% endif %}
   {% endif %}
 {% endif %}
 

--- a/views/includes/check-your-answers/managing-officer-corporate.html
+++ b/views/includes/check-your-answers/managing-officer-corporate.html
@@ -29,7 +29,7 @@
 {% if not IS_REDIS_REMOVAL_ENABLED %}
   {% set changeLinkUrl = OE_CONFIGS.MANAGING_OFFICER_CORPORATE_URL + "/" + moc.id %}
 {% else %}
-  {% set changeLinkUrl = CREATE_CHANGE_LINK_WITH_IDS(OE_CONFIGS.MANAGING_OFFICER_CORPORATE_WITH_PARAMS_URL, OE_TRANSACTION_ID, OE_SUBMISSION_ID) + "/" + moc.id %}
+  {% set changeLinkUrl = CREATE_CHANGE_LINK_WITH_IDS(OE_CONFIGS.MANAGING_OFFICER_CORPORATE_WITH_PARAMS_URL, OE_TRANSACTION_ID, OE_SUBMISSION_ID) + "/" + moc.id %} %}
 {% endif %}
 
 <h3 class="govuk-heading-m">Corporate managing officer</h3>

--- a/views/includes/check-your-answers/managing-officer-corporate.html
+++ b/views/includes/check-your-answers/managing-officer-corporate.html
@@ -29,7 +29,7 @@
 {% if not IS_REDIS_REMOVAL_ENABLED %}
   {% set changeLinkUrl = OE_CONFIGS.MANAGING_OFFICER_CORPORATE_URL + "/" + moc.id %}
 {% else %}
-  {% set changeLinkUrl = CREATE_CHANGE_LINK_WITH_IDS(OE_CONFIGS.MANAGING_OFFICER_CORPORATE_WITH_PARAMS_URL, OE_TRANSACTION_ID, OE_SUBMISSION_ID) + "/" + moc.id %} %}
+  {% set changeLinkUrl = CREATE_CHANGE_LINK_WITH_IDS(OE_CONFIGS.MANAGING_OFFICER_CORPORATE_WITH_PARAMS_URL, OE_TRANSACTION_ID, OE_SUBMISSION_ID) + "/" + moc.id %}
 {% endif %}
 
 <h3 class="govuk-heading-m">Corporate managing officer</h3>

--- a/views/includes/check-your-answers/trusts.html
+++ b/views/includes/check-your-answers/trusts.html
@@ -26,14 +26,18 @@
     {% set isTrustStillInvolved = trustStillInvolved === "Yes" %}
     {% set isTrustNotStillInvolved = trustStillInvolved === "No" %}
     {% set trustCeasedDate = dateMacros.formatDate(trust.ceased_date_day, trust.ceased_date_month, trust.ceased_date_year) %}
-    {% if IS_REDIS_REMOVAL_ENABLED %}
-      {% set changeLinkUrl = CREATE_CHANGE_LINK_WITH_IDS(OE_CONFIGS.UPDATE_TRUSTS_TELL_US_ABOUT_IT_WITH_PARAMS_URL, OE_TRANSACTION_ID, OE_SUBMISSION_ID) %}
-    {% else %}
-       {% if manageTrusts %}
+    {% if not IS_REDIS_REMOVAL_ENABLED %}
+      {% if manageTrusts %}
         {% set changeLinkUrl = OE_CONFIGS.UPDATE_MANAGE_TRUSTS_ORCHESTRATOR_CHANGE_HANDLER_URL %}
       {% else %}
         {% set changeLinkUrl = OE_CONFIGS.UPDATE_TRUSTS_TELL_US_ABOUT_IT_URL %}
-      {% endif %} 
+      {% endif %}
+    {% else %}
+      {% if manageTrusts %}
+        {% set changeLinkUrl = CREATE_CHANGE_LINK_WITH_IDS(OE_CONFIGS.UPDATE_MANAGE_TRUSTS_ORCHESTRATOR_CHANGE_HANDLER_WITH_PARAMS_URL, OE_TRANSACTION_ID, OE_SUBMISSION_ID) %}
+      {% else %}
+        {% set changeLinkUrl = CREATE_CHANGE_LINK_WITH_IDS(OE_CONFIGS.UPDATE_TRUSTS_TELL_US_ABOUT_IT_WITH_PARAMS_URL, OE_TRANSACTION_ID, OE_SUBMISSION_ID) %}
+      {% endif %}
     {% endif %}
   {% endif %}
 

--- a/views/includes/page-templates/add-trust.html
+++ b/views/includes/page-templates/add-trust.html
@@ -20,14 +20,10 @@
         {% set addedTrusts = [] %}
 
         {% if not IS_REDIS_REMOVAL_ENABLED %}
-          {% set changeTrustLink = OE_CONFIGS.UPDATE_MANAGE_TRUSTS_ORCHESTRATOR_CHANGE_HANDLER_URL %}
+          {% set changeTrustsOrchestratorLink = OE_CONFIGS.UPDATE_MANAGE_TRUSTS_ORCHESTRATOR_CHANGE_HANDLER_URL %}
         {% else %}
-          {% if hasTrustsToReview %}
-            {% set changeTrustLink = CREATE_CHANGE_LINK_WITH_IDS(OE_CONFIGS.UPDATE_MANAGE_TRUSTS_ORCHESTRATOR_CHANGE_HANDLER_WITH_PARAMS_URL, OE_TRANSACTION_ID, OE_SUBMISSION_ID) %}
-          {% else %}
-            {% set changeTrustLink = CREATE_CHANGE_LINK_WITH_IDS(OE_CONFIGS.UPDATE_TRUSTS_TELL_US_ABOUT_IT_WITH_PARAMS_URL, OE_TRANSACTION_ID, OE_SUBMISSION_ID) %}
-          {% endif %}
-      {% endif %}
+          {% set changeTrustsOrchestratorLink = CREATE_CHANGE_LINK_WITH_IDS(OE_CONFIGS.UPDATE_MANAGE_TRUSTS_ORCHESTRATOR_CHANGE_HANDLER_WITH_PARAMS_URL, OE_TRANSACTION_ID, OE_SUBMISSION_ID) %}
+        {% endif %}
 
         {% for trust in pageData.trustData %}
             {% if trust.ch_reference.length %}
@@ -40,7 +36,7 @@
                 },
                 actions: {
                   items: [CREATE_CHANGE_LINK(
-                    changeTrustLink + "/" + trust.trust_id,
+                    changeTrustsOrchestratorLink + "/" + trust.trust_id,
                     "Trust " + trust.trust_name,
                     "change-trust-button"
                   )]


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/CC-3413
https://companieshouse.atlassian.net/browse/CC-3407 (rework)

### Change description

- Ensures `is_newly_added` flag is correctly added to trustees during review
- Cleans up `trustInChange` logic during orchestration
- Restores orchestration change/edit paths for trusts and trustees during review
- Adds/updates unit tests to reflect refactored/added functionality

### Work checklist

- [x] Tests added where applicable
- [x] UI changes meet accessibility criteria